### PR TITLE
Upgrade Drupal Core to version 7.39

### DIFF
--- a/docroot/CHANGELOG.txt
+++ b/docroot/CHANGELOG.txt
@@ -1,4 +1,8 @@
 
+Drupal 7.39, 2015-08-19
+-----------------------
+- Fixed security issues (multiple vulnerabilities). See SA-CORE-2015-003.
+
 Drupal 7.38, 2015-06-17
 -----------------------
 - Fixed security issues (multiple vulnerabilities). See SA-CORE-2015-002.

--- a/docroot/includes/ajax.inc
+++ b/docroot/includes/ajax.inc
@@ -230,6 +230,10 @@
  *   functions.
  */
 function ajax_render($commands = array()) {
+  // Although ajax_deliver() does this, some contributed and custom modules
+  // render Ajax responses without using that delivery callback.
+  ajax_set_verification_header();
+
   // Ajax responses aren't rendered with html.tpl.php, so we have to call
   // drupal_get_css() and drupal_get_js() here, in order to have new files added
   // during this request to be loaded by the page. We only want to send back
@@ -487,6 +491,9 @@ function ajax_deliver($page_callback_result) {
     }
   }
 
+  // Let ajax.js know that this response is safe to process.
+  ajax_set_verification_header();
+
   // Print the response.
   $commands = ajax_prepare_response($page_callback_result);
   $json = ajax_render($commands);
@@ -574,6 +581,29 @@ function ajax_prepare_response($page_callback_result) {
   }
 
   return $commands;
+}
+
+/**
+ * Sets a response header for ajax.js to trust the response body.
+ *
+ * It is not safe to invoke Ajax commands within user-uploaded files, so this
+ * header protects against those being invoked.
+ *
+ * @see Drupal.ajax.options.success()
+ */
+function ajax_set_verification_header() {
+  $added = &drupal_static(__FUNCTION__);
+
+  // User-uploaded files cannot set any response headers, so a custom header is
+  // used to indicate to ajax.js that this response is safe. Note that most
+  // Ajax requests bound using the Form API will be protected by having the URL
+  // flagged as trusted in Drupal.settings, so this header is used only for
+  // things like custom markup that gets Ajax behaviors attached.
+  if (empty($added)) {
+    drupal_add_http_header('X-Drupal-Ajax-Token', '1');
+    // Avoid sending the header twice.
+    $added = TRUE;
+  }
 }
 
 /**
@@ -764,7 +794,12 @@ function ajax_pre_render_element($element) {
 
     $element['#attached']['js'][] = array(
       'type' => 'setting',
-      'data' => array('ajax' => array($element['#id'] => $settings)),
+      'data' => array(
+        'ajax' => array($element['#id'] => $settings),
+        'urlIsAjaxTrusted' => array(
+          $settings['url'] => TRUE,
+        ),
+      ),
     );
 
     // Indicate that Ajax processing was successful.

--- a/docroot/includes/bootstrap.inc
+++ b/docroot/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.38');
+define('VERSION', '7.39');
 
 /**
  * Core API compatibility.

--- a/docroot/includes/database/database.inc
+++ b/docroot/includes/database/database.inc
@@ -626,7 +626,7 @@ abstract class DatabaseConnection extends PDO {
    *   A sanitized version of the query comment string.
    */
   protected function filterComment($comment = '') {
-    return preg_replace('/(\/\*\s*)|(\s*\*\/)/', '', $comment);
+    return strtr($comment, array('*' => ' * '));
   }
 
   /**
@@ -2832,7 +2832,7 @@ function db_drop_table($table) {
  *   will be set to the value of the key in all rows. This is most useful for
  *   creating NOT NULL columns with no default value in existing tables.
  * @param $keys_new
- *   Optional keys and indexes specification to be created on the table along
+ *   (optional) Keys and indexes specification to be created on the table along
  *   with adding the field. The format is the same as a table specification, but
  *   without the 'fields' element. If you are adding a type 'serial' field, you
  *   MUST specify at least one key or index including it in this array. See
@@ -3012,7 +3012,7 @@ function db_drop_index($table, $name) {
  * @param $spec
  *   The field specification for the new field.
  * @param $keys_new
- *   Optional keys and indexes specification to be created on the table along
+ *   (optional) Keys and indexes specification to be created on the table along
  *   with changing the field. The format is the same as a table specification
  *   but without the 'fields' element.
  */

--- a/docroot/includes/database/mysql/database.inc
+++ b/docroot/includes/database/mysql/database.inc
@@ -36,6 +36,10 @@ class DatabaseConnection_mysql extends DatabaseConnection {
       // Default to TCP connection on port 3306.
       $dsn = 'mysql:host=' . $connection_options['host'] . ';port=' . (empty($connection_options['port']) ? 3306 : $connection_options['port']);
     }
+    // Character set is added to dsn to ensure PDO uses the proper character
+    // set when escaping. This has security implications. See
+    // https://www.drupal.org/node/1201452 for further discussion.
+    $dsn .= ';charset=utf8';
     $dsn .= ';dbname=' . $connection_options['database'];
     // Allow PDO options to be overridden.
     $connection_options += array(

--- a/docroot/includes/database/mysql/schema.inc
+++ b/docroot/includes/database/mysql/schema.inc
@@ -40,7 +40,7 @@ class DatabaseSchema_mysql extends DatabaseSchema {
     }
     else {
       $db_info = Database::getConnectionInfo();
-      $info['database'] = $db_info['default']['database'];
+      $info['database'] = $db_info[$this->connection->getTarget()]['database'];
       $info['table'] = $table;
     }
     return $info;
@@ -301,10 +301,10 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
   public function renameTable($table, $new_name) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot rename %table to %table_new: table %table doesn't exist.", array('%table' => $table, '%table_new' => $new_name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot rename @table to @table_new: table @table doesn't exist.", array('@table' => $table, '@table_new' => $new_name)));
     }
     if ($this->tableExists($new_name)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot rename %table to %table_new: table %table_new already exists.", array('%table' => $table, '%table_new' => $new_name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot rename @table to @table_new: table @table_new already exists.", array('@table' => $table, '@table_new' => $new_name)));
     }
 
     $info = $this->getPrefixInfo($new_name);
@@ -322,10 +322,10 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
   public function addField($table, $field, $spec, $keys_new = array()) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add field %table.%field: table doesn't exist.", array('%field' => $field, '%table' => $table)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add field @table.@field: table doesn't exist.", array('@field' => $field, '@table' => $table)));
     }
     if ($this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add field %table.%field: field already exists.", array('%field' => $field, '%table' => $table)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add field @table.@field: field already exists.", array('@field' => $field, '@table' => $table)));
     }
 
     $fixnull = FALSE;
@@ -361,7 +361,7 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
   public function fieldSetDefault($table, $field, $default) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot set default value of field %table.%field: field doesn't exist.", array('%table' => $table, '%field' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot set default value of field @table.@field: field doesn't exist.", array('@table' => $table, '@field' => $field)));
     }
 
     if (!isset($default)) {
@@ -376,7 +376,7 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
   public function fieldSetNoDefault($table, $field) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot remove default value of field %table.%field: field doesn't exist.", array('%table' => $table, '%field' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot remove default value of field @table.@field: field doesn't exist.", array('@table' => $table, '@field' => $field)));
     }
 
     $this->connection->query('ALTER TABLE {' . $table . '} ALTER COLUMN `' . $field . '` DROP DEFAULT');
@@ -391,10 +391,10 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
   public function addPrimaryKey($table, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add primary key to table %table: table doesn't exist.", array('%table' => $table)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add primary key to table @table: table doesn't exist.", array('@table' => $table)));
     }
     if ($this->indexExists($table, 'PRIMARY')) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add primary key to table %table: primary key already exists.", array('%table' => $table)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add primary key to table @table: primary key already exists.", array('@table' => $table)));
     }
 
     $this->connection->query('ALTER TABLE {' . $table . '} ADD PRIMARY KEY (' . $this->createKeySql($fields) . ')');
@@ -411,10 +411,10 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
   public function addUniqueKey($table, $name, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add unique key %name to table %table: table doesn't exist.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add unique key @name to table @table: table doesn't exist.", array('@table' => $table, '@name' => $name)));
     }
     if ($this->indexExists($table, $name)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add unique key %name to table %table: unique key already exists.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add unique key @name to table @table: unique key already exists.", array('@table' => $table, '@name' => $name)));
     }
 
     $this->connection->query('ALTER TABLE {' . $table . '} ADD UNIQUE KEY `' . $name . '` (' . $this->createKeySql($fields) . ')');
@@ -431,10 +431,10 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
   public function addIndex($table, $name, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add index %name to table %table: table doesn't exist.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add index @name to table @table: table doesn't exist.", array('@table' => $table, '@name' => $name)));
     }
     if ($this->indexExists($table, $name)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add index %name to table %table: index already exists.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add index @name to table @table: index already exists.", array('@table' => $table, '@name' => $name)));
     }
 
     $this->connection->query('ALTER TABLE {' . $table . '} ADD INDEX `' . $name . '` (' . $this->createKeySql($fields) . ')');
@@ -451,10 +451,10 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
   public function changeField($table, $field, $field_new, $spec, $keys_new = array()) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot change the definition of field %table.%name: field doesn't exist.", array('%table' => $table, '%name' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot change the definition of field @table.@name: field doesn't exist.", array('@table' => $table, '@name' => $field)));
     }
     if (($field != $field_new) && $this->fieldExists($table, $field_new)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot rename field %table.%name to %name_new: target field already exists.", array('%table' => $table, '%name' => $field, '%name_new' => $field_new)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot rename field @table.@name to @name_new: target field already exists.", array('@table' => $table, '@name' => $field, '@name_new' => $field_new)));
     }
 
     $sql = 'ALTER TABLE {' . $table . '} CHANGE `' . $field . '` ' . $this->createFieldSql($field_new, $this->processField($spec));

--- a/docroot/includes/database/pgsql/schema.inc
+++ b/docroot/includes/database/pgsql/schema.inc
@@ -314,10 +314,10 @@ class DatabaseSchema_pgsql extends DatabaseSchema {
 
   function renameTable($table, $new_name) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot rename %table to %table_new: table %table doesn't exist.", array('%table' => $table, '%table_new' => $new_name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot rename @table to @table_new: table @table doesn't exist.", array('@table' => $table, '@table_new' => $new_name)));
     }
     if ($this->tableExists($new_name)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot rename %table to %table_new: table %table_new already exists.", array('%table' => $table, '%table_new' => $new_name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot rename @table to @table_new: table @table_new already exists.", array('@table' => $table, '@table_new' => $new_name)));
     }
 
     // Get the schema and tablename for the old table.
@@ -351,10 +351,10 @@ class DatabaseSchema_pgsql extends DatabaseSchema {
 
   public function addField($table, $field, $spec, $new_keys = array()) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add field %table.%field: table doesn't exist.", array('%field' => $field, '%table' => $table)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add field @table.@field: table doesn't exist.", array('@field' => $field, '@table' => $table)));
     }
     if ($this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add field %table.%field: field already exists.", array('%field' => $field, '%table' => $table)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add field @table.@field: field already exists.", array('@field' => $field, '@table' => $table)));
     }
 
     $fixnull = FALSE;
@@ -393,7 +393,7 @@ class DatabaseSchema_pgsql extends DatabaseSchema {
 
   public function fieldSetDefault($table, $field, $default) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot set default value of field %table.%field: field doesn't exist.", array('%table' => $table, '%field' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot set default value of field @table.@field: field doesn't exist.", array('@table' => $table, '@field' => $field)));
     }
 
     if (!isset($default)) {
@@ -408,7 +408,7 @@ class DatabaseSchema_pgsql extends DatabaseSchema {
 
   public function fieldSetNoDefault($table, $field) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot remove default value of field %table.%field: field doesn't exist.", array('%table' => $table, '%field' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot remove default value of field @table.@field: field doesn't exist.", array('@table' => $table, '@field' => $field)));
     }
 
     $this->connection->query('ALTER TABLE {' . $table . '} ALTER COLUMN "' . $field . '" DROP DEFAULT');
@@ -435,10 +435,10 @@ class DatabaseSchema_pgsql extends DatabaseSchema {
 
   public function addPrimaryKey($table, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add primary key to table %table: table doesn't exist.", array('%table' => $table)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add primary key to table @table: table doesn't exist.", array('@table' => $table)));
     }
     if ($this->constraintExists($table, 'pkey')) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add primary key to table %table: primary key already exists.", array('%table' => $table)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add primary key to table @table: primary key already exists.", array('@table' => $table)));
     }
 
     $this->connection->query('ALTER TABLE {' . $table . '} ADD PRIMARY KEY (' . implode(',', $fields) . ')');
@@ -455,10 +455,10 @@ class DatabaseSchema_pgsql extends DatabaseSchema {
 
   function addUniqueKey($table, $name, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add unique key %name to table %table: table doesn't exist.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add unique key @name to table @table: table doesn't exist.", array('@table' => $table, '@name' => $name)));
     }
     if ($this->constraintExists($table, $name . '_key')) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add unique key %name to table %table: unique key already exists.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add unique key @name to table @table: unique key already exists.", array('@table' => $table, '@name' => $name)));
     }
 
     $this->connection->query('ALTER TABLE {' . $table . '} ADD CONSTRAINT "' . $this->prefixNonTable($table, $name, 'key') . '" UNIQUE (' . implode(',', $fields) . ')');
@@ -475,10 +475,10 @@ class DatabaseSchema_pgsql extends DatabaseSchema {
 
   public function addIndex($table, $name, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add index %name to table %table: table doesn't exist.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add index @name to table @table: table doesn't exist.", array('@table' => $table, '@name' => $name)));
     }
     if ($this->indexExists($table, $name)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add index %name to table %table: index already exists.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add index @name to table @table: index already exists.", array('@table' => $table, '@name' => $name)));
     }
 
     $this->connection->query($this->_createIndexSql($table, $name, $fields));
@@ -495,10 +495,10 @@ class DatabaseSchema_pgsql extends DatabaseSchema {
 
   public function changeField($table, $field, $field_new, $spec, $new_keys = array()) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot change the definition of field %table.%name: field doesn't exist.", array('%table' => $table, '%name' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot change the definition of field @table.@name: field doesn't exist.", array('@table' => $table, '@name' => $field)));
     }
     if (($field != $field_new) && $this->fieldExists($table, $field_new)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot rename field %table.%name to %name_new: target field already exists.", array('%table' => $table, '%name' => $field, '%name_new' => $field_new)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot rename field @table.@name to @name_new: target field already exists.", array('@table' => $table, '@name' => $field, '@name_new' => $field_new)));
     }
 
     $spec = $this->processField($spec);

--- a/docroot/includes/database/query.inc
+++ b/docroot/includes/database/query.inc
@@ -1694,7 +1694,7 @@ class DatabaseCondition implements QueryConditionInterface, Countable {
    * Implements Countable::count().
    *
    * Returns the size of this conditional. The size of the conditional is the
-   * size of its conditional array minus one, because one element is the the
+   * size of its conditional array minus one, because one element is the
    * conjunction.
    */
   public function count() {

--- a/docroot/includes/database/schema.inc
+++ b/docroot/includes/database/schema.inc
@@ -416,7 +416,7 @@ abstract class DatabaseSchema implements QueryPlaceholderInterface {
    *   This is most useful for creating NOT NULL columns with no default
    *   value in existing tables.
    * @param $keys_new
-   *   Optional keys and indexes specification to be created on the
+   *   (optional) Keys and indexes specification to be created on the
    *   table along with adding the field. The format is the same as a
    *   table specification but without the 'fields' element. If you are
    *   adding a type 'serial' field, you MUST specify at least one key
@@ -630,7 +630,7 @@ abstract class DatabaseSchema implements QueryPlaceholderInterface {
    * @param $spec
    *   The field specification for the new field.
    * @param $keys_new
-   *   Optional keys and indexes specification to be created on the
+   *   (optional) Keys and indexes specification to be created on the
    *   table along with changing the field. The format is the same as a
    *   table specification but without the 'fields' element.
    *
@@ -654,7 +654,7 @@ abstract class DatabaseSchema implements QueryPlaceholderInterface {
    */
   public function createTable($name, $table) {
     if ($this->tableExists($name)) {
-      throw new DatabaseSchemaObjectExistsException(t('Table %name already exists.', array('%name' => $name)));
+      throw new DatabaseSchemaObjectExistsException(t('Table @name already exists.', array('@name' => $name)));
     }
     $statements = $this->createTableSql($name, $table);
     foreach ($statements as $statement) {

--- a/docroot/includes/database/select.inc
+++ b/docroot/includes/database/select.inc
@@ -377,7 +377,8 @@ interface SelectQueryInterface extends QueryConditionInterface, QueryAlterableIn
    * @param $field
    *   The field on which to order.
    * @param $direction
-   *   The direction to sort. Legal values are "ASC" and "DESC".
+   *   The direction to sort. Legal values are "ASC" and "DESC". Any other value
+   *   will be converted to "ASC".
    * @return SelectQueryInterface
    *   The called object.
    */
@@ -1384,6 +1385,8 @@ class SelectQuery extends Query implements SelectQueryInterface {
   }
 
   public function orderBy($field, $direction = 'ASC') {
+    // Only allow ASC and DESC, default to ASC.
+    $direction = strtoupper($direction) == 'DESC' ? 'DESC' : 'ASC';
     $this->order[$field] = $direction;
     return $this;
   }

--- a/docroot/includes/database/sqlite/schema.inc
+++ b/docroot/includes/database/sqlite/schema.inc
@@ -232,10 +232,10 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
 
   public function renameTable($table, $new_name) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot rename %table to %table_new: table %table doesn't exist.", array('%table' => $table, '%table_new' => $new_name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot rename @table to @table_new: table @table doesn't exist.", array('@table' => $table, '@table_new' => $new_name)));
     }
     if ($this->tableExists($new_name)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot rename %table to %table_new: table %table_new already exists.", array('%table' => $table, '%table_new' => $new_name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot rename @table to @table_new: table @table_new already exists.", array('@table' => $table, '@table_new' => $new_name)));
     }
 
     $schema = $this->introspectSchema($table);
@@ -278,10 +278,10 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
 
   public function addField($table, $field, $specification, $keys_new = array()) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add field %table.%field: table doesn't exist.", array('%field' => $field, '%table' => $table)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add field @table.@field: table doesn't exist.", array('@field' => $field, '@table' => $table)));
     }
     if ($this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add field %table.%field: field already exists.", array('%field' => $field, '%table' => $table)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add field @table.@field: field already exists.", array('@field' => $field, '@table' => $table)));
     }
 
     // SQLite doesn't have a full-featured ALTER TABLE statement. It only
@@ -494,10 +494,10 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
 
   public function changeField($table, $field, $field_new, $spec, $keys_new = array()) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot change the definition of field %table.%name: field doesn't exist.", array('%table' => $table, '%name' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot change the definition of field @table.@name: field doesn't exist.", array('@table' => $table, '@name' => $field)));
     }
     if (($field != $field_new) && $this->fieldExists($table, $field_new)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot rename field %table.%name to %name_new: target field already exists.", array('%table' => $table, '%name' => $field, '%name_new' => $field_new)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot rename field @table.@name to @name_new: target field already exists.", array('@table' => $table, '@name' => $field, '@name_new' => $field_new)));
     }
 
     $old_schema = $this->introspectSchema($table);
@@ -559,10 +559,10 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
 
   public function addIndex($table, $name, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add index %name to table %table: table doesn't exist.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add index @name to table @table: table doesn't exist.", array('@table' => $table, '@name' => $name)));
     }
     if ($this->indexExists($table, $name)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add index %name to table %table: index already exists.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add index @name to table @table: index already exists.", array('@table' => $table, '@name' => $name)));
     }
 
     $schema['indexes'][$name] = $fields;
@@ -591,10 +591,10 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
 
   public function addUniqueKey($table, $name, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add unique key %name to table %table: table doesn't exist.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add unique key @name to table @table: table doesn't exist.", array('@table' => $table, '@name' => $name)));
     }
     if ($this->indexExists($table, $name)) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add unique key %name to table %table: unique key already exists.", array('%table' => $table, '%name' => $name)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add unique key @name to table @table: unique key already exists.", array('@table' => $table, '@name' => $name)));
     }
 
     $schema['unique keys'][$name] = $fields;
@@ -617,14 +617,14 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
 
   public function addPrimaryKey($table, $fields) {
     if (!$this->tableExists($table)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add primary key to table %table: table doesn't exist.", array('%table' => $table)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot add primary key to table @table: table doesn't exist.", array('@table' => $table)));
     }
 
     $old_schema = $this->introspectSchema($table);
     $new_schema = $old_schema;
 
     if (!empty($new_schema['primary key'])) {
-      throw new DatabaseSchemaObjectExistsException(t("Cannot add primary key to table %table: primary key already exists.", array('%table' => $table)));
+      throw new DatabaseSchemaObjectExistsException(t("Cannot add primary key to table @table: primary key already exists.", array('@table' => $table)));
     }
 
     $new_schema['primary key'] = $fields;
@@ -646,7 +646,7 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
 
   public function fieldSetDefault($table, $field, $default) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot set default value of field %table.%field: field doesn't exist.", array('%table' => $table, '%field' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot set default value of field @table.@field: field doesn't exist.", array('@table' => $table, '@field' => $field)));
     }
 
     $old_schema = $this->introspectSchema($table);
@@ -658,7 +658,7 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
 
   public function fieldSetNoDefault($table, $field) {
     if (!$this->fieldExists($table, $field)) {
-      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot remove default value of field %table.%field: field doesn't exist.", array('%table' => $table, '%field' => $field)));
+      throw new DatabaseSchemaObjectDoesNotExistException(t("Cannot remove default value of field @table.@field: field doesn't exist.", array('@table' => $table, '@field' => $field)));
     }
 
     $old_schema = $this->introspectSchema($table);

--- a/docroot/includes/form.inc
+++ b/docroot/includes/form.inc
@@ -1128,6 +1128,17 @@ function drupal_prepare_form($form_id, &$form, &$form_state) {
   drupal_alter($hooks, $form, $form_state, $form_id);
 }
 
+/**
+ * Helper function to call form_set_error() if there is a token error.
+ */
+function _drupal_invalid_token_set_form_error() {
+  $path = current_path();
+  $query = drupal_get_query_parameters();
+  $url = url($path, array('query' => $query));
+
+  // Setting this error will cause the form to fail validation.
+  form_set_error('form_token', t('The form has become outdated. Copy any unsaved work in the form below and then <a href="@link">reload this page</a>.', array('@link' => $url)));
+}
 
 /**
  * Validates user-submitted form data in the $form_state array.
@@ -1162,16 +1173,11 @@ function drupal_validate_form($form_id, &$form, &$form_state) {
   }
 
   // If the session token was set by drupal_prepare_form(), ensure that it
-  // matches the current user's session.
+  // matches the current user's session. This is duplicate to code in
+  // form_builder() but left to protect any custom form handling code.
   if (isset($form['#token'])) {
-    if (!drupal_valid_token($form_state['values']['form_token'], $form['#token'])) {
-      $path = current_path();
-      $query = drupal_get_query_parameters();
-      $url = url($path, array('query' => $query));
-
-      // Setting this error will cause the form to fail validation.
-      form_set_error('form_token', t('The form has become outdated. Copy any unsaved work in the form below and then <a href="@link">reload this page</a>.', array('@link' => $url)));
-
+    if (!drupal_valid_token($form_state['values']['form_token'], $form['#token']) || !empty($form_state['invalid_token'])) {
+      _drupal_invalid_token_set_form_error();
       // Stop here and don't run any further validation handlers, because they
       // could invoke non-safe operations which opens the door for CSRF
       // vulnerabilities.
@@ -1827,6 +1833,20 @@ function form_builder($form_id, &$element, &$form_state) {
     // from the POST data is set and matches the current form_id.
     if ($form_state['programmed'] || (!empty($form_state['input']) && (isset($form_state['input']['form_id']) && ($form_state['input']['form_id'] == $form_id)))) {
       $form_state['process_input'] = TRUE;
+      // If the session token was set by drupal_prepare_form(), ensure that it
+      // matches the current user's session.
+      $form_state['invalid_token'] = FALSE;
+      if (isset($element['#token'])) {
+        if (empty($form_state['input']['form_token']) || !drupal_valid_token($form_state['input']['form_token'], $element['#token'])) {
+          // Set an early form error to block certain input processing since that
+          // opens the door for CSRF vulnerabilities.
+          _drupal_invalid_token_set_form_error();
+          // This value is checked in _form_builder_handle_input_element().
+          $form_state['invalid_token'] = TRUE;
+          // Make sure file uploads do not get processed.
+          $_FILES = array();
+        }
+      }
     }
     else {
       $form_state['process_input'] = FALSE;
@@ -1930,6 +1950,18 @@ function form_builder($form_id, &$element, &$form_state) {
       $element['#attributes']['enctype'] = 'multipart/form-data';
     }
 
+    // Allow Ajax submissions to the form action to bypass verification. This is
+    // especially useful for multipart forms, which cannot be verified via a
+    // response header.
+    $element['#attached']['js'][] = array(
+      'type' => 'setting',
+      'data' => array(
+        'urlIsAjaxTrusted' => array(
+          $element['#action'] => TRUE,
+        ),
+      ),
+    );
+
     // If a form contains a single textfield, and the ENTER key is pressed
     // within it, Internet Explorer submits the form with no POST data
     // identifying any submit button. Other browsers submit POST data as though
@@ -1978,6 +2010,19 @@ function form_builder($form_id, &$element, &$form_state) {
  * Adds the #name and #value properties of an input element before rendering.
  */
 function _form_builder_handle_input_element($form_id, &$element, &$form_state) {
+  static $safe_core_value_callbacks = array(
+    'form_type_token_value',
+    'form_type_textarea_value',
+    'form_type_textfield_value',
+    'form_type_checkbox_value',
+    'form_type_checkboxes_value',
+    'form_type_radios_value',
+    'form_type_password_confirm_value',
+    'form_type_select_value',
+    'form_type_tableselect_value',
+    'list_boolean_allowed_values_callback',
+  );
+
   if (!isset($element['#name'])) {
     $name = array_shift($element['#parents']);
     $element['#name'] = $name;
@@ -2056,7 +2101,14 @@ function _form_builder_handle_input_element($form_id, &$element, &$form_state) {
       // property, optionally filtered through $value_callback.
       if ($input_exists) {
         if (function_exists($value_callback)) {
-          $element['#value'] = $value_callback($element, $input, $form_state);
+          // Skip all value callbacks except safe ones like text if the CSRF
+          // token was invalid.
+          if (empty($form_state['invalid_token']) || in_array($value_callback, $safe_core_value_callbacks)) {
+            $element['#value'] = $value_callback($element, $input, $form_state);
+          }
+          else {
+            $input = NULL;
+          }
         }
         if (!isset($element['#value']) && isset($input)) {
           $element['#value'] = $input;
@@ -3911,6 +3963,29 @@ function theme_hidden($variables) {
 }
 
 /**
+ * Process function to prepare autocomplete data.
+ *
+ * @param $element
+ *   A textfield or other element with a #autocomplete_path.
+ *
+ * @return array
+ *   The processed form element.
+ */
+function form_process_autocomplete($element) {
+  $element['#autocomplete_input'] = array();
+  if ($element['#autocomplete_path'] && drupal_valid_path($element['#autocomplete_path'])) {
+    $element['#autocomplete_input']['#id'] = $element['#id'] .'-autocomplete';
+    // Force autocomplete to use non-clean URLs since this protects against the
+    // browser interpreting the path plus search string as an actual file.
+    $current_clean_url = isset($GLOBALS['conf']['clean_url']) ? $GLOBALS['conf']['clean_url'] : NULL;
+    $GLOBALS['conf']['clean_url'] = 0;
+    $element['#autocomplete_input']['#url_value'] = url($element['#autocomplete_path'], array('absolute' => TRUE));
+    $GLOBALS['conf']['clean_url'] = $current_clean_url;
+  }
+  return $element;
+}
+
+/**
  * Returns HTML for a textfield form element.
  *
  * @param $variables
@@ -3928,14 +4003,14 @@ function theme_textfield($variables) {
   _form_set_class($element, array('form-text'));
 
   $extra = '';
-  if ($element['#autocomplete_path'] && drupal_valid_path($element['#autocomplete_path'])) {
+  if ($element['#autocomplete_path'] && !empty($element['#autocomplete_input'])) {
     drupal_add_library('system', 'drupal.autocomplete');
     $element['#attributes']['class'][] = 'form-autocomplete';
 
     $attributes = array();
     $attributes['type'] = 'hidden';
-    $attributes['id'] = $element['#attributes']['id'] . '-autocomplete';
-    $attributes['value'] = url($element['#autocomplete_path'], array('absolute' => TRUE));
+    $attributes['id'] = $element['#autocomplete_input']['#id'];
+    $attributes['value'] = $element['#autocomplete_input']['#url_value'];
     $attributes['disabled'] = 'disabled';
     $attributes['class'][] = 'autocomplete';
     $extra = '<input' . drupal_attributes($attributes) . ' />';

--- a/docroot/includes/menu.inc
+++ b/docroot/includes/menu.inc
@@ -1487,7 +1487,7 @@ function menu_tree_collect_node_links(&$tree, &$node_links) {
  *   menu_tree_collect_node_links().
  */
 function menu_tree_check_access(&$tree, $node_links = array()) {
-  if ($node_links) {
+  if ($node_links && (user_access('access content') || user_access('bypass node access'))) {
     $nids = array_keys($node_links);
     $select = db_select('node', 'n');
     $select->addField('n', 'nid');

--- a/docroot/misc/ajax.js
+++ b/docroot/misc/ajax.js
@@ -14,6 +14,8 @@
 
 Drupal.ajax = Drupal.ajax || {};
 
+Drupal.settings.urlIsAjaxTrusted = Drupal.settings.urlIsAjaxTrusted || {};
+
 /**
  * Attaches the Ajax behavior to each Ajax form element.
  */
@@ -130,6 +132,11 @@ Drupal.ajax = function (base, element, element_settings) {
   // 5. /nojs# - Followed by a fragment.
   //      E.g.: path/nojs#myfragment
   this.url = element_settings.url.replace(/\/nojs(\/|$|\?|&|#)/g, '/ajax$1');
+  // If the 'nojs' version of the URL is trusted, also trust the 'ajax' version.
+  if (Drupal.settings.urlIsAjaxTrusted[element_settings.url]) {
+    Drupal.settings.urlIsAjaxTrusted[this.url] = true;
+  }
+
   this.wrapper = '#' + element_settings.wrapper;
 
   // If there isn't a form, jQuery.ajax() will be used instead, allowing us to
@@ -155,18 +162,36 @@ Drupal.ajax = function (base, element, element_settings) {
       ajax.ajaxing = true;
       return ajax.beforeSend(xmlhttprequest, options);
     },
-    success: function (response, status) {
+    success: function (response, status, xmlhttprequest) {
       // Sanity check for browser support (object expected).
       // When using iFrame uploads, responses must be returned as a string.
       if (typeof response == 'string') {
         response = $.parseJSON(response);
       }
+
+      // Prior to invoking the response's commands, verify that they can be
+      // trusted by checking for a response header. See
+      // ajax_set_verification_header() for details.
+      // - Empty responses are harmless so can bypass verification. This avoids
+      //   an alert message for server-generated no-op responses that skip Ajax
+      //   rendering.
+      // - Ajax objects with trusted URLs (e.g., ones defined server-side via
+      //   #ajax) can bypass header verification. This is especially useful for
+      //   Ajax with multipart forms. Because IFRAME transport is used, the
+      //   response headers cannot be accessed for verification.
+      if (response !== null && !Drupal.settings.urlIsAjaxTrusted[ajax.url]) {
+        if (xmlhttprequest.getResponseHeader('X-Drupal-Ajax-Token') !== '1') {
+          var customMessage = Drupal.t("The response failed verification so will not be processed.");
+          return ajax.error(xmlhttprequest, ajax.url, customMessage);
+        }
+      }
+
       return ajax.success(response, status);
     },
-    complete: function (response, status) {
+    complete: function (xmlhttprequest, status) {
       ajax.ajaxing = false;
       if (status == 'error' || status == 'parsererror') {
-        return ajax.error(response, ajax.url);
+        return ajax.error(xmlhttprequest, ajax.url);
       }
     },
     dataType: 'json',
@@ -175,6 +200,9 @@ Drupal.ajax = function (base, element, element_settings) {
 
   // Bind the ajaxSubmit function to the element event.
   $(ajax.element).bind(element_settings.event, function (event) {
+    if (!Drupal.settings.urlIsAjaxTrusted[ajax.url] && !Drupal.urlIsLocal(ajax.url)) {
+      throw new Error(Drupal.t('The callback URL is not local and not trusted: !url', {'!url': ajax.url}));
+    }
     return ajax.eventResponse(this, event);
   });
 
@@ -447,8 +475,8 @@ Drupal.ajax.prototype.getEffect = function (response) {
 /**
  * Handler for the form redirection error.
  */
-Drupal.ajax.prototype.error = function (response, uri) {
-  alert(Drupal.ajaxError(response, uri));
+Drupal.ajax.prototype.error = function (xmlhttprequest, uri, customMessage) {
+  alert(Drupal.ajaxError(xmlhttprequest, uri, customMessage));
   // Remove the progress element.
   if (this.progress.element) {
     $(this.progress.element).remove();
@@ -462,7 +490,7 @@ Drupal.ajax.prototype.error = function (response, uri) {
   $(this.element).removeClass('progress-disabled').removeAttr('disabled');
   // Reattach behaviors, if they were detached in beforeSerialize().
   if (this.form) {
-    var settings = response.settings || this.settings || Drupal.settings;
+    var settings = this.settings || Drupal.settings;
     Drupal.attachBehaviors(this.form, settings);
   }
 };

--- a/docroot/misc/autocomplete.js
+++ b/docroot/misc/autocomplete.js
@@ -271,8 +271,11 @@ Drupal.ACDB.prototype.search = function (searchString) {
   var db = this;
   this.searchString = searchString;
 
-  // See if this string needs to be searched for anyway.
-  searchString = searchString.replace(/^\s+|\s+$/, '');
+  // See if this string needs to be searched for anyway. The pattern ../ is
+  // stripped since it may be misinterpreted by the browser.
+  searchString = searchString.replace(/^\s+|\.{2,}\/|\s+$/g, '');
+  // Skip empty search strings, or search strings ending with a comma, since
+  // that is the separator between search terms.
   if (searchString.length <= 0 ||
     searchString.charAt(searchString.length - 1) == ',') {
     return;

--- a/docroot/modules/aggregator/aggregator.info
+++ b/docroot/modules/aggregator/aggregator.info
@@ -7,8 +7,8 @@ files[] = aggregator.test
 configure = admin/config/services/aggregator/settings
 stylesheets[all][] = aggregator.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/aggregator/tests/aggregator_test.info
+++ b/docroot/modules/aggregator/tests/aggregator_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/block/block.info
+++ b/docroot/modules/block/block.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = block.test
 configure = admin/structure/block
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/block/tests/block_test.info
+++ b/docroot/modules/block/tests/block_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/block/tests/themes/block_test_theme/block_test_theme.info
+++ b/docroot/modules/block/tests/themes/block_test_theme/block_test_theme.info
@@ -13,8 +13,8 @@ regions[footer] = Footer
 regions[highlighted] = Highlighted
 regions[help] = Help
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/blog/blog.info
+++ b/docroot/modules/blog/blog.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 files[] = blog.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/book/book.info
+++ b/docroot/modules/book/book.info
@@ -7,8 +7,8 @@ files[] = book.test
 configure = admin/content/book/settings
 stylesheets[all][] = book.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/color/color.info
+++ b/docroot/modules/color/color.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 files[] = color.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/comment/comment.info
+++ b/docroot/modules/comment/comment.info
@@ -9,8 +9,8 @@ files[] = comment.test
 configure = admin/content/comment
 stylesheets[all][] = comment.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/contact/contact.info
+++ b/docroot/modules/contact/contact.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = contact.test
 configure = admin/structure/contact
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/contextual/contextual.info
+++ b/docroot/modules/contextual/contextual.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 files[] = contextual.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/dashboard/dashboard.info
+++ b/docroot/modules/dashboard/dashboard.info
@@ -7,8 +7,8 @@ files[] = dashboard.test
 dependencies[] = block
 configure = admin/dashboard/customize
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/dblog/dblog.info
+++ b/docroot/modules/dblog/dblog.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 files[] = dblog.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field/field.info
+++ b/docroot/modules/field/field.info
@@ -11,8 +11,8 @@ dependencies[] = field_sql_storage
 required = TRUE
 stylesheets[all][] = theme/field.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field/modules/field_sql_storage/field_sql_storage.info
+++ b/docroot/modules/field/modules/field_sql_storage/field_sql_storage.info
@@ -7,8 +7,8 @@ dependencies[] = field
 files[] = field_sql_storage.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field/modules/list/list.info
+++ b/docroot/modules/field/modules/list/list.info
@@ -7,8 +7,8 @@ dependencies[] = field
 dependencies[] = options
 files[] = tests/list.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field/modules/list/tests/list_test.info
+++ b/docroot/modules/field/modules/list/tests/list_test.info
@@ -5,8 +5,8 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field/modules/number/number.info
+++ b/docroot/modules/field/modules/number/number.info
@@ -6,8 +6,8 @@ core = 7.x
 dependencies[] = field
 files[] = number.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field/modules/options/options.info
+++ b/docroot/modules/field/modules/options/options.info
@@ -6,8 +6,8 @@ core = 7.x
 dependencies[] = field
 files[] = options.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field/modules/text/text.info
+++ b/docroot/modules/field/modules/text/text.info
@@ -7,8 +7,8 @@ dependencies[] = field
 files[] = text.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field/tests/field_test.info
+++ b/docroot/modules/field/tests/field_test.info
@@ -6,8 +6,8 @@ files[] = field_test.entity.inc
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/field_ui/field_ui.info
+++ b/docroot/modules/field_ui/field_ui.info
@@ -6,8 +6,8 @@ core = 7.x
 dependencies[] = field
 files[] = field_ui.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/file/file.info
+++ b/docroot/modules/file/file.info
@@ -6,8 +6,8 @@ core = 7.x
 dependencies[] = field
 files[] = tests/file.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/file/tests/file.test
+++ b/docroot/modules/file/tests/file.test
@@ -377,6 +377,18 @@ class FileManagedFileElementTestCase extends FileFieldTestCase {
         $this->drupalPost($path, array(), t('Save'));
         $this->assertRaw(t('The file id is %fid.', array('%fid' => 0)), 'Submitted without a file.');
 
+        // Submit with a file, but with an invalid form token. Ensure the file
+        // was not saved.
+        $last_fid_prior = $this->getLastFileId();
+        $edit = array(
+          'files[' . $input_base_name . ']' => drupal_realpath($test_file->uri),
+          'form_token' => 'invalid token',
+        );
+        $this->drupalPost($path, $edit, t('Save'));
+        $this->assertText('The form has become outdated. Copy any unsaved work in the form below');
+        $last_fid = $this->getLastFileId();
+        $this->assertEqual($last_fid_prior, $last_fid, 'File was not saved when uploaded with an invalid form token.');
+
         // Submit a new file, without using the Upload button.
         $last_fid_prior = $this->getLastFileId();
         $edit = array('files[' . $input_base_name . ']' => drupal_realpath($test_file->uri));

--- a/docroot/modules/file/tests/file_module_test.info
+++ b/docroot/modules/file/tests/file_module_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/filter/filter.info
+++ b/docroot/modules/filter/filter.info
@@ -7,8 +7,8 @@ files[] = filter.test
 required = TRUE
 configure = admin/config/content/formats
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/forum/forum.info
+++ b/docroot/modules/forum/forum.info
@@ -9,8 +9,8 @@ files[] = forum.test
 configure = admin/structure/forum
 stylesheets[all][] = forum.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/help/help.info
+++ b/docroot/modules/help/help.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 files[] = help.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/image/image.info
+++ b/docroot/modules/image/image.info
@@ -7,8 +7,8 @@ dependencies[] = file
 files[] = image.test
 configure = admin/config/media/image-styles
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/image/tests/image_module_test.info
+++ b/docroot/modules/image/tests/image_module_test.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = image_module_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/locale/locale.info
+++ b/docroot/modules/locale/locale.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = locale.test
 configure = admin/config/regional/language
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/locale/tests/locale_test.info
+++ b/docroot/modules/locale/tests/locale_test.info
@@ -5,8 +5,8 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/menu/menu.info
+++ b/docroot/modules/menu/menu.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = menu.test
 configure = admin/structure/menu
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/node/node.info
+++ b/docroot/modules/node/node.info
@@ -9,8 +9,8 @@ required = TRUE
 configure = admin/structure/types
 stylesheets[all][] = node.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/node/tests/node_access_test.info
+++ b/docroot/modules/node/tests/node_access_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/node/tests/node_test.info
+++ b/docroot/modules/node/tests/node_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/node/tests/node_test_exception.info
+++ b/docroot/modules/node/tests/node_test_exception.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/openid/openid.info
+++ b/docroot/modules/openid/openid.info
@@ -5,8 +5,8 @@ package = Core
 core = 7.x
 files[] = openid.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/openid/tests/openid_test.info
+++ b/docroot/modules/openid/tests/openid_test.info
@@ -6,8 +6,8 @@ core = 7.x
 dependencies[] = openid
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/overlay/overlay.info
+++ b/docroot/modules/overlay/overlay.info
@@ -4,8 +4,8 @@ package = Core
 version = VERSION
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/path/path.info
+++ b/docroot/modules/path/path.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = path.test
 configure = admin/config/search/path
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/php/php.info
+++ b/docroot/modules/php/php.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 files[] = php.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/poll/poll.info
+++ b/docroot/modules/poll/poll.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = poll.test
 stylesheets[all][] = poll.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/profile/profile.info
+++ b/docroot/modules/profile/profile.info
@@ -11,8 +11,8 @@ configure = admin/config/people/profile
 ; See user_system_info_alter().
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/profile/profile.test
+++ b/docroot/modules/profile/profile.test
@@ -339,12 +339,22 @@ class ProfileTestAutocomplete extends ProfileTestCase {
     $this->setProfileField($field, $field['value']);
 
     // Set some html for what we want to see in the page output later.
-    $autocomplete_html = '<input type="hidden" id="' . drupal_html_id('edit-' . $field['form_name'] . '-autocomplete') . '" value="' . url('profile/autocomplete/' . $field['fid'], array('absolute' => TRUE)) . '" disabled="disabled" class="autocomplete" />';
-    $field_html = '<input type="text" maxlength="255" name="' . $field['form_name'] . '" id="' . drupal_html_id('edit-' . $field['form_name']) . '" size="60" value="' . $field['value'] . '" class="form-text form-autocomplete required" />';
+    // Autocomplete always uses non-clean URLs.
+    $current_clean_url = isset($GLOBALS['conf']['clean_url']) ? $GLOBALS['conf']['clean_url'] : NULL;
+    $GLOBALS['conf']['clean_url'] = 0;
+    $autocomplete_url = url('profile/autocomplete/' . $field['fid'], array('absolute' => TRUE));
+    $GLOBALS['conf']['clean_url'] = $current_clean_url;
+    $autocomplete_id = drupal_html_id('edit-' . $field['form_name'] . '-autocomplete');
+    $autocomplete_html = '<input type="hidden" id="' . $autocomplete_id . '" value="' . $autocomplete_url . '" disabled="disabled" class="autocomplete" />';
 
     // Check that autocompletion html is found on the user's profile edit page.
     $this->drupalGet('user/' . $this->admin_user->uid . '/edit/' . $category);
     $this->assertRaw($autocomplete_html, 'Autocomplete found.');
+    $this->assertFieldByXPath(
+      '//input[@type="text" and @name="' . $field['form_name'] . '" and contains(@class, "form-autocomplete")]',
+      '',
+      'Text input field found'
+    );
     $this->assertRaw('misc/autocomplete.js', 'Autocomplete JavaScript found.');
     $this->assertRaw('class="form-text form-autocomplete"', 'Autocomplete form element class found.');
 

--- a/docroot/modules/rdf/rdf.info
+++ b/docroot/modules/rdf/rdf.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 files[] = rdf.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/rdf/tests/rdf_test.info
+++ b/docroot/modules/rdf/tests/rdf_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/search/search.info
+++ b/docroot/modules/search/search.info
@@ -8,8 +8,8 @@ files[] = search.test
 configure = admin/config/search/settings
 stylesheets[all][] = search.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/search/tests/search_embedded_form.info
+++ b/docroot/modules/search/tests/search_embedded_form.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/search/tests/search_extra_type.info
+++ b/docroot/modules/search/tests/search_extra_type.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/search/tests/search_node_tags.info
+++ b/docroot/modules/search/tests/search_node_tags.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/shortcut/shortcut.info
+++ b/docroot/modules/shortcut/shortcut.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = shortcut.test
 configure = admin/config/user-interface/shortcut
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/drupal_web_test_case.php
+++ b/docroot/modules/simpletest/drupal_web_test_case.php
@@ -2221,6 +2221,7 @@ class DrupalWebTestCase extends DrupalTestCase {
 
     // Submit the POST request.
     $return = drupal_json_decode($this->drupalPost(NULL, $edit, array('path' => $ajax_path, 'triggering_element' => $triggering_element), $options, $headers, $form_html_id, $extra_post));
+    $this->assertIdentical($this->drupalGetHeader('X-Drupal-Ajax-Token'), '1', 'Ajax response header found.');
 
     // Change the page content by applying the returned commands.
     if (!empty($ajax_settings) && !empty($return)) {

--- a/docroot/modules/simpletest/simpletest.info
+++ b/docroot/modules/simpletest/simpletest.info
@@ -56,8 +56,8 @@ files[] = tests/upgrade/update.trigger.test
 files[] = tests/upgrade/update.field.test
 files[] = tests/upgrade/update.user.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/actions_loop_test.info
+++ b/docroot/modules/simpletest/tests/actions_loop_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/ajax_forms_test.info
+++ b/docroot/modules/simpletest/tests/ajax_forms_test.info
@@ -5,8 +5,8 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/ajax_test.info
+++ b/docroot/modules/simpletest/tests/ajax_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/batch_test.info
+++ b/docroot/modules/simpletest/tests/batch_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/common_test.info
+++ b/docroot/modules/simpletest/tests/common_test.info
@@ -7,8 +7,8 @@ stylesheets[all][] = common_test.css
 stylesheets[print][] = common_test.print.css
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/common_test_cron_helper.info
+++ b/docroot/modules/simpletest/tests/common_test_cron_helper.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/database_test.info
+++ b/docroot/modules/simpletest/tests/database_test.info
@@ -5,8 +5,8 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/database_test.test
+++ b/docroot/modules/simpletest/tests/database_test.test
@@ -1414,10 +1414,47 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
     }
 
     $query = (string)$query;
-    $expected = "/* Testing query comments SELECT nid FROM {node}; -- */ SELECT test.name AS name, test.age AS age\nFROM \n{test} test";
+    $expected = "/* Testing query comments  * / SELECT nid FROM {node}; -- */ SELECT test.name AS name, test.age AS age\nFROM \n{test} test";
 
     $this->assertEqual($num_records, 4, 'Returned the correct number of rows.');
     $this->assertEqual($query, $expected, 'The flattened query contains the sanitised comment string.');
+
+    $connection = Database::getConnection();
+    foreach ($this->makeCommentsProvider() as $test_set) {
+      list($expected, $comments) = $test_set;
+      $this->assertEqual($expected, $connection->makeComment($comments));
+    }
+  }
+
+  /**
+   * Provides expected and input values for testVulnerableComment().
+   */
+  function makeCommentsProvider() {
+    return array(
+      array(
+        '/*  */ ',
+        array(''),
+      ),
+      // Try and close the comment early.
+      array(
+        '/* Exploit  * / DROP TABLE node; -- */ ',
+        array('Exploit */ DROP TABLE node; --'),
+      ),
+      // Variations on comment closing.
+      array(
+        '/* Exploit  * / * / DROP TABLE node; -- */ ',
+        array('Exploit */*/ DROP TABLE node; --'),
+      ),
+      array(
+        '/* Exploit  *  * // DROP TABLE node; -- */ ',
+        array('Exploit **// DROP TABLE node; --'),
+      ),
+      // Try closing the comment in the second string which is appended.
+      array(
+        '/* Exploit  * / DROP TABLE node; --; Another try  * / DROP TABLE node; -- */ ',
+        array('Exploit */ DROP TABLE node; --', 'Another try */ DROP TABLE node; --'),
+      ),
+    );
   }
 
   /**

--- a/docroot/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
+++ b/docroot/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
@@ -7,8 +7,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/docroot/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/docroot/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/entity_cache_test.info
+++ b/docroot/modules/simpletest/tests/entity_cache_test.info
@@ -6,8 +6,8 @@ core = 7.x
 dependencies[] = entity_cache_test_dependency
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/entity_cache_test_dependency.info
+++ b/docroot/modules/simpletest/tests/entity_cache_test_dependency.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/entity_crud_hook_test.info
+++ b/docroot/modules/simpletest/tests/entity_crud_hook_test.info
@@ -5,8 +5,8 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/entity_query_access_test.info
+++ b/docroot/modules/simpletest/tests/entity_query_access_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/error_test.info
+++ b/docroot/modules/simpletest/tests/error_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/file_test.info
+++ b/docroot/modules/simpletest/tests/file_test.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = file_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/filter_test.info
+++ b/docroot/modules/simpletest/tests/filter_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/form_test.info
+++ b/docroot/modules/simpletest/tests/form_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/image_test.info
+++ b/docroot/modules/simpletest/tests/image_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/menu_test.info
+++ b/docroot/modules/simpletest/tests/menu_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/module_test.info
+++ b/docroot/modules/simpletest/tests/module_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/path_test.info
+++ b/docroot/modules/simpletest/tests/path_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/psr_0_test/psr_0_test.info
+++ b/docroot/modules/simpletest/tests/psr_0_test/psr_0_test.info
@@ -5,8 +5,8 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/psr_4_test/psr_4_test.info
+++ b/docroot/modules/simpletest/tests/psr_4_test/psr_4_test.info
@@ -5,8 +5,8 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/requirements1_test.info
+++ b/docroot/modules/simpletest/tests/requirements1_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/requirements2_test.info
+++ b/docroot/modules/simpletest/tests/requirements2_test.info
@@ -7,8 +7,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/session_test.info
+++ b/docroot/modules/simpletest/tests/session_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/system_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_dependencies_test.info
@@ -6,8 +6,8 @@ core = 7.x
 hidden = TRUE
 dependencies[] = _missing_dependency
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
@@ -6,8 +6,8 @@ core = 7.x
 hidden = TRUE
 dependencies[] = system_incompatible_core_version_test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/system_incompatible_core_version_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_core_version_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 5.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
@@ -7,8 +7,8 @@ hidden = TRUE
 ; system_incompatible_module_version_test declares version 1.0
 dependencies[] = system_incompatible_module_version_test (>2.0)
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/system_incompatible_module_version_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_module_version_test.info
@@ -5,8 +5,8 @@ version = 1.0
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/system_test.info
+++ b/docroot/modules/simpletest/tests/system_test.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = system_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/taxonomy_test.info
+++ b/docroot/modules/simpletest/tests/taxonomy_test.info
@@ -6,8 +6,8 @@ core = 7.x
 hidden = TRUE
 dependencies[] = taxonomy
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/theme_test.info
+++ b/docroot/modules/simpletest/tests/theme_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
+++ b/docroot/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
@@ -6,8 +6,8 @@ hidden = TRUE
 settings[basetheme_only] = base theme value
 settings[subtheme_override] = base theme value
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
+++ b/docroot/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
@@ -6,8 +6,8 @@ hidden = TRUE
 
 settings[subtheme_override] = subtheme value
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/themes/test_theme/test_theme.info
+++ b/docroot/modules/simpletest/tests/themes/test_theme/test_theme.info
@@ -17,8 +17,8 @@ stylesheets[all][] = system.base.css
 
 settings[theme_test_setting] = default value
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/update_script_test.info
+++ b/docroot/modules/simpletest/tests/update_script_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/update_test_1.info
+++ b/docroot/modules/simpletest/tests/update_test_1.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/update_test_2.info
+++ b/docroot/modules/simpletest/tests/update_test_2.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/update_test_3.info
+++ b/docroot/modules/simpletest/tests/update_test_3.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/url_alter_test.info
+++ b/docroot/modules/simpletest/tests/url_alter_test.info
@@ -5,8 +5,8 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/simpletest/tests/xmlrpc_test.info
+++ b/docroot/modules/simpletest/tests/xmlrpc_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/statistics/statistics.info
+++ b/docroot/modules/statistics/statistics.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = statistics.test
 configure = admin/config/system/statistics
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/syslog/syslog.info
+++ b/docroot/modules/syslog/syslog.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = syslog.test
 configure = admin/config/development/logging
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/system/system.info
+++ b/docroot/modules/system/system.info
@@ -12,8 +12,8 @@ files[] = system.test
 required = TRUE
 configure = admin/config/system
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/system/system.module
+++ b/docroot/modules/system/system.module
@@ -359,7 +359,7 @@ function system_element_info() {
     '#size' => 60,
     '#maxlength' => 128,
     '#autocomplete_path' => FALSE,
-    '#process' => array('ajax_process_form'),
+    '#process' => array('form_process_autocomplete', 'ajax_process_form'),
     '#theme' => 'textfield',
     '#theme_wrappers' => array('form_element'),
   );

--- a/docroot/modules/system/tests/cron_queue_test.info
+++ b/docroot/modules/system/tests/cron_queue_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/taxonomy/taxonomy.info
+++ b/docroot/modules/taxonomy/taxonomy.info
@@ -8,8 +8,8 @@ files[] = taxonomy.module
 files[] = taxonomy.test
 configure = admin/structure/taxonomy
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/toolbar/toolbar.info
+++ b/docroot/modules/toolbar/toolbar.info
@@ -4,8 +4,8 @@ core = 7.x
 package = Core
 version = VERSION
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/tracker/tracker.info
+++ b/docroot/modules/tracker/tracker.info
@@ -6,8 +6,8 @@ version = VERSION
 core = 7.x
 files[] = tracker.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/translation/tests/translation_test.info
+++ b/docroot/modules/translation/tests/translation_test.info
@@ -5,8 +5,8 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/translation/translation.info
+++ b/docroot/modules/translation/translation.info
@@ -6,8 +6,8 @@ version = VERSION
 core = 7.x
 files[] = translation.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/trigger/tests/trigger_test.info
+++ b/docroot/modules/trigger/tests/trigger_test.info
@@ -4,8 +4,8 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/trigger/trigger.info
+++ b/docroot/modules/trigger/trigger.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = trigger.test
 configure = admin/structure/trigger
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/update/tests/aaa_update_test.info
+++ b/docroot/modules/update/tests/aaa_update_test.info
@@ -4,8 +4,8 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/update/tests/bbb_update_test.info
+++ b/docroot/modules/update/tests/bbb_update_test.info
@@ -4,8 +4,8 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/update/tests/ccc_update_test.info
+++ b/docroot/modules/update/tests/ccc_update_test.info
@@ -4,8 +4,8 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
+++ b/docroot/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
@@ -3,8 +3,8 @@ description = Test theme which acts as a base theme for other test subthemes.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
+++ b/docroot/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
@@ -4,8 +4,8 @@ core = 7.x
 base theme = update_test_basetheme
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/update/tests/update_test.info
+++ b/docroot/modules/update/tests/update_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/update/update.info
+++ b/docroot/modules/update/update.info
@@ -6,8 +6,8 @@ core = 7.x
 files[] = update.test
 configure = admin/reports/updates/settings
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/user/tests/user_form_test.info
+++ b/docroot/modules/user/tests/user_form_test.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/modules/user/user.info
+++ b/docroot/modules/user/user.info
@@ -9,8 +9,8 @@ required = TRUE
 configure = admin/config/people
 stylesheets[all][] = user.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/profiles/minimal/minimal.info
+++ b/docroot/profiles/minimal/minimal.info
@@ -5,8 +5,8 @@ core = 7.x
 dependencies[] = block
 dependencies[] = dblog
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/profiles/standard/standard.info
+++ b/docroot/profiles/standard/standard.info
@@ -24,8 +24,8 @@ dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = rdf
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/docroot/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -6,8 +6,8 @@ core = 7.x
 hidden = TRUE
 files[] = drupal_system_listing_compatible_test.test
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/docroot/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -8,8 +8,8 @@ version = VERSION
 core = 6.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/profiles/testing/testing.info
+++ b/docroot/profiles/testing/testing.info
@@ -4,8 +4,8 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/robots.txt
+++ b/docroot/robots.txt
@@ -11,10 +11,7 @@
 # Ignored: http://example.com/site/robots.txt
 #
 # For more information about the robots.txt standard, see:
-# http://www.robotstxt.org/wc/robots.html
-#
-# For syntax checking, see:
-# http://www.sxw.org.uk/computing/robots/check.html
+# http://www.robotstxt.org/robotstxt.html
 
 User-agent: *
 Crawl-delay: 10
@@ -48,10 +45,6 @@ Disallow: /user/register/
 Disallow: /user/password/
 Disallow: /user/login/
 Disallow: /user/logout/
-Disallow: /multimedia/continuity
-Disallow: /multimedia/food-safety-week-2015-la-toolkit
-Disallow: /multimedia/food-safety-week-2015-partners
-Disallow: /multimedia/dbw-2015-pecyn-cyfathrebu
 # Paths (no clean URLs)
 Disallow: /?q=admin/
 Disallow: /?q=comment/reply/
@@ -62,3 +55,9 @@ Disallow: /?q=user/password/
 Disallow: /?q=user/register/
 Disallow: /?q=user/login/
 Disallow: /?q=user/logout/
+# FSA-specific URLs
+Disallow: /multimedia/continuity
+Disallow: /multimedia/food-safety-week-2015-la-toolkit
+Disallow: /multimedia/food-safety-week-2015-partners
+Disallow: /multimedia/dbw-2015-pecyn-cyfathrebu
+

--- a/docroot/themes/bartik/bartik.info
+++ b/docroot/themes/bartik/bartik.info
@@ -34,8 +34,8 @@ regions[footer] = Footer
 settings[shortcut_module_link] = 0
 
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/themes/garland/garland.info
+++ b/docroot/themes/garland/garland.info
@@ -7,8 +7,8 @@ stylesheets[all][] = style.css
 stylesheets[print][] = print.css
 settings[garland_width] = fluid
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/themes/seven/seven.info
+++ b/docroot/themes/seven/seven.info
@@ -13,8 +13,8 @@ regions[page_bottom] = Page bottom
 regions[sidebar_first] = First sidebar
 regions_hidden[] = sidebar_first
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 

--- a/docroot/themes/stark/stark.info
+++ b/docroot/themes/stark/stark.info
@@ -5,8 +5,8 @@ version = VERSION
 core = 7.x
 stylesheets[all][] = layout.css
 
-; Information added by Drupal.org packaging script on 2015-06-17
-version = "7.38"
+; Information added by Drupal.org packaging script on 2015-08-19
+version = "7.39"
 project = "drupal"
-datestamp = "1434567286"
+datestamp = "1440020197"
 


### PR DESCRIPTION
Upgraded Drupal Core to the latest version - **7.39**.

Modified the included robots.txt file to retain the custom rules added by FSA. These are now at the very end of the file, making them easier to identify for next time.

[ Fixes #10247 ]