### PR TITLE
Master: Ensure links in review date emails use admin domain

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_review_date/fsa_review_date.info
+++ b/docroot/sites/all/modules/custom/fsa_review_date/fsa_review_date.info
@@ -4,4 +4,4 @@ core = 7.x
 package = FSA Custom
 dependencies[] = date
 configure = admin/config/content/review
-version = 7.x-1.1
+version = 7.x-1.2

--- a/docroot/sites/all/modules/custom/fsa_review_date/fsa_review_date.module
+++ b/docroot/sites/all/modules/custom/fsa_review_date/fsa_review_date.module
@@ -405,7 +405,7 @@ function fsa_review_date_mail($key, &$message, $params) {
       $message['subject'] = variable_get('fsa_review_date_email_subject', FSA_REVIEW_DATE_EMAIL_SUBJECT);
       $message['from'] = variable_get('fsa_review_date_email_from', FSA_REVIEW_DATE_EMAIL_FROM);
       $message['headers']['From'] = variable_get('fsa_review_date_email_from', FSA_REVIEW_DATE_EMAIL_FROM);
-      $view_link = t('View these online at @url', array('@url' => url('admin/reports/review', array('absolute' => TRUE, 'alias' => TRUE))));
+      $view_link = t('View these online at @url', array('@url' => url(local_get_site_domain(TRUE, 'https') . '/admin/reports/review', array('absolute' => TRUE, 'alias' => TRUE))));
       $message['body'][] = _fsa_review_date_content_list(t('The following content items are due for review today'));
       $message['body'][] = $view_link;
       $message['body'][] = '';

--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -18,11 +18,17 @@ define('REWRITE_COMMITTEE_URLS', TRUE);
  * Returns the main site domain for rewriting non committee urls
  *
  * @param boolean $admin
- *   Determines whether to return an admin domain or front-end domain.
+ *   (optional) Determines whether to return an admin domain or front-end domain.
+ *
+ * @param string $protocol
+ *   (optional) The protocol to use with the domain. If none is specified,
+ *   protocol-relative URLs will be returned. If a protocol is supplied, it
+ *   should not contain the colon or the //, eg 'http', 'https'
  *
  * @return string
+ *   The domain for the local site
  */
-function local_get_site_domain($admin = FALSE){
+function local_get_site_domain($admin = FALSE, $protocol = ''){
 
   // Get a local development site domain if it's populated.
   // This will typically be set in settings.local.php, but could also be
@@ -57,7 +63,8 @@ function local_get_site_domain($admin = FALSE){
 
   // Return the domain for the selected environment. If none is set, we return
   // www.food.gov.uk as default.
-  return !empty($environment) && !empty($environments[$environment]) ? $environments[$environment] : '//www.food.gov.uk';
+  $protocol = !empty($protocol) ? "$protocol:" : '';
+  return !empty($environment) && !empty($environments[$environment]) ? $protocol . $environments[$environment] : "$protocol//www.food.gov.uk";
 }
 
 /**


### PR DESCRIPTION
The links in the review date reminder emails were previously using the standard domain, but they need to use the admin domain to enable users to view the reports.

1. Modified the function `local_get_site_domain()` to accept an additional parameter for `$protocol`
2. Modified the function that builds the review date emails to use this function and specify `TRUE` for the `$admin` parameter, as well as `https` for the new `$protocol` parameter.

[ Partial fix for #10143 ]