### PR TITLE
Upgrade Migrate module to 7.x-2.8

### DIFF
--- a/docroot/sites/all/modules/migration/migrate/CHANGELOG.txt
+++ b/docroot/sites/all/modules/migration/migrate/CHANGELOG.txt
@@ -1,3 +1,256 @@
+Migrate 2.8
+===========
+
+Features and enhancements
+- #2379289 - Better handle interaction of --update with highwater marks.
+- #2403643 - Support an additional level of subfields.
+- #2472045 - Add language subfields only if field is translatable.
+- #2474809 - Provide better message for bad dependencies.
+- #2397791 - Provide detailed field validation errors.
+- #2309563 - Add support for running migrations via wildcard name.
+- #2095841 - Abstract mail system disablement for more flexibility.
+- #2419373 - Provide ability to cache map lookups.
+- #2141687 - Provide detailed message on file copy error.
+
+Bug fixes
+  Field sanitization added to prevent possibility of XSS - see security advisory
+  https://security.drupal.org/node/155268.
+- #2447115 - Add xpath handling to the field mapping editor.
+- #2497015 - Term reference handler would ignore all terms if one was NULL.
+- #2488560 - MigrateSourceList/MigrateSourceMultiItems iterators prematurely
+             return.
+- #2446105 - Keep coded DNM source field mappings from overriding UI mappings.
+- #2415977 - Use temporary:// instead of /tmp for drush logging.
+- #2475473 - Fix handling of --idlist when map not joined.
+- #2465387 - Fix handling of --stop option on migrate-import.
+
+Migrate 2.7
+===========
+
+Features and enhancements
+- #2296911 - Add a source handler for IBM DB2.
+- #2256761 - Add a destination handler for variables.
+- #2047815 - Support multi-column source keys in idlist.
+- #1751438 - Add spreadsheet source plugin.
+
+Bug fixes
+- #2415597 - Make batching of SQL sources optional, and force map_joinable FALSE.
+- #2403593 - SQL batching messes up cases with altered queries, such as idlist.
+- #2298969 - Verify wizard validation function exists.
+- #2268863 - Fix drush --all option.
+- #2410523 - Remove inconsistent escaping of migrate_drush_path.
+
+Migrate 2.6
+===========
+
+IMPORTANT CHANGES SINCE MIGRATE 2.5
+-----------------------------------
+Migration developers will need to add the "advanced migration information"
+permission to their roles to continue seeing all the info in the UI they're
+used to.
+
+Auto-registration (having classes be registered just based on their class name,
+with no call to registerMigration or definition in hook_migrate_api()) is no
+longer supported. Registration of classes defined in hook_migrate_api() is no
+longer automatic - do a drush migrate-register or use the Register button in the
+UI to register them.
+
+Migration class constructors should now always accept an $arguments array as
+the first parameter and pass it to its parent. This version does support legacy
+migrations which pass a group object, or nothing, but these methods are
+deprecated.
+
+Features and enhancements
+- #2390229 - Make literal strings monolithic.
+- #2391789 - Add extender getter to better support extending wizards.
+- #2363015 - Add support for modifying wizards defined by other modules.
+- #2353527 - Add getter/setter for trackLastImported.
+- #2302929 - Explicitly count IDs for JSON source counts.
+- #2296187 - Batch MigrateSQLSource queries.
+- #2260211 - Allow skipping of file contents in MigrateListFiles.
+- #2259089 - Display actual query for SQL sources.
+- #2224297 - Destination handler for custom blocks.
+- #2370677 - Add removeStep() method to Wizard API.
+- #2306953 - Give basic users a little more information.
+- #2261357 - Add prepareCallback/completeCallback to table destination.
+- #2306923 - Propagate message statuses to drupal_set_message in batch.
+- #2301679 - Display all source key fields in the message view.
+- #2312075 - Add --ignore-highwater option to drush imports
+- #1961316 - Get data from all XML namespaces
+- #1298724 - Add a node revision destination plugin.
+- #1890610 - Add a MongoDB source plugin
+- #2065295 - Add ability to disable other module's hooks during migration.
+- #2051547 - Add ability to revert UI-defined field mappings.
+- #1998632 - Extend MigrateItemsXML to handle an array of XML files.
+- #1990612 - Add a row status argument to MigrateException, allowing rows to
+             be cleanly skipped by throwing exceptions.
+- #2017835 - Add MigrateFileUriAsIs file class, and make file migrations more
+             flexible.
+- #2004426 - UI support for editing dependencies; enable setting dependencies
+             through arguments.
+- #1826112 - A new API has been added to support external modules in developing
+             easy-to-use wizard-based UIs.
+- #1833380 - Major refactoring of the UI, breaking groups and migrations
+             (tasks) into separate pages, introducing an advanced permission and
+             presenting a simplified UI to those with only the basic permission.
+- #1860450 - The UI now has the capability of spawning import/rollback operations
+             in drush, with email notifications of completion. The notification
+             ability is available when running drush at the command line, which
+             may be useful for running imports via cron.
+- #1996602 - A default field handler is now provided that should handle many if
+             not most field types without custom handlers.
+- #1901980 - Support encrypting particular arguments saved to the database, to
+             support wizard implementations that may be prompting for secure
+             database credentials.
+- #1896096 - Add ability to define field mappings via arguments at registration
+             time, and use those to override mappings in code.
+- #1961620 - When editing field mappings, allow destination or source fields to
+             be explicitly set DNM.
+- #1996280 - Allow all field/subfields/options to be edited, and indent
+             subfields/options to make the relationship more clear.
+- #1996350 - Allow sourceMigration to be edited.
+- #1996736 - Add support for hook_migrate_api_alter().
+- #1984568 - Add setters to enable constructing migrations according to a
+             dependency injection pattern.
+- #1835822 - Hash source rows to detect changes.
+- #1975180 - Explicitly check dependency existence so missing dependencies aren't
+             reported as circular.
+- #1984534 - Updating/cleanup of examples to reflect current best practices.
+- #1972600 - Add getter for the MigrateXMLReader member of MigrateSourceXML.
+- #1856694 - Allow disabling of uri encoding.
+- #1835142 - Add names-only option to drush ms command.
+- #1892296 - Increase time limit for batch UI migrations.
+- #1839644 - Groups have been extended to record titles and arguments in the db.
+- #1896920 - Remove auto-registration, and make static registration expicit.
+- #1928956 - Clean up registration/instantiation chicken-and-egg problems, by
+             supporting consistent constructor arguments.
+- #1550878 - Added UI for deregistering migrations, including one-button
+             deregistration of orphans.
+- #1792894 - Remove empty field values, permitting proper defaulting.
+- #1903236 - Allow reset of migrate_migrations() cache.
+- #1894344 - Support warn_on_override for bulk unmigrated methods.
+- #1886404 - Allow subfields to be mapped before primary fields.
+
+Bug fixes
+- #2391891 - idlist with XML source causes exception.
+- #2314077 - Don't merge group dependencies into migration dependencies.
+- #2392683 - Set vocabulary name (bundle) explicitly for term reference fields.
+- #2266395 - Check for valid picture file saving users.
+- #2225551 - Add field validation to entity destination plugins.
+- #2285966 - Added exception handling around constructors.
+- #2370877 - Fix reloading of wizard steps after first.
+- #2358767 - Topological sort to help avoid false circular dependency errors.
+- #2019193 - Properly handle destination DNM status on field mapping save.
+- #2250081 - Fix PostgreSQL failure updating node statistics on comments.
+- #2157933 - Fix PostgreSQL error with empty source migrations.
+- #2177313 - Make sure reused file entities are saved to pick up field changes.
+- #2352971 - Treat empty default values as NULL in field mapping editor.
+- #2347205 - Explicitly default the language for terms.
+- #2307599 - Notice for non-advanced users on rollback.
+- #2305105 - Remove pedantically-deprecated hyphens.
+- #2325237 - Handle language arrays for file fields.
+- #2258909 - Use migrated languages for file fields.
+- #2323605 - Handle single-parent terms properly.
+- #2313495 - Handle multilingual path aliases.
+- #2261227 - Fixed missing subfields on edit mapping form.
+- #2154385 - Add file/line context to source plugin exceptions.
+- #2190255 - Remove duplicate warnings on missing XML source.
+- #2129609 - Remove warnings on MS SQL counts.
+- #2109931 - Pass drush global options to subprocess.
+- #2236279 - Prevent ignore_case from causing created terms to be lower-cased.
+- #2104149 - Sanity-check decrypted arguments.
+- #2047523 - Consistently document destination handler fields() implementations.
+- #2244759 - Rollback migrations in proper (reverse) order in UI.
+- #2184641 - Make saveHighwater() work with PostgreSQL.
+- #2076035 - Properly check key values in saveMessage().
+- #2076035 - Validate that term names are not empty.
+- #2225809 - Use proper API for registering wizard classes.
+- #2105037 - Expose nid/uid destinations when is_new is on.
+- #2145213 - Add SQLMap constructor documentation.
+- #2213033 - Add batch callback documentation.
+- #2095829 - Remove all variables on uninstall.
+- #2072721 - Proper title for migrate_example_baseball feature.
+- #1999228 - Removed AJAX from field mapping form for performance.
+- #2237755 - Fix activeUrl handling in JSON source.
+- #2237891 - Use drupal_register_shutdown_function().
+- #2141409 - Handle drush spawning when Drupal in subdirectory.
+- #2191335 - Remove unused columns from CSV source row.
+- #2210533 - Properly pass directory by reference.
+- #2141569 - Explicitly create group in baseball example.
+- #2159291 - Add message for missing argument to drush migrate-messages.
+- #2019193 - Fix unsetting of DNM source fields through the UI.
+- #2227061 - Fix to subfields in a multi-value context.
+- #2170177 - Properly handle multi-value fields when a subfield is mapped first.
+- #2120205 - Fix bug when upgrading lastimported from D6 to D7.
+- #2109821 - Handle multi-value subfields in the default field handler.
+- #2039649 - Smarter setting of file 'type' field.
+- #2106925 - Fix machine_name generation for legacy migrations.
+- #2102087 - Don't pass --group to drush subprocess.
+- #2099585 - Enable group option on drush migrate-stop.
+- #2088255 - Eliminate notices on migrate_map_hash with track_changes.
+- #2014849 - Make sure (again) statistics properly default to 0.
+- #2042535 - Properly set file_usage for user pictures.
+- #2060631 - Fix notices on poll vote import.
+- #2049689 - Empty values for node is_new caused SQL errors.
+- #2042399 - Node import did not respect revision flag.
+- #2034885 - For XML sources, don't override values populated in prepareRow().
+- #2041267 - Handle lack of potential dependencies on edit page.
+- #2040101 - Breadcrumbs in migration UI missing sections
+- #2033947 - Empty migration display names when matching group names.
+- #2037265 - Static migrations were not registered on module enable.
+- #2021457 - Coding standard improvements for xml.inc.
+- #2030559 - Add deprecation messages for arguments().
+- #1854382 - Fix handling of terms with leading spaces.
+- #2025137 - Ignore --update in the presence of --idlist.
+- #2023813 - Apply defaultValue() for empty XML values.
+- #2023657 - Prevent duplicate aliases when updating nodes.
+- #2021973 - Drush deregistration needs to handle mixed-case machine names.
+- #2017443 - Properly hash XML source rows with track_changes on.
+- #2020095 - Preserve arguments in legacy constructors.
+- #2018841 - Default field handler needs to account for empty column
+             descriptions.
+- #2016173 - Fix fatal error editing MigrationBase migrations.
+- #2015327 - Remove broken automatic field mapping feature.
+- #2014849 - Make sure statistics properly default to 0.
+- #2011024 - Wildcard groups/tasks in the menu hierarchy, saving the need to
+             rebuild menus when migrations are registered/deregistered.
+- #2010884 - Clean up empty default groups on dbupdate.
+- #2004296 - Enforce map/message table names with prefixes.
+- #2009222 - Properly update map/message tables on a non-default connection.
+- #2006158 - Fix warnings on default field handler fields().
+- #1999918 - Move permissions to core Migrate module.
+- #1999290 - Check that an XMLMigration has actually populated $row->xml.
+- #1989012 - Support preserve_files for MigrateFileFid.
+- #1982564 - Properly handle messages for ignored rows.
+- #1989022 - Strip HTML tags from drush fields output.
+- #1988008 - Restore group dependency support.
+- #1985750 - Add missing prepareRollback/completeRollback for file destinations.
+- #1978702 - Check highwater marks against the starting highwater.
+- #1974216 - Change field mapping table PK to a simple serial column.
+- #1977578 - Bad exception handling in MigrateDestinationTableCopy.
+- #1973030 - Handle zero-valued timestamps properly.
+- #1973092 - Fix preservation of sourceMigration when editing mappings.
+- #1968358 - Prevent unnecessary reimport when using track_changes.
+- #1968014 - Fix menu notices on task list page.
+- #1967946 - Missing check on existence of mapping.
+- #1849350 - Make sure encoding of uris doesn't break query strings.
+- #1844316 - Ensure rollback_action is added to all map tables.
+- #1913462 - Fix update functions returning arrays.
+- #1831940 - Allow empty string source keys in handleSourceMigration().
+- #1896042 - Fix incorrect usage of originalQuery.
+- #1954936 - Allow overriding source count in isComplete.
+- #1952430 - Prevent bogus "no error provided" messages.
+- #1931168 - Properly cache class info in _migrate_class_list().
+- #1900914 - Disable email with no custom mail system configured.
+- #1901648 - Missing bundle property on file migrations.
+- #1885362 - Make access callback explicit, to avoid conflict with admin_views.
+- #1880512 - Strip tags from descriptions on drush migrate-mappings.
+- #1872446 - Properly handle updates on role migration.
+- #1871764 - Pass zero values through handleSourceMigration.
+- #1839534 - Handle missing chunk separator in MigrateItemFile.
+- #1854382 - Prevent duplicate terms due to leading/trailing spaces.
+- #1794236 - Namespace detail pages within menu system.
+- #1836426 - Proper check on activeUrl for multiple XML files.
 
 Migrate 2.5
 ===========
@@ -10,12 +263,6 @@ If your migrations are not explicitly registered, you must request auto-registra
 with a "drush mar" (drush migrate-auto-register) command, or by clicking the
 "Register" button at admin/content/migrate/registration.
 
-Bug fixes
-- #1827052 - Properly check for bad XML.
-
-Migrate 2.5 Release Candidate 2
-===============================
-
 Features and enhancements
 - #1824024 - Destination and field handlers may now be registered through
              hook_migrate_api(). Automatic registration of all migration and
@@ -26,14 +273,6 @@ Features and enhancements
              hook_migrate_api().
 - #1819730 - Make migration of files in a field context non-fatal.
 - #1816652 - Provide useful warning when file subfield arrays don't line up.
-
-Bug fixes
-- #1824118 - Make --force work for rollbacks.
-
-Migrate 2.5 Release Candidate 1
-===============================
-
-Features and enhancements
 - #1778952 - Enable registration of dynamic migrations via hook_migrate_api().
              Add explicit auto-registration of non-dynamic migrations, remove
              performing registration on cache clear.
@@ -54,6 +293,8 @@ Features and enhancements
 - #1621906 - Support DESTINATION system-of-records for menu links.
 
 Bug fixes
+- #1827052 - Properly check for bad XML.
+- #1824118 - Make --force work for rollbacks.
 - #1659150 - Change 'ok' message types to 'status'.
 - #1690080 - Deal with self-references in handleSourceMigration().
 - #1797644 - Remove bogus assignment on term update.

--- a/docroot/sites/all/modules/migration/migrate/README.txt
+++ b/docroot/sites/all/modules/migration/migrate/README.txt
@@ -6,8 +6,8 @@ users are included. Plugins permit migration of other types of content.
 
 Usage
 -----
-Documentation is at http://drupal.org/node/415260. To get started, enable the 
-migrate_example module and browse to admin/content/migrate to see its dashboard. 
+Documentation is at http://drupal.org/migrate. To get started, enable the
+migrate_example module and browse to admin/content/migrate to see its dashboard.
 The code for this migration is in migrate_example/beer.inc (advanced examples are
 in wine.inc). Mimic that file in order to specify your own migrations. 
 

--- a/docroot/sites/all/modules/migration/migrate/includes/base.inc
+++ b/docroot/sites/all/modules/migration/migrate/includes/base.inc
@@ -37,9 +37,9 @@ abstract class MigrationBase {
   }
 
   /**
-   * The name of a migration group, used to collect related migrations.
+   * A migration group object, used to collect related migrations.
    *
-   * @var string
+   * @var MigrateGroup
    */
   protected $group;
   public function getGroup() {
@@ -54,6 +54,9 @@ abstract class MigrationBase {
   protected $description;
   public function getDescription() {
     return $this->description;
+  }
+  public function setDescription($description) {
+    $this->description = $description;
   }
 
   /**
@@ -143,8 +146,20 @@ abstract class MigrationBase {
   public function getHardDependencies() {
     return $this->dependencies;
   }
+  public function setHardDependencies(array $dependencies) {
+    $this->dependencies = $dependencies;
+  }
+  public function addHardDependencies(array $dependencies) {
+    $this->dependencies = array_merge($this->dependencies, $dependencies);
+  }
   public function getSoftDependencies() {
     return $this->softDependencies;
+  }
+  public function setSoftDependencies(array $dependencies) {
+    $this->softDependencies = $dependencies;
+  }
+  public function addSoftDependencies(array $dependencies) {
+    $this->softDependencies = array_merge($this->softDependencies, $dependencies);
   }
   public function getDependencies() {
     return array_merge($this->dependencies, $this->softDependencies);
@@ -160,6 +175,13 @@ abstract class MigrationBase {
   public static function setDisplayFunction($display_function) {
     self::$displayFunction = $display_function;
   }
+
+  /**
+   * Track whether or not we've already displayed an encryption warning
+   *
+   * @var bool
+   */
+  protected static $showEncryptionWarning = TRUE;
 
   /**
    * The fraction of the memory limit at which an operation will be interrupted.
@@ -194,6 +216,14 @@ abstract class MigrationBase {
   protected $timeLimit;
 
   /**
+   * A time limit in seconds appropriate to be used in a batch
+   * import. Defaults to 240.
+   *
+   * @var int
+   */
+  protected $batchTimeLimit = 240;
+
+  /**
    * MigrateTeamMember objects representing people involved with this
    * migration.
    *
@@ -202,6 +232,9 @@ abstract class MigrationBase {
   protected $team = array();
   public function getTeam() {
     return $this->team;
+  }
+  public function setTeam(array $team) {
+    $this->team = $team;
   }
 
   /**
@@ -214,6 +247,9 @@ abstract class MigrationBase {
   public function getIssuePattern() {
     return $this->issuePattern;
   }
+  public function setIssuePattern($issue_pattern) {
+    $this->issuePattern = $issue_pattern;
+  }
 
   /**
    * If we set an error handler (during import), remember the previous one so
@@ -222,6 +258,22 @@ abstract class MigrationBase {
    * @var callback
    */
   protected $previousErrorHandler = NULL;
+
+  /**
+   * Arguments configuring a migration.
+   *
+   * @var array
+   */
+  protected $arguments = array();
+  public function getArguments() {
+    return $this->arguments;
+  }
+  public function setArguments(array $arguments) {
+    $this->arguments = $arguments;
+  }
+  public function addArguments(array $arguments) {
+    $this->arguments = array_merge($this->arguments, $arguments);
+  }
 
   /**
    * Disabling a migration prevents it from running with --all, or individually
@@ -233,6 +285,34 @@ abstract class MigrationBase {
   public function getEnabled() {
     return $this->enabled;
   }
+  public function setEnabled($enabled) {
+    $this->enabled = $enabled;
+  }
+
+  /**
+   * Any module hooks which should be disabled during migration processes.
+   *
+   * @var array
+   *  Key: Hook name (e.g., 'node_insert')
+   *  Value: Array of modules for which to disable this hook (e.g., array('pathauto')).
+   */
+  protected $disableHooks = array();
+  public function getDisableHooks() {
+    return $this->disableHooks;
+  }
+
+  /**
+   * An array to track 'mail_system' variable if disabled.
+   */
+  protected $mailSystem = array();
+
+  /**
+   * Have we already warned about obsolete constructor argumentss on this request?
+   *
+   * @var bool
+   */
+  static protected $groupArgumentWarning = FALSE;
+  static protected $emptyArgumentsWarning = FALSE;
 
   /**
    * Codes representing the result of a rollback or import process.
@@ -284,17 +364,51 @@ abstract class MigrationBase {
   }
 
   /**
-   * General initialization of a MigrationBase object.
+   * Construction of a MigrationBase instance.
+   *
+   * @param array $arguments
    */
-  public function __construct($group = NULL) {
-    $this->machineName = $this->generateMachineName();
-
-    if (empty($group)) {
-      $this->group = MigrateGroup::getInstance('default');
+  public function __construct($arguments = array()) {
+    // Support for legacy code passing a group object as the first parameter.
+    if (is_object($arguments) && is_a($arguments, 'MigrateGroup')) {
+      $this->group = $arguments;
+      $this->arguments['group_name'] = $arguments->getName();
+      if (!self::$groupArgumentWarning &&
+          variable_get('migrate_deprecation_warnings', 1)) {
+        self::displayMessage(t('Passing a group object to a migration constructor is now deprecated - pass through the arguments array passed to the leaf class instead.'));
+        self::$groupArgumentWarning = TRUE;
+      }
     }
     else {
-      $this->group = $group;
+      if (empty($arguments)) {
+        $this->arguments = array();
+        if (!self::$emptyArgumentsWarning &&
+            variable_get('migrate_deprecation_warnings', 1)) {
+          self::displayMessage(t('Passing an empty first parameter to a migration constructor is now deprecated - pass through the arguments array passed to the leaf class instead.'));
+          self::$emptyArgumentsWarning = TRUE;
+        }
+      }
+      else {
+        $this->arguments = $arguments;
+      }
+      if (empty($this->arguments['group_name'])) {
+        $this->arguments['group_name'] = 'default';
+      }
+      $this->group = MigrateGroup::getInstance($this->arguments['group_name']);
     }
+    if (isset($this->arguments['machine_name'])) {
+      $this->machineName = $this->arguments['machine_name'];
+    }
+    else {
+      // Deprecated - this supports old code which does not pass the arguments
+      // array through to the base constructor. Remove in the next version.
+      $this->machineName = $this->machineFromClass(get_class($this));
+    }
+    // Make any group arguments directly accessible to the specific migration,
+    // other than group dependencies.
+    $group_arguments = $this->group->getArguments();
+    unset($group_arguments['dependencies']);
+    $this->arguments += $group_arguments;
 
     // Record the memory limit in bytes
     $limit = trim(ini_get('memory_limit'));
@@ -323,16 +437,20 @@ abstract class MigrationBase {
     // Record the time limit
     $this->timeLimit = ini_get('max_execution_time');
 
-    // Prevent any emails from being sent out on migration
-    global $conf;
-    if (!empty($conf['mail_system'])) {
-      foreach ($conf['mail_system'] as $system => $class) {
-        $conf['mail_system'][$system] = 'MigrateMailIgnore';
-      }
-    }
+    // Save the current mail system, prior to disabling emails.
+    $this->saveMailSystem();
+
+    // Prevent emails from being sent out during migrations.
+    $this->disableMailSystem();
 
     // Make sure we clear our semaphores in case of abrupt exit
-    register_shutdown_function(array($this, 'endProcess'));
+    drupal_register_shutdown_function(array($this, 'endProcess'));
+
+    // Save any hook disablement information.
+    if (isset($this->arguments['disable_hooks']) &&
+        is_array($this->arguments['disable_hooks'])) {
+      $this->disableHooks = $this->arguments['disable_hooks'];
+    }
   }
 
   /**
@@ -358,7 +476,10 @@ abstract class MigrationBase {
    * @param string $machine_name
    * @param array $arguments
    */
-  static public function registerMigration($class_name, $machine_name = NULL, array $arguments = array()) {
+  static public function registerMigration($class_name, $machine_name = NULL,
+      array $arguments = array()) {
+    // Support for legacy migration code - in later releases, the machine_name
+    // should always be explicit.
     if (!$machine_name) {
       $machine_name = self::machineFromClass($class_name);
     }
@@ -368,11 +489,20 @@ abstract class MigrationBase {
                           array('!name' => $machine_name)));
     }
 
-    // Making sure the machine name is in the arguments array helps with
-    // chicken-and-egg problems in determining the machine name.
-    if (!isset($arguments['machine_name'])) {
-      $arguments['machine_name'] = $machine_name;
+    // We no longer have any need to store the machine_name in the arguments.
+    if (isset($arguments['machine_name'])) {
+      unset($arguments['machine_name']);
     }
+
+    if (isset($arguments['group_name'])) {
+      $group_name = $arguments['group_name'];
+      unset($arguments['group_name']);
+    }
+    else {
+      $group_name = 'default';
+    }
+
+    $arguments = self::encryptArguments($arguments);
 
     // Register the migration if it's not already there; if it is,
     // update the class and arguments in case they've changed.
@@ -380,6 +510,7 @@ abstract class MigrationBase {
       ->key(array('machine_name' => $machine_name))
       ->fields(array(
                 'class_name' => $class_name,
+                'group_name' => $group_name,
                 'arguments' => serialize($arguments)
         ))
       ->execute();
@@ -395,17 +526,27 @@ abstract class MigrationBase {
     $rows_deleted = db_delete('migrate_status')
                     ->condition('machine_name', $machine_name)
                     ->execute();
+    // Make sure the group gets deleted if we were the only member.
+    MigrateGroup::deleteOrphans();
   }
 
   /**
-   * By default, the migration machine name is the class name (with the
-   * Migration suffix, if present, stripped).
+   * The migration machine name is stored in the arguments.
+   *
+   * @return string
    */
   protected function generateMachineName() {
-    $class_name = get_class($this);
-    return self::machineFromClass($class_name);
+    return $this->arguments['machine_name'];
   }
 
+  /**
+   * Given only a class name, derive a machine name (the class name with the
+   * "Migration" suffix, if any, removed).
+   *
+   * @param $class_name
+   *
+   * @return string
+   */
   protected static function machineFromClass($class_name) {
     if (preg_match('/Migration$/', $class_name)) {
       $machine_name = drupal_substr($class_name, 0,
@@ -422,38 +563,74 @@ abstract class MigrationBase {
    *
    * @param string $machine_name
    */
+
+  /**
+   * Return the single instance of the given migration.
+   *
+   * @param $machine_name
+   *  The unique machine name of the migration to retrieve.
+   * @param string $class_name
+   *  Deprecated - no longer used, class name is retrieved from migrate_status.
+   * @param array $arguments
+   *  Deprecated - no longer used, arguments are retrieved from migrate_status.
+   *
+   * @return MigrationBase
+   */
   static public function getInstance($machine_name, $class_name = NULL, array $arguments = array()) {
     $migrations = &drupal_static(__FUNCTION__, array());
     // Otherwise might miss cache hit on case difference
     $machine_name_key = drupal_strtolower($machine_name);
     if (!isset($migrations[$machine_name_key])) {
-      // Skip the query if our caller already made it
-      if (!$class_name) {
-        // See if we know about this migration
-        $row = db_select('migrate_status', 'ms')
-               ->fields('ms', array('class_name', 'arguments'))
-               ->condition('machine_name', $machine_name)
-               ->execute()
-               ->fetchObject();
-        if ($row) {
-          $class_name = $row->class_name;
-          $arguments = unserialize($row->arguments);
+      // See if we know about this migration
+      $row = db_select('migrate_status', 'ms')
+             ->fields('ms', array('class_name', 'group_name', 'arguments'))
+             ->condition('machine_name', $machine_name)
+             ->execute()
+             ->fetchObject();
+      if ($row) {
+        $class_name = $row->class_name;
+        $arguments = unserialize($row->arguments);
+        $arguments = self::decryptArguments($arguments);
+        $arguments['group_name'] = $row->group_name;
+      }
+      else {
+        // Can't find a migration with this name
+        self::displayMessage(t('No migration found with machine name !machine',
+          array('!machine' => $machine_name)));
+        return NULL;
+      }
+      $arguments['machine_name'] = $machine_name;
+      if (class_exists($class_name)) {
+        try {
+          $migrations[$machine_name_key] = new $class_name($arguments);
         }
-        else {
-          // Can't find a migration with this name
-          throw new MigrateException(t('No migration found with machine name !machine',
+        catch (Exception $e) {
+          self::displayMessage(t('Migration !machine could not be constructed.',
             array('!machine' => $machine_name)));
+          self::displayMessage($e->getMessage());
+          return NULL;
         }
       }
-      $migrations[$machine_name_key] = new $class_name($arguments);
+      else {
+        self::displayMessage(t('No migration class !class found',
+          array('!class' => $class_name)));
+        return NULL;
+      }
+      if (isset($arguments['dependencies'])) {
+        $migrations[$machine_name_key]->setHardDependencies(
+          $arguments['dependencies']);
+      }
+      if (isset($arguments['soft_dependencies'])) {
+        $migrations[$machine_name_key]->setSoftDependencies(
+          $arguments['soft_dependencies']);
+      }
     }
     return $migrations[$machine_name_key];
   }
 
   /**
-   * Identifies whether this migration is "dynamic" (that is, allows multiple
-   * instances distinguished by differing parameters). A dynamic class should
-   * override this with a return value of TRUE.
+   * @deprecated - No longer a useful distinction between "status" and "dynamic"
+   *  migrations.
    */
   static public function isDynamic() {
     return FALSE;
@@ -625,9 +802,16 @@ abstract class MigrationBase {
         if (!empty($this->highwaterField['type']) && $this->highwaterField['type'] == 'int') {
           // If the highwater is an integer type, we need to force the DB server
           // to treat the varchar highwater field as an integer (otherwise it will
-          // think '5' > '10'). CAST(highwater AS INTEGER) would be ideal, but won't
-          // work in MySQL. This hack is thought to be portable.
-          $query->where('(highwater+0) < :highwater', array(':highwater' => $highwater));
+          // think '5' > '10').
+          switch (Database::getConnection()->databaseType()) {
+            case 'pgsql':
+              $query->where('(CASE WHEN highwater=\'\' THEN 0 ELSE CAST(highwater AS INTEGER) END) < :highwater', array(':highwater' => intval($highwater)));
+              break;
+            default:
+              // CAST(highwater AS INTEGER) would be ideal, but won't
+              // work in MySQL. This hack is thought to be portable.
+              $query->where('(highwater+0) < :highwater', array(':highwater' => $highwater));
+          }
         }
         else {
           $query->condition('highwater', $highwater, '<');
@@ -684,7 +868,7 @@ abstract class MigrationBase {
     else {
       foreach ($this->dependencies as $dependency) {
         $migration = MigrationBase::getInstance($dependency);
-        if (!$migration->isComplete()) {
+        if (!$migration || !$migration->isComplete()) {
           return FALSE;
         }
       }
@@ -699,7 +883,7 @@ abstract class MigrationBase {
     $incomplete = array();
     foreach ($this->getDependencies() as $dependency) {
       $migration = MigrationBase::getInstance($dependency);
-      if (!$migration->isComplete()) {
+      if (!$migration || !$migration->isComplete()) {
         $incomplete[] = $dependency;
       }
     }
@@ -751,6 +935,17 @@ abstract class MigrationBase {
                        'initialHighwater' => $this->getHighwater(),
                        ))
                      ->execute();
+    }
+
+    // If we're disabling any hooks, reset the static module_implements cache so
+    // it is rebuilt with the specified hooks removed by our
+    // hook_module_implements_alter(). By setting #write_cache to FALSE, we
+    // ensure that our munged version of the hooks array does not get written
+    // to the persistent cache and interfere with other Drupal processes.
+    if (!empty($this->disableHooks)) {
+      $implementations = &drupal_static('module_implements');
+      $implementations = array();
+      $implementations['#write_cache'] = FALSE;
     }
   }
 
@@ -905,6 +1100,14 @@ abstract class MigrationBase {
   }
 
   /**
+   * Set the PHP time limit. This method may be called from batch callbacks
+   * before calling the processImport method.
+   */
+  public function setBatchTimeLimit() {
+    drupal_set_time_limit($this->batchTimeLimit);
+  }
+
+  /**
    * A derived migration class does the actual rollback or import work in these
    * methods - we cannot declare them abstract because some classes may define
    * only one.
@@ -1000,20 +1203,146 @@ abstract class MigrationBase {
   }
 
   /**
+   * Encrypt an incoming value. Detects for existence of the Drupal 'Encrypt'
+   *  module or the mcrypt PHP extension.
+   *
+   * @param string $value
+   * @return string The encrypted value.
+   */
+  static public function encrypt($value) {
+    if (module_exists('encrypt')) {
+      $value = encrypt($value);
+    }
+    else if (extension_loaded('mcrypt')) {
+      // Mimic encrypt module to ensure compatibility
+      $key = drupal_substr(variable_get('drupal_private_key', 'no_key'), 0, 32);
+      $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB);
+      $iv = mcrypt_create_iv($iv_size, MCRYPT_RAND);
+      $value = mcrypt_encrypt(MCRYPT_RIJNDAEL_256, $key, $value,
+                              MCRYPT_MODE_ECB, $iv);
+
+      $encryption_array['text'] = $value;
+      // For forward compatibility with the encrypt module.
+      $encryption_array['method'] = 'mcrypt_rij_256';
+      $encryption_array['key_name'] = 'drupal_private_key';
+      $value = serialize($encryption_array);
+    }
+    else {
+      if (self::$showEncryptionWarning) {
+        MigrationBase::displayMessage(t('Encryption of secure migration information is not supported. Ensure the <a href="@encrypt">Encrypt module</a> or <a href="mcrypt">mcrypt PHP extension</a> is installed for this functionality.',
+            array(
+              '@encrypt' => 'http://drupal.org/project/encrypt',
+              '@mcrypt' => 'http://php.net/manual/en/book.mcrypt.php',
+            )
+          ),
+          'warning');
+        self::$showEncryptionWarning = FALSE;
+      }
+    }
+    return $value;
+  }
+
+  /**
+   * Decrypt an incoming value.
+   *
+   * @param string $value
+   * @return string The encrypted value
+   */
+  static public function decrypt($value) {
+    if (module_exists('encrypt')) {
+      $value = decrypt($value);
+    }
+    else if (extension_loaded('mcrypt')) {
+      // Mimic encrypt module to ensure compatibility
+      $encryption_array = unserialize($value);
+      $method = $encryption_array['method']; // Not used right now
+      $text = $encryption_array['text'];
+      $key_name = $encryption_array['key_name']; // Not used right now
+
+      $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB);
+      $iv = mcrypt_create_iv($iv_size, MCRYPT_RAND);
+      $key = drupal_substr(variable_get('drupal_private_key', 'no_key'), 0, 32);
+      $value = mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $key, $text,
+                              MCRYPT_MODE_ECB, $iv);
+    }
+    else {
+      if (self::$showEncryptionWarning) {
+        MigrationBase::displayMessage(t('Encryption of secure migration information is not supported. Ensure the <a href="@encrypt">Encrypt module</a> or <a href="mcrypt">mcrypt PHP extension</a> is installed for this functionality.',
+            array(
+              '@encrypt' => 'http://drupal.org/project/encrypt',
+              '@mcrypt' => 'http://php.net/manual/en/book.mcrypt.php',
+            )
+          ),
+          'warning');
+        self::$showEncryptionWarning = FALSE;
+      }
+    }
+    return $value;
+  }
+
+  /**
+   * Make sure any arguments we want to be encrypted get encrypted.
+   *
+   * @param array $arguments
+   *
+   * @return array
+   */
+  static public function encryptArguments(array $arguments) {
+    if (isset($arguments['encrypted_arguments'])) {
+      foreach ($arguments['encrypted_arguments'] as $argument_name) {
+        if (isset($arguments[$argument_name])) {
+          $arguments[$argument_name] = self::encrypt(
+            serialize($arguments[$argument_name]));
+        }
+      }
+    }
+    return $arguments;
+  }
+
+  /**
+   * Make sure any arguments we want to be decrypted get decrypted.
+   *
+   * @param array $arguments
+   *
+   * @return array
+   */
+  static public function decryptArguments(array $arguments) {
+    if (isset($arguments['encrypted_arguments'])) {
+      foreach ($arguments['encrypted_arguments'] as $argument_name) {
+        if (isset($arguments[$argument_name])) {
+          $decrypted_string = self::decrypt($arguments[$argument_name]);
+          // A decryption failure will return FALSE and issue a notice. We need
+          // to distinguish a failure from a serialized FALSE.
+          $unserialized_value = @unserialize($decrypted_string);
+          if ($unserialized_value === FALSE && $decrypted_string != serialize(FALSE)) {
+            self::displayMessage(t('Failed to decrypt argument %argument_name',
+              array('%argument_name' => $argument_name)));
+            unset($arguments[$argument_name]);
+          }
+          else {
+            $arguments[$argument_name] = $unserialized_value;
+          }
+        }
+      }
+    }
+    return $arguments;
+  }
+
+  /**
    * Convert an incoming string (which may be a UNIX timestamp, or an arbitrarily-formatted
    * date/time string) to a UNIX timestamp.
    *
    * @param string $value
    */
   static public function timestamp($value) {
-    // Default empty values to now
-    if (empty($value)) {
-      return time();
-    }
-
     // Does it look like it's already a timestamp? Just return it
     if (is_numeric($value)) {
       return $value;
+    }
+
+    // Default empty values to now
+    if (empty($value)) {
+      return time();
     }
 
     $date = new DateTime($value);
@@ -1025,6 +1354,39 @@ abstract class MigrationBase {
       }
     }
     return $time;
+  }
+
+  /**
+   * Saves the current mail system, or set a system default if there is none.
+   */
+  protected function saveMailSystem() {
+    global $conf;
+    if (empty($conf['mail_system'])) {
+      $conf['mail_system']['default-system'] = 'MigrateMailIgnore';
+    }
+    else {
+      $this->mailSystem = $conf['mail_system'];
+    }
+  }
+
+  /**
+   * Disables mail system to prevent emails from being sent during migrations.
+   */
+  public function disableMailSystem() {
+    global $conf;
+    if (!empty($conf['mail_system'])) {
+      foreach ($conf['mail_system'] as $system => $class) {
+        $conf['mail_system'][$system] = 'MigrateMailIgnore';
+      }
+    }
+  }
+
+  /**
+   * Restores the original saved mail system for migrations that require it.
+   */
+  public function restoreMailSystem() {
+    global $conf;
+    $conf['mail_system'] = $this->mailSystem;
   }
 }
 

--- a/docroot/sites/all/modules/migration/migrate/includes/destination.inc
+++ b/docroot/sites/all/modules/migration/migrate/includes/destination.inc
@@ -105,11 +105,22 @@ abstract class MigrateDestination {
  * All destination handlers should be derived from MigrateDestinationHandler
  */
 abstract class MigrateDestinationHandler extends MigrateHandler {
-  // abstract function arguments(...)
+  // Any one or more of these methods may be implemented
+
   /**
-   * Any one or more of these methods may be implemented
+   * Documentation of any fields added to the destination by this handler.
+   *
+   * @param $entity_type
+   *  The entity type (node, user, etc.) for which to list fields.
+   * @param $bundle
+   *  The bundle (article, blog, etc.), if any, for which to list fields.
+   * @param Migration $migration
+   *  Optionally, the migration providing the context.
+   * @return array
+   *  An array keyed by field name, with field descriptions as values.
    */
-  //abstract public function fields();
+  //abstract public function fields($entity_type, $bundle, $migration = NULL);
+
   //abstract public function prepare($entity, stdClass $row);
   //abstract public function complete($entity, stdClass $row);
 }

--- a/docroot/sites/all/modules/migration/migrate/includes/exception.inc
+++ b/docroot/sites/all/modules/migration/migrate/includes/exception.inc
@@ -6,13 +6,30 @@
  */
 
 class MigrateException extends Exception {
+  /**
+   * The level of the error being reported (a Migration::MESSAGE_* constant)
+   * @var int
+   */
   protected $level;
   public function getLevel() {
     return $this->level;
   }
 
-  public function __construct($message, $level = Migration::MESSAGE_ERROR) {
+  /**
+   * The status to record in the map table for the current item (a
+   * MigrateMap::STATUS_* constant)
+   *
+   * @var int
+   */
+  protected $status;
+  public function getStatus() {
+    return $this->status;
+  }
+
+  public function __construct($message, $level = Migration::MESSAGE_ERROR,
+                              $status = MigrateMap::STATUS_FAILED) {
     $this->level = $level;
+    $this->status = $status;
     parent::__construct($message);
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/includes/field_mapping.inc
+++ b/docroot/sites/all/modules/migration/migrate/includes/field_mapping.inc
@@ -30,6 +30,19 @@ class MigrateFieldMapping {
   }
 
   /**
+   * @var int
+   */
+  const MAPPING_SOURCE_CODE = 1;
+  const MAPPING_SOURCE_DB = 2;
+  protected $mappingSource = self::MAPPING_SOURCE_CODE;
+  public function getMappingSource() {
+    return $this->mappingSource;
+  }
+  public function setMappingSource($mapping_source) {
+    $this->mappingSource = $mapping_source;
+  }
+
+  /**
    * Default value for simple mappings, when there is no source mapping or the
    * source field is empty. If both this and the sourceField are omitted, the
    * mapping is just a stub for annotating the destination field.
@@ -96,6 +109,7 @@ class MigrateFieldMapping {
    * 'source_field' - Name of the source field in the incoming row containing the
    *  value to be assigned
    * 'default_value' - A constant value to be assigned in the absence of source_field
+   * Deprecated - subfield notation is now preferred.
    *
    * @var array
    */
@@ -173,6 +187,9 @@ class MigrateFieldMapping {
   }
 
   public function arguments($arguments) {
+    if (variable_get('migrate_deprecation_warnings', 1)) {
+      MigrationBase::displayMessage(t('The field mapping arguments() method is now deprecated - please use subfield notation instead.'));
+    }
     $this->arguments = $arguments;
     return $this;
   }

--- a/docroot/sites/all/modules/migration/migrate/includes/group.inc
+++ b/docroot/sites/all/modules/migration/migrate/includes/group.inc
@@ -7,13 +7,34 @@
 
 class MigrateGroup {
   /**
-   * The name of the group - used to identify it in drush commands.
+   * The machine name of the group - used to identify it in drush commands.
    *
    * @var string
    */
   protected $name;
   public function getName() {
     return $this->name;
+  }
+
+  /**
+   * The user-visible title of the group.
+   *
+   * @var string
+   */
+  protected $title;
+  public function getTitle() {
+    return $this->title;
+  }
+
+  /**
+   * Domain-specific arguments for the group (to be applied to all migrations
+   * in the group).
+   *
+   * @var array
+   */
+  protected $arguments = array();
+  public function getArguments() {
+    return $this->arguments;
   }
 
   /**
@@ -35,9 +56,11 @@ class MigrateGroup {
   static public function groups() {
     $groups = array();
     $dependent_groups = array();
+    $dependencies_list = array();
     $required_groups = array();
     foreach (self::$groupList as $name => $group) {
       $dependencies = $group->getDependencies();
+      $dependencies_list[$name] = $dependencies;
       if (count($dependencies) > 0) {
         // Set groups with dependencies aside for reordering
         $dependent_groups[$name] = $group;
@@ -48,29 +71,11 @@ class MigrateGroup {
         $groups[$name] = $group;
       }
     }
-    $iterations = 0;
-    while (count($dependent_groups) > 0) {
-      if ($iterations++ > 20) {
-        $group_names = implode(',', array_keys($dependent_groups));
-        throw new MigrateException(t('Failure to sort migration list - most likely due ' .
-              'to circular dependencies involving groups !group_names',
-        array('!group_names' => $group_names)));
-      }
-      foreach ($dependent_groups as $name => $group) {
-        $ready = TRUE;
-        // Scan all the dependencies for this group and make sure they're all
-        // in the final list
-        foreach ($group->getDependencies() as $dependency) {
-          if (!isset($groups[$dependency])) {
-            $ready = FALSE;
-            break;
-          }
-        }
-        if ($ready) {
-          // Yes they are! Move this group to the final list
-          $groups[$name] = $group;
-          unset($dependent_groups[$name]);
-        }
+
+    $ordered_groups = migrate_order_dependencies($dependencies_list);
+    foreach ($ordered_groups as $name) {
+      if (!isset($groups[$name])) {
+        $groups[$name] = $dependent_groups[$name];
       }
     }
 
@@ -86,8 +91,10 @@ class MigrateGroup {
    * @param array $dependencies
    *  List of dependent groups.
    */
-  public function __construct($name, $dependencies = array()) {
+  public function __construct($name, $dependencies = array(), $title = '', $arguments = array()) {
     $this->name = $name;
+    $this->title = $title;
+    $this->arguments = $arguments;
     $this->dependencies = $dependencies;
   }
 
@@ -102,8 +109,94 @@ class MigrateGroup {
    */
   static public function getInstance($name, $dependencies = array()) {
     if (empty(self::$groupList[$name])) {
-      self::$groupList[$name] = new MigrateGroup($name, $dependencies);
+      $row = db_select('migrate_group', 'mg')
+             ->fields('mg')
+             ->condition('name', $name)
+             ->execute()
+             ->fetchObject();
+      if ($row) {
+        $arguments = unserialize($row->arguments);
+        $arguments = MigrationBase::decryptArguments($arguments);
+        if (empty($dependencies) && isset($arguments['dependencies'])) {
+          $dependencies = $arguments['dependencies'];
+        }
+        self::$groupList[$name] = new MigrateGroup($name, $dependencies,
+          $row->title, $arguments);
+      }
+      else {
+        self::register($name);
+        self::$groupList[$name] = new MigrateGroup($name, $dependencies);
+      }
     }
     return self::$groupList[$name];
+  }
+
+  /**
+   * Register a new migration group in the migrate_group table.
+   *
+   * @param string $name
+   *  The machine name (unique identifier) for the group.
+   *
+   * @param string $title
+   *  A user-visible title for the group. Defaults to the machine name.
+   *
+   * @param array $arguments
+   *  An array of group arguments - generally data that applies to all migrations
+   *  in the group.
+   */
+  static public function register($name, $title = NULL, array $arguments = array()) {
+    if (!$title) {
+      $title = $name;
+    }
+
+    $arguments = MigrationBase::encryptArguments($arguments);
+
+    // Register the migration if it's not already there; if it is,
+    // update the class and arguments in case they've changed.
+    db_merge('migrate_group')
+      ->key(array('name' => $name))
+      ->fields(array(
+                'title' => $title,
+                'arguments' => serialize($arguments)
+        ))
+      ->execute();
+  }
+
+
+  /**
+   * Deregister a migration group - remove it from the database, and also
+   * remove migrations attached to it.
+   *
+   * @param string $name
+   *  (Machine) name of the group to deregister.
+   */
+  static public function deregister($name) {
+    $result = db_select('migrate_status', 'ms')
+              ->fields('ms', array('machine_name'))
+              ->condition('group_name', $name)
+              ->execute();
+    foreach ($result as $row) {
+      Migration::deregisterMigration($row->machine_name);
+    }
+
+    db_delete('migrate_group')
+      ->condition('name', $name)
+      ->execute();
+  }
+
+  /**
+   * Remove any groups which no longer contain any migrations.
+   */
+  static public function deleteOrphans() {
+    $query = db_select('migrate_group', 'mg');
+    $query->addField('mg', 'name');
+    $query->leftJoin('migrate_status', 'ms', 'mg.name=ms.group_name');
+    $query->isNull('ms.machine_name');
+    $result = $query->execute();
+    foreach ($result as $row) {
+      db_delete('migrate_group')
+        ->condition('name', $row->name)
+        ->execute();
+    }
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/includes/map.inc
+++ b/docroot/sites/all/modules/migration/migrate/includes/map.inc
@@ -44,11 +44,26 @@ abstract class MigrateMap implements Iterator {
   protected $sourceKeyMap, $destinationKeyMap;
 
   /**
+   * Get the source key map.
+   */
+  public function getSourceKeyMap() {
+    return $this->sourceKeyMap;
+  }
+
+  /**
    * Boolean determining whether to track last_imported times in map tables
    *
    * @var boolean
    */
   protected $trackLastImported = FALSE;
+  public function getTrackLastImported() {
+    return $this->trackLastImported;
+  }
+  public function setTrackLastImported($trackLastImported) {
+    if (is_bool($trackLastImported)) {
+      $this->trackLastImported = $trackLastImported;
+    }
+  }
 
   /**
    * Save a mapping from the key values in the source row to the destination
@@ -58,9 +73,11 @@ abstract class MigrateMap implements Iterator {
    * @param $dest_ids
    * @param $status
    * @param $rollback_action
+   * @param $hash
    */
   abstract public function saveIDMapping(stdClass $source_row, array $dest_ids,
-    $status = MigrateMap::STATUS_IMPORTED, $rollback_action = MigrateMap::ROLLBACK_DELETE);
+    $status = MigrateMap::STATUS_IMPORTED,
+    $rollback_action = MigrateMap::ROLLBACK_DELETE, $hash = NULL);
 
   /**
    * Record a message related to a source record

--- a/docroot/sites/all/modules/migration/migrate/includes/migration.inc
+++ b/docroot/sites/all/modules/migration/migrate/includes/migration.inc
@@ -22,6 +22,9 @@ abstract class Migration extends MigrationBase {
   public function getSource() {
     return $this->source;
   }
+  public function setSource(MigrateSource $source) {
+    $this->source = $source;
+  }
 
   /**
    * Destination object for the migration, derived from MigrateDestination.
@@ -32,6 +35,9 @@ abstract class Migration extends MigrationBase {
   public function getDestination() {
     return $this->destination;
   }
+  public function setDestination(MigrateDestination $destination) {
+    $this->destination = $destination;
+  }
 
   /**
    * Map object tracking relationships between source and destination data
@@ -41,6 +47,9 @@ abstract class Migration extends MigrationBase {
   protected $map;
   public function getMap() {
     return $this->map;
+  }
+  public function setMap(MigrateMap $map) {
+    $this->map = $map;
   }
 
   /**
@@ -59,6 +68,9 @@ abstract class Migration extends MigrationBase {
   public function getSystemOfRecord() {
     return $this->systemOfRecord;
   }
+  public function setSystemOfRecord($system_of_record) {
+    $this->systemOfRecord = $system_of_record;
+  }
 
   /**
    * Specify value of needs_update for current map row. Usually set by
@@ -75,6 +87,12 @@ abstract class Migration extends MigrationBase {
    * @var int
    */
   protected $defaultRollbackAction = MigrateMap::ROLLBACK_DELETE;
+  public function getDefaultRollbackAction() {
+    return $this->defaultRollbackAction;
+  }
+  public function setDefaultRollbackAction($rollback_action) {
+    $this->defaultRollbackAction = $rollback_action;
+  }
 
   /**
    * The rollback action to be saved for the current row.
@@ -84,13 +102,72 @@ abstract class Migration extends MigrationBase {
   public $rollbackAction;
 
   /**
-   * Simple mappings between destination fields (keys) and source fields (values).
+   * Field mappings defined in code.
    *
    * @var array
    */
-  protected $fieldMappings = array();
+  protected $storedFieldMappings = array();
+  protected $storedFieldMappingsRetrieved = FALSE;
+  public function getStoredFieldMappings() {
+    if (!$this->storedFieldMappingsRetrieved) {
+      $this->loadFieldMappings();
+      $this->storedFieldMappingsRetrieved = TRUE;
+    }
+    return $this->storedFieldMappings;
+  }
+
+  /**
+   * Field mappings retrieved from storage.
+   *
+   * @var array
+   */
+  protected $codedFieldMappings = array();
+  public function getCodedFieldMappings() {
+    return $this->codedFieldMappings;
+  }
+
+  /**
+   * All field mappings, with those retrieved from the database overriding those
+   * defined in code.
+   *
+   * @var array
+   */
+  protected $allFieldMappings = array();
   public function getFieldMappings() {
-    return $this->fieldMappings;
+    if (empty($allFieldMappings)) {
+      $this->allFieldMappings = array_merge($this->getCodedFieldMappings(),
+                                            $this->getStoredFieldMappings());
+      // If there are multiple mappings of a given source field to no
+      // destination field, keep only the last (so the UI can override a source
+      // field DNM that was defined in code).
+      $no_destination = array();
+      // But also remove a mapping of a source field to nothing, if there is
+      // a mapping to something.
+      $mapped_source_fields = array();
+      /** @var MigrateFieldMapping $mapping */
+      foreach ($this->allFieldMappings as $destination_field => $mapping) {
+        $source_field = $mapping->getSourceField();
+        // If the source field is not mapped to a destination field, the
+        // array index is integer.
+        if (is_int($destination_field)) {
+          if (isset($no_destination[$source_field])) {
+            unset($this->allFieldMappings[$no_destination[$source_field]]);
+            unset($no_destination[$source_field]);
+          }
+          $no_destination[$source_field] = $destination_field;
+          if (isset($mapped_source_fields[$source_field])) {
+            unset($this->allFieldMappings[$destination_field]);
+          }
+        }
+        else {
+          $mapped_source_fields[$source_field] = $source_field;
+        }
+      }
+
+      // Make sure primary fields come before their subfields
+      ksort($this->allFieldMappings);
+    }
+    return $this->allFieldMappings;
   }
 
   /**
@@ -119,6 +196,9 @@ abstract class Migration extends MigrationBase {
   public function getHighwaterField() {
     return $this->highwaterField;
   }
+  public function setHighwaterField(array $highwater_field) {
+    $this->highwaterField = $highwater_field;
+  }
 
   /**
    * The object currently being constructed
@@ -143,8 +223,29 @@ abstract class Migration extends MigrationBase {
   /**
    * General initialization of a Migration object.
    */
-  public function __construct($group = NULL) {
-    parent::__construct($group);
+  public function __construct($arguments = array()) {
+    parent::__construct($arguments);
+  }
+
+  /**
+   * Register a new migration process in the migrate_status table. This will
+   * generally be used in two contexts - by the class detection code for
+   * static (one instance per class) migrations, and by the module implementing
+   * dynamic (parameterized class) migrations.
+   *
+   * @param string $class_name
+   * @param string $machine_name
+   * @param array $arguments
+   */
+  static public function registerMigration($class_name, $machine_name = NULL,
+      array $arguments = array()) {
+    // Record any field mappings provided via arguments.
+    if (isset($arguments['field_mappings'])) {
+      self::saveFieldMappings($machine_name, $arguments['field_mappings']);
+      unset($arguments['field_mappings']);
+    }
+
+    parent::registerMigration($class_name, $machine_name, $arguments);
   }
 
   /**
@@ -161,9 +262,16 @@ abstract class Migration extends MigrationBase {
     try {
       // Remove map and message tables
       $migration = self::getInstance($machine_name);
-      $migration->map->destroy();
+      if ($migration && method_exists($migration, 'getMap')) {
+        $migration->getMap()->destroy();
+      }
 
-      // TODO: Clear log entries? Or keep for historical purposes?
+      // @todo: Clear log entries? Or keep for historical purposes?
+
+      // Remove stored field mappings for this migration
+      $rows_deleted = db_delete('migrate_field_mapping')
+                      ->condition('machine_name', $machine_name)
+                      ->execute();
 
       // Call the parent deregistration (which clears migrate_status) last, the
       // above will reference it.
@@ -171,6 +279,51 @@ abstract class Migration extends MigrationBase {
     }
     catch (Exception $e) {
       // Fail silently if it's already gone
+    }
+  }
+
+  /**
+   * Record an array of field mappings to the database.
+   *
+   * @param $machine_name
+   * @param array $field_mappings
+   */
+  static public function saveFieldMappings($machine_name, array $field_mappings) {
+    // Clear existing field mappings
+    db_delete('migrate_field_mapping')
+      ->condition('machine_name', $machine_name)
+      ->execute();
+    foreach ($field_mappings as $field_mapping) {
+      $destination_field = $field_mapping->getDestinationField();
+      $source_field = $field_mapping->getSourceField();
+      db_insert('migrate_field_mapping')
+        ->fields(array(
+            'machine_name' => $machine_name,
+            'destination_field' => is_null($destination_field) ? '' : $destination_field,
+            'source_field' => is_null($source_field) ? '' : $source_field,
+            'options' => serialize($field_mapping)
+          ))
+        ->execute();
+    }
+  }
+
+  /**
+   * Load any stored field mappings from the database.
+   */
+  public function loadFieldMappings() {
+    $result = db_select('migrate_field_mapping', 'mfm')
+              ->fields('mfm', array('destination_field', 'source_field', 'options'))
+              ->condition('machine_name', $this->machineName)
+              ->execute();
+    foreach ($result as $row) {
+      $field_mapping = unserialize($row->options);
+      $field_mapping->setMappingSource(MigrateFieldMapping::MAPPING_SOURCE_DB);
+      if (empty($row->destination_field)) {
+        $this->storedFieldMappings[] = $field_mapping;
+      }
+      else {
+        $this->storedFieldMappings[$row->destination_field] = $field_mapping;
+      }
     }
   }
 
@@ -193,25 +346,25 @@ abstract class Migration extends MigrationBase {
                                   $warn_on_override = TRUE) {
     // Warn of duplicate mappings
     if ($warn_on_override && !is_null($destination_field) &&
-        isset($this->fieldMappings[$destination_field])) {
+        isset($this->codedFieldMappings[$destination_field])) {
       self::displayMessage(
         t('!name addFieldMapping: !dest was previously mapped from !source, overridden',
           array('!name' => $this->machineName, '!dest' => $destination_field,
-                '!source' => $this->fieldMappings[$destination_field]->getSourceField())),
+                '!source' => $this->codedFieldMappings[$destination_field]->getSourceField())),
         'warning');
     }
     $mapping = new MigrateFieldMapping($destination_field, $source_field);
     if (is_null($destination_field)) {
-      $this->fieldMappings[] = $mapping;
+      $this->codedFieldMappings[] = $mapping;
     }
     else {
-      $this->fieldMappings[$destination_field] = $mapping;
+      $this->codedFieldMappings[$destination_field] = $mapping;
     }
     return $mapping;
   }
 
   /**
-   * Remove any existing mappings for a given destination or source field.
+   * Remove any existing coded mappings for a given destination or source field.
    *
    * @param string $destination_field
    *  Name of the destination field.
@@ -220,12 +373,12 @@ abstract class Migration extends MigrationBase {
    */
   public function removeFieldMapping($destination_field, $source_field = NULL) {
     if (isset($destination_field)) {
-      unset($this->fieldMappings[$destination_field]);
+      unset($this->codedFieldMappings[$destination_field]);
     }
     if (isset($source_field)) {
-      foreach ($this->fieldMappings as $key => $mapping) {
+      foreach ($this->codedFieldMappings as $key => $mapping) {
         if ($mapping->getSourceField() == $source_field) {
-          unset($this->fieldMappings[$key]);
+          unset($this->codedFieldMappings[$key]);
         }
       }
     }
@@ -254,12 +407,12 @@ abstract class Migration extends MigrationBase {
    * @param string $issue_group
    *  Issue group name to apply to the generated mappings (defaults to 'DNM').
    */
-  public function addUnmigratedDestinations(array $fields, $issue_group = NULL) {
+  public function addUnmigratedDestinations(array $fields, $issue_group = NULL, $warn_on_override = TRUE) {
     if (!$issue_group) {
       $issue_group = t('DNM');
     }
     foreach ($fields as $field) {
-      $this->addFieldMapping($field)
+      $this->addFieldMapping($field, NULL, $warn_on_override)
            ->issueGroup($issue_group);
     }
   }
@@ -274,12 +427,12 @@ abstract class Migration extends MigrationBase {
    * @param string $issue_group
    *  Issue group name to apply to the generated mappings (defaults to 'DNM').
    */
-  public function addUnmigratedSources(array $fields, $issue_group = NULL) {
+  public function addUnmigratedSources(array $fields, $issue_group = NULL, $warn_on_override = TRUE) {
     if (!$issue_group) {
       $issue_group = t('DNM');
     }
     foreach ($fields as $field) {
-      $this->addFieldMapping(NULL, $field)
+      $this->addFieldMapping(NULL, $field, $warn_on_override)
            ->issueGroup($issue_group);
     }
   }
@@ -289,7 +442,7 @@ abstract class Migration extends MigrationBase {
    * source rows have been processed).
    */
   public function isComplete() {
-    $total = $this->source->count(TRUE);
+    $total = $this->sourceCount(TRUE);
     // If the source is uncountable, we have no way of knowing if it's
     // complete, so stipulate that it is.
     if ($total < 0) {
@@ -551,8 +704,8 @@ abstract class Migration extends MigrationBase {
     }
     catch (Exception $e) {
       self::displayMessage(
-        t('Migration failed with source plugin exception: !e',
-          array('!e' => $e->getMessage())));
+        t('Migration failed with source plugin exception: %e, in %file:%line',
+          array('%e' => $e->getMessage(), '%file' => $e->getFile(), '%line' => $e->getLine())));
       return MigrationBase::RESULT_FAILED;
     }
     while ($this->source->valid()) {
@@ -570,28 +723,33 @@ abstract class Migration extends MigrationBase {
         $ids = $this->destination->import($this->destinationValues, $this->sourceValues);
         migrate_instrument_stop('destination import');
         if ($ids) {
-          $this->map->saveIDMapping($this->sourceValues, $ids, $this->needsUpdate,
-                                    $this->rollbackAction);
+          $this->map->saveIDMapping($this->sourceValues, $ids,
+            $this->needsUpdate, $this->rollbackAction,
+            $data_row->migrate_map_hash);
           $this->successes_since_feedback++;
           $this->total_successes++;
         }
         else {
           $this->map->saveIDMapping($this->sourceValues, array(),
-            MigrateMap::STATUS_FAILED, $this->rollbackAction);
-          $message = t('New object was not saved, no error provided');
-          $this->saveMessage($message);
-          self::displayMessage($message);
+            MigrateMap::STATUS_FAILED, $this->rollbackAction,
+            $data_row->migrate_map_hash);
+          if ($this->map->messageCount() == 0) {
+            $message = t('New object was not saved, no error provided');
+            $this->saveMessage($message);
+            self::displayMessage($message);
+          }
         }
       }
       catch (MigrateException $e) {
         $this->map->saveIDMapping($this->sourceValues, array(),
-          MigrateMap::STATUS_FAILED, $this->rollbackAction);
+          $e->getStatus(), $this->rollbackAction, $data_row->migrate_map_hash);
         $this->saveMessage($e->getMessage(), $e->getLevel());
         self::displayMessage($e->getMessage());
       }
       catch (Exception $e) {
         $this->map->saveIDMapping($this->sourceValues, array(),
-          MigrateMap::STATUS_FAILED, $this->rollbackAction);
+          MigrateMap::STATUS_FAILED, $this->rollbackAction,
+          $data_row->migrate_map_hash);
         $this->handleException($e);
       }
       $this->total_processed++;
@@ -624,8 +782,8 @@ abstract class Migration extends MigrationBase {
       }
       catch (Exception $e) {
         self::displayMessage(
-          t('Migration failed with source plugin exception: !e',
-            array('!e' => $e->getMessage())));
+          t('Migration failed with source plugin exception: %e, in %file:%line',
+            array('%e' => $e->getMessage(), '%file' => $e->getFile(), '%line' => $e->getLine())));
         return MigrationBase::RESULT_FAILED;
       }
     }
@@ -679,7 +837,7 @@ abstract class Migration extends MigrationBase {
       $row = $this->source->current();
       // Cheat for XML migrations, which don't pick up the source values
       // until applyMappings() applies the xpath()
-      if (is_a($this, 'XMLMigration')) {
+      if (is_a($this, 'XMLMigration') && isset($row->xml)) {
         $this->sourceValues = $row;
         $this->applyMappings();
         $row = $this->sourceValues;
@@ -1038,7 +1196,7 @@ abstract class Migration extends MigrationBase {
    */
   protected function applyMappings() {
     $this->destinationValues = new stdClass;
-    foreach ($this->fieldMappings as $mapping) {
+    foreach ($this->getFieldMappings() as $mapping) {
       $destination = $mapping->getDestinationField();
       // Skip mappings with no destination (source fields marked DNM)
       if ($destination) {
@@ -1055,7 +1213,7 @@ abstract class Migration extends MigrationBase {
 
         // If there's a source mapping, and a source value in the data row, copy
         // to the destination
-        if ($source && property_exists($this->sourceValues, $source)) {
+        if ($source && isset($this->sourceValues->{$source})) {
           $destination_values = $this->sourceValues->$source;
         }
         // Otherwise, apply the default value (if any)
@@ -1119,8 +1277,11 @@ abstract class Migration extends MigrationBase {
         // Are we dealing with the primary value of the destination field, or a
         // subfield?
         $destination = explode(':', $destination);
+        // Count how many levels of fields are in the mapping. We'll use the
+        // last one.
+        $destination_count = count($destination);
         $destination_field = $destination[0];
-        if (isset($destination[1])) {
+	      if ($destination_count == 2) {
           $subfield = $destination[1];
           // We're processing the subfield before the primary value, initialize it
           if (!property_exists($this->destinationValues, $destination_field)) {
@@ -1134,6 +1295,24 @@ abstract class Migration extends MigrationBase {
           // Add the subfield value to the arguments array.
           $this->destinationValues->{$destination_field}['arguments'][$subfield] = $destination_values;
         }
+        elseif ($destination_count == 3) {
+	        $subfield2 = $destination[2];
+	        // We're processing the subfield before the primary value, initialize it
+	        if (!property_exists($this->destinationValues, $destination_field)) {
+		        $this->destinationValues->$destination_field = array();
+	        }
+	        // We have a value, and need to convert to an array so we can add
+	        // arguments.
+	        elseif (!is_array($this->destinationValues->$destination_field)) {
+		        $this->destinationValues->$destination_field = array($this->destinationValues->$destination_field);
+	        }
+	        if (!is_array($this->destinationValues->{$destination_field}['arguments'][$destination[1]])) {
+		        // Convert first subfield level to an array so we can add to it.
+		        $this->destinationValues->{$destination_field}['arguments'][$destination[1]] = array( $this->destinationValues->{$destination_field}['arguments'][$destination[1]] );
+	        }
+	        // Add the subfield value to the arguments array.
+	        $this->destinationValues->{$destination_field}['arguments'][$destination[1]]['arguments'][$subfield2] = $destination_values;
+        }
         // Just the primary value, the first time through for this field, simply
         // set it.
         elseif (!property_exists($this->destinationValues, $destination_field)) {
@@ -1141,7 +1320,8 @@ abstract class Migration extends MigrationBase {
         }
         // We've seen a subfield, so add as an array value.
         else {
-          $this->destinationValues->{$destination_field}[] = $destination_values;
+          $this->destinationValues->{$destination_field} = array_merge(
+            (array)$destination_values, $this->destinationValues->{$destination_field});
         }
       }
     }
@@ -1202,15 +1382,17 @@ abstract class Migration extends MigrationBase {
     $results = array();
     // Each $source_key will be an array of key values
     foreach ($source_keys as $source_key) {
-      // If any source keys are empty, skip this set
+      // If any source keys are NULL, skip this set
       $continue = FALSE;
       foreach ($source_key as $value) {
-        if (empty($value) && $value !== 0 && $value !== '0') {
+        if (!isset($value)) {
           $continue = TRUE;
           break;
         }
       }
-      if ($continue || empty($source_key)) {
+      // Occasionally $source_key comes through with an empty string.
+      $sanity_check = array_filter($source_key);
+      if ($continue || empty($source_key) || empty($sanity_check)) {
         continue;
       }
       // Loop through each source migration, checking for an existing dest ID.
@@ -1261,7 +1443,7 @@ abstract class Migration extends MigrationBase {
     }
     else {
       $value = reset($results);
-      return empty($value) ? NULL : $value;
+      return empty($value) && $value !== 0 && $value !== '0' ? NULL : $value;
     }
   }
 
@@ -1372,7 +1554,7 @@ abstract class Migration extends MigrationBase {
   /**
    * Save any messages we've queued up to the message table.
    */
-  protected function saveQueuedMessages() {
+  public function saveQueuedMessages() {
     foreach ($this->queuedMessages as $queued_message) {
       $this->saveMessage($queued_message['message'], $queued_message['level']);
     }
@@ -1391,12 +1573,19 @@ abstract class Migration extends MigrationBase {
 }
 
 /**
- * Convenience class - deriving from this rather than directory from Migration
- * ensures that a class will not be registered as a migration itself - it is
- * the implementor's responsibility to register each instance of a dynamic
- * migration class.
+ * @deprecated - This class is no longer necessary, inherit directly from
+ *  Migration instead.
  */
 abstract class DynamicMigration extends Migration {
+  static $deprecationWarning = FALSE;
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    if (variable_get('migrate_deprecation_warnings', 1) &&
+        !self::$deprecationWarning) {
+      self::displayMessage(t('The DynamicMigration class is no longer necessary and is now deprecated - please derive your migration classes directly from Migration.'));
+      self::$deprecationWarning = TRUE;
+    }
+  }
   /**
    * Overrides default of FALSE
    */

--- a/docroot/sites/all/modules/migration/migrate/includes/source.inc
+++ b/docroot/sites/all/modules/migration/migrate/includes/source.inc
@@ -79,6 +79,20 @@ abstract class MigrateSource implements Iterator {
   protected $highwaterField;
 
   /**
+   * The highwater mark at the beginning of the import operation.
+   *
+   * @var
+   */
+  protected $originalHighwater = '';
+
+  /**
+   * Used in the case of multiple key sources that need to use idlist.
+   *
+   * @var string
+   */
+  protected $multikeySeparator = ':';
+
+  /**
    * List of source IDs to process.
    *
    * @var array
@@ -115,6 +129,14 @@ abstract class MigrateSource implements Iterator {
    * @var boolean
    */
   protected $skipCount = FALSE;
+
+  /**
+   * If TRUE, we will maintain hashed source rows to determine whether incoming
+   * data has changed.
+   *
+   * @var bool
+   */
+  protected $trackChanges = FALSE;
 
   /**
    * By default, next() will directly read the map row and add it to the data
@@ -186,6 +208,9 @@ abstract class MigrateSource implements Iterator {
     if (!empty($options['cache_key'])) {
       $this->cacheKey = $options['cache_key'];
     }
+    if (!empty($options['track_changes'])) {
+      $this->trackChanges = $options['track_changes'];
+    }
   }
 
   /**
@@ -229,6 +254,9 @@ abstract class MigrateSource implements Iterator {
     $this->numProcessed = 0;
     $this->numIgnored = 0;
     $this->highwaterField = $this->activeMigration->getHighwaterField();
+    if (!empty($this->highwaterField)) {
+      $this->originalHighwater = $this->activeMigration->getHighwater();
+    }
     if ($this->activeMigration->getOption('idlist')) {
       $this->idList = explode(',', $this->activeMigration->getOption('idlist'));
     }
@@ -248,9 +276,11 @@ abstract class MigrateSource implements Iterator {
   public function next() {
     $this->currentKey = NULL;
     $this->currentRow = NULL;
+
     migrate_instrument_start(get_class($this) . ' getNextRow');
     while ($row = $this->getNextRow()) {
       migrate_instrument_stop(get_class($this) . ' getNextRow');
+
       // Populate the source key for this row
       $this->currentKey = $this->activeMigration->prepareKey(
         $this->activeMap->getSourceKey(), $row);
@@ -267,23 +297,24 @@ abstract class MigrateSource implements Iterator {
         }
       }
 
-      // First, determine if this row should be passed to prepareRow(), or skipped
-      // entirely. The rules are:
+      // First, determine if this row should be passed to prepareRow(), or
+      // skipped entirely. The rules are:
       // 1. If there's an explicit idlist, that's all we care about (ignore
       //    highwaters and map rows).
       $prepared = FALSE;
       if (!empty($this->idList)) {
-        if (in_array(reset($this->currentKey), $this->idList)) {
-          // In the list, fall through.
-        }
-        else {
-          // Not in the list, skip it
-          $this->currentRow = NULL;
-          continue;
+        // Check first source key.
+        if (!in_array(reset($this->currentKey), $this->idList)) {
+          // If this is a compound source key, check the full key.
+          $compoundKey = implode($this->multikeySeparator, $this->currentKey);
+          if (count($this->currentKey) == 1 || !in_array($compoundKey, $this->idList)) {
+            // Could not find the key, skip.
+            continue;
+          }
         }
       }
-      // 2. If the row is not in the map (we have never tried to import it before),
-      //    we always want to try it.
+      // 2. If the row is not in the map (we have never tried to import it
+      //    before), we always want to try it.
       elseif (!isset($row->migrate_map_sourceid1)) {
         // Fall through
       }
@@ -293,35 +324,51 @@ abstract class MigrateSource implements Iterator {
       }
       // 4. At this point, we have a row which has previously been imported and
       //    not marked for update. If we're not using highwater marks, then we
-      //    will not take this row.
+      //    will not take this row. Except, if we're looking for changes in the
+      //    data, we need to go through prepareRow() before we can decide to
+      //    skip it.
       elseif (empty($this->highwaterField)) {
-        // No highwater, skip
-        $this->currentRow = NULL;
-        continue;
+        if ($this->trackChanges) {
+          if ($this->prepareRow($row) !== FALSE) {
+            if ($this->dataChanged($row)) {
+              // This is a keeper
+              $this->currentRow = $row;
+              break;
+            }
+            else {
+              // No change, skip it.
+              continue;
+            }
+          }
+          else {
+            // prepareRow() told us to skip it.
+            continue;
+          }
+        }
+        else {
+          // No highwater and not tracking changes, skip.
+          continue;
+        }
       }
       // 5. The initial highwater mark, before anything is migrated, is ''. We
       //    want to make sure we don't mistakenly skip rows with a highwater
       //    field value of 0, so explicitly handle '' here.
-      elseif ($this->activeMigration->getHighwater() === '') {
+      elseif ($this->originalHighwater === '') {
         // Fall through
       }
-      // 6. So, we are using highwater marks. Take the row if its highwater field
-      //    value is greater than the saved mark, otherwise skip it.
+      // 6. So, we are using highwater marks. Take the row if its highwater
+      //    field value is greater than the saved mark, otherwise skip it.
       else {
         // Call prepareRow() here, in case the highwaterField needs preparation
         if ($this->prepareRow($row) !== FALSE) {
-          if ($row->{$this->highwaterField['name']} > $this->activeMigration->getHighwater()) {
+          if ($row->{$this->highwaterField['name']} > $this->originalHighwater) {
             $this->currentRow = $row;
             break;
           }
           else {
             // Skip
-            $this->currentRow = NULL;
             continue;
           }
-        }
-        else {
-          $this->currentRow = NULL;
         }
         $prepared = TRUE;
       }
@@ -358,6 +405,10 @@ abstract class MigrateSource implements Iterator {
     migrate_instrument_stop(get_class($this->activeMigration) . ' prepareRow');
     // We're explicitly skipping this row - keep track in the map table
     if ($return === FALSE) {
+      // Make sure we replace any previous messages for this item with any
+      // new ones.
+      $this->activeMigration->getMap()->delete($this->currentKey, TRUE);
+      $this->activeMigration->saveQueuedMessages();
       $this->activeMigration->getMap()->saveIDMapping($row, array(),
         MigrateMap::STATUS_IGNORED, $this->activeMigration->rollbackAction);
       $this->numIgnored++;
@@ -366,8 +417,62 @@ abstract class MigrateSource implements Iterator {
     }
     else {
       $return = TRUE;
+      // When tracking changed data, We want to quietly skip (rather than
+      // "ignore") rows with changes. The caller needs to make that decision,
+      // so we need to provide them with the necessary information (before and
+      // after hashes).
+      if ($this->trackChanges) {
+        $unhashed_row = clone ($row);
+        // Remove all map data, otherwise we'll have a false positive on the
+        // second import (attempt) on a row.
+        foreach ($unhashed_row as $field => $data) {
+          if (strpos($field, 'migrate_map_') === 0) {
+            unset($unhashed_row->$field);
+          }
+        }
+        $row->migrate_map_original_hash = isset($row->migrate_map_hash) ?
+          $row->migrate_map_hash : '';
+        $row->migrate_map_hash = $this->hash($unhashed_row);
+      }
+      else {
+        $row->migrate_map_hash = '';
+      }
     }
+
     $this->numProcessed++;
     return $return;
+  }
+
+  /**
+   * Determine whether this row has changed, and therefore whether it should
+   * be processed.
+   *
+   * @param $row
+   *
+   * @return bool
+   */
+  protected function dataChanged($row) {
+    if ($row->migrate_map_original_hash != $row->migrate_map_hash) {
+      $return = TRUE;
+    }
+    else {
+      $return = FALSE;
+    }
+
+    return $return;
+  }
+
+  /**
+   * Generate a hash of the source row.
+   *
+   * @param $row
+   *
+   * @return string
+   */
+  protected function hash($row) {
+    migrate_instrument_start('MigrateSource::hash');
+    $hash = md5(serialize($row));
+    migrate_instrument_stop('MigrateSource::hash');
+    return $hash;
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/migrate.api.php
+++ b/docroot/sites/all/modules/migration/migrate/migrate.api.php
@@ -6,17 +6,96 @@
  */
 
 /**
- * Registers your module as an implementor of Migrate-based classes.
+ * Registers your module as an implementor of Migrate-based classes and provides
+ * default configuration for migration processes.
+ *
+ * @return
+ *   An associative array with the following keys (of which only 'api' is
+ *   required):
+ *   - api: Always 2 for any module implementing the Migrate 2 API.
+ *   - groups: An associative array, keyed by group machine name, defining one
+ *     or more migration groups. Each value is an associative array - the 'title'
+ *     key defines a user-visible name for the group; any other values are
+ *     passed as arguments to all migrations in the group.
+ *   - migrations: An associative array, keyed by migration machine name,
+ *     defining one or more migrations. Each value is an associative array - any
+ *     keys other than the following are passed as arguments to the migration
+ *     constructor:
+ *     - class_name (required): The name of the class implementing the migration.
+ *     - group_name: The machine name of the group containing the migration.
+ *     - disable_hooks: An associative array, keyed by hook name, listing hook
+ *       implementations to be disabled during migration. Each value is an
+ *       array of module names whose implementations of the hook in the key is
+ *       to be disabled.
+ *   - destination handlers: An array of classes implementing destination
+ *     handlers.
+ *   - field handlers: An array of classes implementing field handlers.
+ *   - wizard classes: An array of classes that provide Migrate UI wizards.
+ *   - wizard extenders: An array of classes that extend Migrate UI wizards.
+ *     Keys are the wizard classes, values are arrays of extender classes.
+ *
+ * See system_hook_info() for all hook groups defined by Drupal core.
+ *
+ * @see hook_migrate_api_alter().
  */
 function hook_migrate_api() {
   $api = array(
     'api' => 2,
+    'groups' => array(
+      'legacy' => array(
+        'title' => t('Import from legacy system'),
+        // Default format for all content migrations
+        'default_format' => 'filtered_html',
+      ),
+    ),
+    'migrations' => array(
+      'ExampleUser' => array(
+        'class_name' => 'ExampleUserMigration',
+        'group_name' => 'legacy',
+        'default_role' => 'member', // Added to constructor $arguments
+      ),
+      'ExampleNode' => array(
+        'class_name' => 'ExampleNodeMigration',
+        'group_name' => 'legacy',
+        'default_uid' => 1, // Added to constructor $arguments
+        'disable_hooks' => array(
+          // Improve migration performance, and prevent accidental emails.
+          'node_insert' => array(
+            'expensive_module',
+            'email_notification_module',
+          ),
+          'node_update' => array(
+            'expensive_module',
+            'email_notification_module',
+          ),
+        ),
+      ),
+    ),
   );
   return $api;
 }
 
 /**
+ * Alter information from all implementations of hook_migrate_api().
+ *
+ * @param array $info
+ *   An array of results from hook_migrate_api(), keyed by module name.
+ *
+ * @see hook_migrate_api().
+ */
+function hook_migrate_api_alter(array &$info) {
+  // Override the class for another module's migration - say, to add some
+  // additional preprocessing in prepareRow().
+  if (isset($info['MODULE_NAME']['migrations']['ExampleNode'])) {
+    $info['MODULE_NAME']['migrations']['ExampleNode']['class_name'] = 'MyBetterExampleNodeMigration';
+  }
+}
+
+/**
  * Provides text to be displayed at the top of the dashboard page (migrate_ui).
+ *
+ * @return
+ *  Translated text for display on the dashboard page.
  */
 function hook_migrate_overview() {
   return t('<p>Listed below are all the migration processes defined for migration

--- a/docroot/sites/all/modules/migration/migrate/migrate.drush.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate.drush.inc
@@ -17,12 +17,15 @@ function migrate_drush_command() {
     'instrument' => 'Capture performance information (timer, memory, or all)',
     'force' => 'Force an operation to run, even if all dependencies are not satisfied',
     'group' => 'Name of the migration group to run',
+    'notify' => 'Send email notification upon completion of operation',
+    'wildcard' => 'Process migrations that match a certain pattern. For example, Content*.',
   );
   $items['migrate-status'] = array(
     'description' => 'List all migrations with current status.',
     'options' => array(
       'refresh' => 'Recognize new migrations and update counts',
       'group' => 'Name of the migration group to list',
+      'names-only' => 'Only return names, not all the details (faster)',
     ),
     'arguments' => array(
       'migration' => 'Restrict to a single migration. Optional',
@@ -129,8 +132,6 @@ function migrate_drush_command() {
   $items['migrate-rollback'] = array(
     'description' => 'Roll back the destination objects from a given migration',
     'options' => $migration_options,
-    // We will bootstrap to login from within the command callback.
-    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
     'arguments' => array(
       'migration' => 'Name of migration(s) to roll back. Delimit multiple using commas.',
     ),
@@ -144,12 +145,13 @@ function migrate_drush_command() {
     'drupal dependencies' => array('migrate'),
     'aliases' => array('mr'),
   );
-  $migration_options['update'] = 'In addition to processing unimported items from the source, update previously-imported items with new data';
+  $migration_options['update'] = 'In addition to processing unprocessed items from the source, update previously-imported items with new data';
   $migration_options['needs-update'] =
     'Reimport up to 10K records where needs_update=1. This option is only needed when your Drupal DB is on a different DB server from your source data. Otherwise, these records get migrated with just migrate-import.';
   $migration_options['stop'] = 'Stop specified migration(s) if applicable.';
   $migration_options['rollback'] = 'Rollback specified migration(s) if applicable.';
   $migration_options['file_function'] = 'Override file function to use when migrating images.';
+  $migration_options['ignore-highwater'] = 'Ignore the highwater field during migration';
   $items['migrate-import'] = array(
     'description' => 'Perform one or more migration processes',
     'options' => $migration_options,
@@ -160,6 +162,7 @@ function migrate_drush_command() {
       'migrate-import Article' => 'Import new articles',
       'migrate-import Article --update' => 'Import new items, and also update previously-imported items',
       'migrate-import Article --idlist=4,9' => 'Import two specific articles. The ids refer to the value of the primary key in base table',
+      'migrate-import Article --idlist=450:pasta,451' => 'Import two specific articles. A colon can be used to separate parts of compound keys; otherwise, compound keys match by the first key field.',
       'migrate-import Article --limit="60 seconds" --stop --rollback' =>
         'Import for up to 60 seconds after stopping and rolling back the Article migration.',
       'migrate-import Article --limit="100 items"' =>
@@ -172,7 +175,8 @@ function migrate_drush_command() {
   );
   $items['migrate-stop'] = array(
     'description' => 'Stop an active migration operation',
-    'options' => array('all' => 'Stop all active migration operations'),
+    'options' => array('all' => 'Stop all active migration operations',
+      'group' => 'Name of a specific migration group to stop'),
     'arguments' => array(
       'migration' => 'Name of migration to stop',
     ),
@@ -198,20 +202,29 @@ function migrate_drush_command() {
   );
   $items['migrate-deregister'] = array(
     'description' => 'Remove all tracking of a migration',
-    'options' => array('orphans' => 'Remove tracking for any migrations whose implementing class no longer exists'),
+    'options' => array(
+      'orphans' => 'Remove tracking for any migrations whose implementing class no longer exists',
+      'group' => 'Remove tracking of a migration group, and any migrations assigned to it',
+    ),
     'arguments' => array(
       'migration' => 'Name of migration to deregister',
     ),
     'examples' => array(
       'migrate-deregister Article' => 'Deregister the Article migration',
       'migrate-deregister --orphans' => 'Deregister any no-longer-implemented migrations',
+      'migrate-deregister --group=myblog' => 'Deregister the myblog group and all migrations within it',
     ),
     'drupal dependencies' => array('migrate'),
   );
   $items['migrate-auto-register'] = array(
-    'description' => 'Register any newly-defined migration classes',
+    'description' => 'Register any newly defined migration classes',
     'drupal dependencies' => array('migrate'),
     'aliases' => array('mar'),
+  );
+  $items['migrate-register'] = array(
+    'description' => 'Register or reregister any statically defined migrations',
+    'drupal dependencies' => array('migrate'),
+    'aliases' => array('mreg'),
   );
   $items['migrate-wipe'] = array(
     'description' => 'Delete all nodes from specified content types.',
@@ -236,9 +249,11 @@ function migrate_drush_command() {
  */
 function drush_migrate_get_options() {
   $options = array();
-  $blacklist = array('stop', 'rollback', 'update', 'all');
+  $blacklist = array('stop', 'rollback', 'update', 'all', 'group');
   $command = drush_parse_command();
-  foreach ($command['options'] as $key => $value) {
+  $global_options = drush_get_global_options();
+  $opts = array_merge($command['options'], $global_options);
+  foreach ($opts as $key => $value) {
     // Strip leading --
     $key = ltrim($key, '-');
     if (!in_array($key, $blacklist)) {
@@ -281,6 +296,7 @@ function drush_migrate_status($name = NULL) {
   try {
     $refresh = drush_get_option('refresh');
     $group_option = drupal_strtolower(drush_get_option('group'));
+    $names_only = drush_get_option('names-only');
 
     // Validate input and load Migration(s).
     if ($name) {
@@ -311,56 +327,69 @@ function drush_migrate_status($name = NULL) {
         if ($group_members_count == 1) {
           // An empty line and the headers.
           $table[] = array('');
-          $table[] = array(dt('Group: !name', array('!name' => $group->getName())), dt('Total'), dt('Imported'), dt('Unimported'), dt('Status'), dt('Last imported'));
+          if ($names_only) {
+            $table[] = array(dt('Group: !name',
+              array('!name' => $group->getName())));
+          }
+          else {
+            $table[] = array(dt('Group: !name',
+              array('!name' => $group->getName())), dt('Total'), dt('Imported'),
+                    dt('Unprocessed'), dt('Status'), dt('Last imported'));
+          }
         }
-        $has_counts = TRUE;
-        if (method_exists($migration, 'sourceCount')) {
-          $total = $migration->sourceCount($refresh);
-          if ($total < 0) {
+        if (!$names_only) {
+          $has_counts = TRUE;
+          if (method_exists($migration, 'sourceCount')) {
+            $total = $migration->sourceCount($refresh);
+            if ($total < 0) {
+              $has_counts = FALSE;
+              $total = dt('N/A');
+            }
+          }
+          else {
             $has_counts = FALSE;
             $total = dt('N/A');
           }
+          if (method_exists($migration, 'importedCount')) {
+            $imported = $migration->importedCount();
+            $processed = $migration->processedCount();
+          }
+          else {
+            $has_counts = FALSE;
+            $imported = dt('N/A');
+          }
+          if ($has_counts) {
+            $unimported = $total - $processed;
+          }
+          else {
+            $unimported = dt('N/A');
+          }
+          $status = $migration->getStatus();
+          switch ($status) {
+            case MigrationBase::STATUS_IDLE:
+              $status = dt('Idle');
+              break;
+            case MigrationBase::STATUS_IMPORTING:
+              $status = dt('Importing');
+              break;
+            case MigrationBase::STATUS_ROLLING_BACK:
+              $status = dt('Rolling back');
+              break;
+            case MigrationBase::STATUS_STOPPING:
+              $status = dt('Stopping');
+              break;
+            case MigrationBase::STATUS_DISABLED:
+              $status = dt('Disabled');
+              break;
+            default:
+              $status = dt('Unknown');
+              break;
+          }
+          $table[] = array($migration->getMachineName(), $total, $imported, $unimported, $status, $migration->getLastImported());
         }
         else {
-          $has_counts = FALSE;
-          $total = dt('N/A');
+          $table[] = array($migration->getMachineName());
         }
-        if (method_exists($migration, 'importedCount')) {
-          $imported = $migration->importedCount();
-          $processed = $migration->processedCount();
-        }
-        else {
-          $has_counts = FALSE;
-          $imported = dt('N/A');
-        }
-        if ($has_counts) {
-          $unimported = $total - $processed;
-        }
-        else {
-          $unimported = dt('N/A');
-        }
-        $status = $migration->getStatus();
-        switch ($status) {
-          case MigrationBase::STATUS_IDLE:
-            $status = dt('Idle');
-            break;
-          case MigrationBase::STATUS_IMPORTING:
-            $status = dt('Importing');
-            break;
-          case MigrationBase::STATUS_ROLLING_BACK:
-            $status = dt('Rolling back');
-            break;
-          case MigrationBase::STATUS_STOPPING:
-            $status = dt('Stopping');
-            break;
-          case MigrationBase::STATUS_DISABLED:
-            $status = dt('Disabled');
-            break;
-          default:
-            $status = dt('Unknown');
-            break;
-        }
-        $table[] = array($migration->getMachineName(), $total, $imported, $unimported, $status, $migration->getLastImported());
       }
     }
     drush_print_table($table);
@@ -382,7 +411,7 @@ function drush_migrate_fields_destination($args = NULL) {
       if (method_exists($destination, 'fields')) {
         $table = array();
         foreach ($destination->fields($migration) as $machine_name => $description) {
-          $table[] = array($description, $machine_name);
+          $table[] = array(strip_tags($description), $machine_name);
         }
         drush_print_table($table);
       }
@@ -407,7 +436,7 @@ function drush_migrate_fields_source($args = NULL) {
       if (method_exists($source, 'fields')) {
         $table = array();
         foreach ($source->fields() as $machine_name => $description) {
-          $table[] = array($description, $machine_name);
+          $table[] = array(strip_tags($description), $machine_name);
         }
         drush_print_table($table);
       }
@@ -438,14 +467,20 @@ function drush_migrate_mappings($args = NULL) {
         $dest_descriptions = array();
         if (method_exists($destination, 'fields')) {
           foreach ($destination->fields($migration) as $machine_name => $description) {
-            $dest_descriptions[$machine_name] = $description;
+            if (is_array($description)) {
+              $description = reset($description);
+            }
+            $dest_descriptions[$machine_name] = strip_tags($description);
           }
         }
         $source = $migration->getSource();
         $src_descriptions = array();
         if (method_exists($source, 'fields')) {
           foreach ($source->fields() as $machine_name => $description) {
-            $src_descriptions[$machine_name] = $description;
+            if (is_array($description)) {
+              $description = reset($description);
+            }
+            $src_descriptions[$machine_name] = strip_tags($description);
           }
         }
       }
@@ -545,6 +580,10 @@ function drush_migrate_mappings($args = NULL) {
  * Display messages for a migration.
  */
 function drush_migrate_messages($migration_name) {
+  if (!trim($migration_name)) {
+    drush_log(dt('You must specify a migration name'), 'status');
+    return;
+  }
   try {
     $migration = MigrationBase::getInstance($migration_name);
     if (is_a($migration, 'Migration')) {
@@ -783,6 +822,12 @@ function drush_migrate_audit($args = NULL) {
  */
 function drush_migrate_rollback($args = NULL) {
   try {
+    if (drush_get_option('notify', FALSE)) {
+      // Capture non-informational output for mailing
+      ob_start();
+      ob_implicit_flush(FALSE);
+    }
+
     $migrations = drush_migrate_get_migrations($args);
 
     // Rollback in reverse order
@@ -873,6 +918,31 @@ function drush_migrate_rollback($args = NULL) {
   if ($_migrate_track_timer && !drush_get_context('DRUSH_DEBUG')) {
     drush_print_timers();
   }
+
+  // Notify user
+  if (drush_get_option('notify')) {
+    _drush_migrate_notify();
+  }
+}
+
+/**
+ * Send email notification to the user running the operation.
+ */
+function _drush_migrate_notify() {
+  global $user;
+  if ($user->uid) {
+    $uid = $user->uid;
+  }
+  else {
+    $uid = 1;
+  }
+  $account = user_load($uid);
+  $params['account'] = $account;
+  $params['output'] = ob_get_contents();
+  drush_print_r(ob_get_status());
+  ob_end_flush();
+  drupal_mail('migrate_ui', 'import_complete', $account->mail,
+    user_preferred_language($account), $params);
 }
 
 function drush_migrate_get_migrations($args) {
@@ -883,7 +953,7 @@ function drush_migrate_get_migrations($args) {
     $seen = $start === TRUE ? TRUE : FALSE;
 
     foreach ($migration_objects as $name => $migration) {
-      if (!$seen && (drupal_strtolower($start) . 'migration' == drupal_strtolower($name))) {
+      if (!$seen && (drupal_strtolower($start) == drupal_strtolower($name))) {
         // We found our starting migration. $seen is always TRUE now.
         $seen = TRUE;
       }
@@ -898,6 +968,14 @@ function drush_migrate_get_migrations($args) {
       if (drupal_strtolower($group) !=
           drupal_strtolower($migration->getGroup()->getName()) ||
             !$migration->getEnabled()) {
+        unset($migration_objects[$name]);
+      }
+    }
+  }
+  elseif ($wildcard = drush_get_option('wildcard')) {
+    foreach ($migration_objects as $name => $migration) {
+      if (!fnmatch(drupal_strtolower($wildcard), drupal_strtolower($name)) ||
+        !$migration->getEnabled()) {
         unset($migration_objects[$name]);
       }
     }
@@ -974,18 +1052,23 @@ function drush_migrate_rollback_validate($args = NULL) {
 
 function drush_migrate_validate_common($args) {
   if (drush_get_option('all')) {
-    if (!empty($args) || drush_get_option('group')) {
-      return drush_set_error(NULL, dt('You must specify exactly one of a migration name, --all, or --group'));
+    if (!empty($args) || drush_get_option('group') || drush_get_option('wildcard')) {
+      return drush_set_error(NULL, dt('You must specify exactly one of a migration name, --all, or --group, or --wildcard'));
     }
   }
   elseif (drush_get_option('group')) {
-    if (!empty($args) || drush_get_option('all')) {
-      return drush_set_error(NULL, dt('You must specify exactly one of a migration name, --all, or --group'));
+    if (!empty($args) || drush_get_option('all') || drush_get_option('wildcard')) {
+      return drush_set_error(NULL, dt('You must specify exactly one of a migration name, --all, or --group, or --wildcard'));
+    }
+  }
+  elseif (drush_get_option('wildcard')) {
+    if (!empty($args) || drush_get_option('all') || drush_get_option('group')) {
+      return drush_set_error(NULL, dt('You must specify exactly one of a migration name, --all, or --group, or --wildcard'));
     }
   }
   else {
     if (empty($args)) {
-      return drush_set_error(NULL, dt('You must specify exactly one of a migration name, --all, or --group'));
+      return drush_set_error(NULL, dt('You must specify exactly one of a migration name, --all, or --group, or --wildcard'));
     }
     $machine_names = explode(',', $args);
 
@@ -1024,7 +1107,29 @@ function drush_migrate_validate_common($args) {
  */
 function drush_migrate_pre_migrate_import($args = NULL) {
   if (drush_get_option('stop')) {
-    drush_invoke('migrate-stop', $args);
+    drush_unset_option('stop');
+    try {
+      /** @var Migration[] $migrations */
+      $migrations = drush_migrate_get_migrations($args);
+      foreach ($migrations as $migration) {
+        $status = $migration->getStatus();
+        if ($status == MigrationBase::STATUS_IMPORTING ||
+            $status == MigrationBase::STATUS_ROLLING_BACK) {
+          drush_log(dt("Stopping '!description' migration", array('!description' => $migration->getMachineName())));
+          $migration->stopProcess();
+          // Give the process a chance to stop.
+          $count = 0;
+          while ($migration->getStatus() != MigrationBase::STATUS_IDLE
+                 && $count++ < 5) {
+            sleep(1);
+          }
+        }
+      }
+    }
+    catch (MigrateException $e) {
+      drush_print($e->getMessage());
+      exit;
+    }
   }
   if (drush_get_option('rollback')) {
     drush_unset_option('rollback');
@@ -1040,6 +1145,11 @@ function drush_migrate_pre_migrate_import($args = NULL) {
  */
 function drush_migrate_import($args = NULL) {
   try {
+    if (drush_get_option('notify', FALSE)) {
+      // Capture non-informational output for mailing
+      ob_start();
+      ob_implicit_flush(FALSE);
+    }
     $migrations = drush_migrate_get_migrations($args);
     $options = array();
     if ($idlist = drush_get_option('idlist', FALSE)) {
@@ -1101,8 +1211,12 @@ function drush_migrate_import($args = NULL) {
     foreach ($migrations as $machine_name => $migration) {
       drush_log(dt("Importing '!description' migration",
         array('!description' => $machine_name)));
-      if (drush_get_option('update')) {
+      if (drush_get_option('update') && !$idlist) {
         $migration->prepareUpdate();
+
+        if (drush_get_option('ignore-highwater')) {
+          $migration->setHighwaterField(array());
+        }
       }
       if (drush_get_option('needs-update')) {
         $map_rows = $migration->getMap()->getRowsNeedingUpdate(10000);
@@ -1190,14 +1304,19 @@ function drush_migrate_import($args = NULL) {
   if ($_migrate_track_timer && !drush_get_context('DRUSH_DEBUG')) {
     drush_print_timers();
   }
+
+  // Notify user
+  if (drush_get_option('notify')) {
+    _drush_migrate_notify();
+  }
 }
 
-//**
-// * Stop clearing or importing a given content set.
-// *
-// * @param $content_set
-// *  The name of the Migration
-// */
+/**
+ * Stop clearing or importing a given content set.
+ *
+ * @param $content_set
+ *  The name of the Migration
+ */
 function drush_migrate_stop($args = NULL) {
   try {
     $migrations = drush_migrate_get_migrations($args);
@@ -1231,31 +1350,40 @@ function drush_migrate_reset_status($args = NULL) {
 }
 
 /**
- * Deregister a given migration, or all orphaned migrations. Note that the
- * migration might no longer "exist" (the class implementation might be gone),
- * so we can't count on being able to instantiate it, or use migrate_migrations().
+ * Deregister a given migration, migration group, or all orphaned migrations.
+ * Note that the migration might no longer "exist" (the class implementation
+ * might be gone), so we can't count on being able to instantiate it, or use
+ * migrate_migrations().
  */
 function drush_migrate_deregister($args = NULL) {
   try {
     $orphans = drush_get_option('orphans');
-    if ($orphans) {
-      $migrations = array();
-      $result = db_select('migrate_status', 'ms')
-                    ->fields('ms', array('class_name', 'machine_name'))
-                    ->execute();
-      foreach ($result as $row) {
-        if (!class_exists($row->class_name)) {
-          $migrations[] = $row->machine_name;
-        }
-      }
+    $group = drush_get_option('group');
+    if ($group) {
+      MigrateGroup::deregister($group);
+      drush_log(dt("Deregistered group '!description' and all its migrations",
+        array('!description' => $group)), 'success');
     }
     else {
-      $migrations = explode(',', $args);
-    }
-    foreach ($migrations as $machine_name) {
-      drush_migrate_deregister_migration($machine_name);
-      drush_log(dt("Deregistered '!description' migration",
-        array('!description' => $machine_name)), 'success');
+      if ($orphans) {
+        $migrations = array();
+        $result = db_select('migrate_status', 'ms')
+                      ->fields('ms', array('class_name', 'machine_name'))
+                      ->execute();
+        foreach ($result as $row) {
+          if (!class_exists($row->class_name)) {
+            $migrations[] = $row->machine_name;
+          }
+        }
+      }
+      else {
+        $migrations = explode(',', $args);
+      }
+      foreach ($migrations as $machine_name) {
+        drush_migrate_deregister_migration(drupal_strtolower($machine_name));
+        drush_log(dt("Deregistered '!description' migration",
+          array('!description' => $machine_name)), 'success');
+      }
     }
   }
   catch (MigrateException $e) {
@@ -1277,13 +1405,28 @@ function drush_migrate_deregister_migration($machine_name) {
   db_delete('migrate_status')
     ->condition('machine_name', $machine_name)
     ->execute();
+  db_delete('migrate_field_mapping')
+    ->condition('machine_name', $machine_name)
+    ->execute();
 }
 
 /**
- * Register any previously-unrecognized non-dynamic migrations.
+ * Auto-registration is no longer supported. This command should be removed
+ * entirely in a future point release.
+ *
+ * @deprecated
  */
 function drush_migrate_auto_register($args = NULL) {
-  migrate_autoregister();
+  drush_log(dt('The auto-registration feature has been removed. Migrations '
+    . 'must now be explicitly registered.'), 'error');
+}
+
+/**
+ * Register any migrations defined in hook_migrate_api().
+ */
+function drush_migrate_register($args = NULL) {
+  migrate_static_registration();
+  drush_log(dt('All statically defined migrations have been (re)registered.'), 'success');
 }
 
 /**

--- a/docroot/sites/all/modules/migration/migrate/migrate.info
+++ b/docroot/sites/all/modules/migration/migrate/migrate.info
@@ -1,6 +1,6 @@
 name = "Migrate"
 description = "Import content from external sources"
-package = "Development"
+package = "Migration"
 core = 7.x
 
 files[] = includes/base.inc
@@ -14,6 +14,7 @@ files[] = includes/map.inc
 files[] = includes/source.inc
 files[] = includes/team.inc
 files[] = migrate.mail.inc
+files[] = plugins/destinations/block_custom.inc
 files[] = plugins/destinations/entity.inc
 files[] = plugins/destinations/term.inc
 files[] = plugins/destinations/user.inc
@@ -28,15 +29,19 @@ files[] = plugins/destinations/table_copy.inc
 files[] = plugins/destinations/menu.inc
 files[] = plugins/destinations/menu_links.inc
 files[] = plugins/destinations/statistics.inc
+files[] = plugins/destinations/variable.inc
 files[] = plugins/sources/csv.inc
+files[] = plugins/sources/db2.inc
 files[] = plugins/sources/files.inc
 files[] = plugins/sources/json.inc
 files[] = plugins/sources/list.inc
+files[] = plugins/sources/mongodb.inc
 files[] = plugins/sources/multiitems.inc
 files[] = plugins/sources/sql.inc
 files[] = plugins/sources/sqlmap.inc
 files[] = plugins/sources/mssql.inc
 files[] = plugins/sources/oracle.inc
+files[] = plugins/sources/spreadsheet.inc
 files[] = plugins/sources/xml.inc
 files[] = tests/import/options.test
 files[] = tests/plugins/destinations/comment.test
@@ -46,9 +51,9 @@ files[] = tests/plugins/destinations/term.test
 files[] = tests/plugins/destinations/user.test
 files[] = tests/plugins/sources/xml.test
 
-; Information added by drupal.org packaging script on 2012-11-07
-version = "7.x-2.5"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-2.8"
 core = "7.x"
 project = "migrate"
-datestamp = "1352299007"
+datestamp = "1435760949"
 

--- a/docroot/sites/all/modules/migration/migrate/migrate.install
+++ b/docroot/sites/all/modules/migration/migrate/migrate.install
@@ -9,6 +9,8 @@ function migrate_schema() {
   $schema = array();
   $schema['migrate_status'] = migrate_schema_status();
   $schema['migrate_log'] = migrate_schema_log();
+  $schema['migrate_group'] = migrate_schema_group();
+  $schema['migrate_field_mapping'] = migrate_schema_field_mapping();
   return $schema;
 }
 
@@ -27,6 +29,12 @@ function migrate_schema_status() {
         'length' => 255,
         'not null' => TRUE,
         'description' => 'Name of class to instantiate for this migration',
+      ),
+      'group_name' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'description' => 'Name of group containing migration',
       ),
       'status' => array(
         'type' => 'int',
@@ -115,6 +123,74 @@ function migrate_schema_log() {
   );
 }
 
+function migrate_schema_group() {
+  return array(
+    'description' => 'Information on migration groups',
+    'fields' => array(
+      'name' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'description' => 'Unique machine name for a migration group',
+      ),
+      'title' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'description' => 'Display name for a migration group',
+      ),
+      'arguments' => array(
+        'type' => 'blob',
+        'not null' => FALSE,
+        'size' => 'big',
+        'serialize' => TRUE,
+        'description' => 'A serialized array of arguments to the migration group',
+      ),
+    ),
+    'primary key' => array('name'),
+  );
+}
+
+function migrate_schema_field_mapping() {
+  return array(
+    'description' => 'History of migration processes',
+    'fields' => array(
+      'fmid' => array(
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'Unique ID for the field mapping row',
+      ),
+      'machine_name' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'description' => 'Parent migration for the field mapping',
+      ),
+      'destination_field' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'description' => 'Destination field for the field mapping',
+      ),
+      'source_field' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'description' => 'Source field for the field mapping',
+      ),
+      'options' => array(
+        'type' => 'blob',
+        'not null' => FALSE,
+        'size' => 'big',
+        'serialize' => TRUE,
+        'description' => 'A serialized MigrateFieldMapping object holding all options',
+      ),
+    ),
+    'primary key' => array('fmid'),
+  );
+}
+
 /**
  * Implements hook_uninstall().
  * Drop map/message tables, in case implementing classes did not.
@@ -137,13 +213,17 @@ function migrate_uninstall() {
       ->condition('module', 'migrate')
       ->execute();
   }
+
+  // Remove variables
+  variable_del('migrate_disable_autoregistration');
+  variable_del('migrate_disabled_handlers');
+  variable_del('migrate_deprecation_warnings');
 }
 
 /**
  * Add highwater mark
  */
 function migrate_update_7001() {
-  $ret = array();
   if (!db_field_exists('migrate_status', 'highwater')) {
     db_add_field('migrate_status', 'highwater', array(
           'type' => 'varchar',
@@ -155,7 +235,7 @@ function migrate_update_7001() {
     );
   }
 
-  $ret[] = t('Added highwater column to migrate_status table');
+  $ret = t('Added highwater column to migrate_status table');
   return $ret;
 }
 
@@ -163,7 +243,6 @@ function migrate_update_7001() {
  * Add last_imported field to all map tables
  */
 function migrate_update_7002() {
-  $ret = array();
   foreach (db_find_tables('migrate_map_%') as $tablename) {
     if (!db_field_exists($tablename, 'last_imported')) {
       db_add_field($tablename, 'last_imported', array(
@@ -175,7 +254,7 @@ function migrate_update_7002() {
       ));
     }
   }
-  $ret[] = t('Added last_imported column to all map tables');
+  $ret = t('Added last_imported column to all map tables');
   return $ret;
 }
 
@@ -183,7 +262,7 @@ function migrate_update_7002() {
  * Add lastthroughput column to migrate_status
  */
 function migrate_update_7003() {
-  $ret = array();
+  $ret = '';
   if (!db_field_exists('migrate_status', 'lastthroughput')) {
     db_add_field('migrate_status', 'lastthroughput', array(
         'type' => 'int',
@@ -194,7 +273,7 @@ function migrate_update_7003() {
     );
   }
 
-  $ret[] = t('Added lastthroughput column to migrate_status table');
+  $ret = t('Added lastthroughput column to migrate_status table');
   return $ret;
 }
 
@@ -202,7 +281,7 @@ function migrate_update_7003() {
  * Convert lastimported datetime field to lastimportedtime int field.
  */
 function migrate_update_7004() {
-  $ret = array();
+  $ret = '';
   if (!db_field_exists('migrate_status', 'lastimportedtime')) {
     db_add_field('migrate_status', 'lastimportedtime', array(
         'type' => 'int',
@@ -212,7 +291,7 @@ function migrate_update_7004() {
       )
     );
 
-    if (!db_field_exists('migrate_status', 'lastimported')) {
+    if (db_field_exists('migrate_status', 'lastimported')) {
       $result = db_select('migrate_status', 'ms')
                 ->fields('ms', array('machine_name', 'lastimported'))
                 ->execute();
@@ -226,7 +305,7 @@ function migrate_update_7004() {
 
       db_drop_field('migrate_status', 'lastimported');
 
-      $ret[] = t('Converted lastimported datetime field to lastimportedtime int field');
+      $ret .= "\n" . t('Converted lastimported datetime field to lastimportedtime int field');
     }
   }
   return $ret;
@@ -236,11 +315,11 @@ function migrate_update_7004() {
  * Add support for history logging
  */
 function migrate_update_7005() {
-  $ret = array();
+  $ret = '';
   if (!db_table_exists('migrate_log')) {
-    $ret[] = t('Create migrate_log table');
+    $ret .= "\n" . t('Create migrate_log table');
     db_create_table('migrate_log', migrate_schema_log());
-    $ret[] = t('Remove historic columns from migrate_status table');
+    $ret .= "\n" . t('Remove historic columns from migrate_status table');
     db_drop_field('migrate_status', 'lastthroughput');
     db_drop_field('migrate_status', 'lastimportedtime');
   }
@@ -252,7 +331,7 @@ function migrate_update_7005() {
  * dependencies or sourceMigration() must be changed! See CHANGELOG.txt.
  */
 function migrate_update_7006() {
-  $ret = array();
+  $ret = '';
   if (!db_field_exists('migrate_status', 'class_name')) {
     db_add_field('migrate_status', 'class_name', array(
           'type' => 'varchar',
@@ -266,7 +345,7 @@ function migrate_update_7006() {
     db_query("UPDATE {migrate_status}
               SET class_name = CONCAT(machine_name, 'Migration')
              ");
-    $ret[] = t('Added class_name column to migrate_status table');
+    $ret = t('Added class_name column to migrate_status table');
   }
   return $ret;
 }
@@ -275,7 +354,7 @@ function migrate_update_7006() {
  * Add arguments field to migrate_status table.
  */
 function migrate_update_7007() {
-  $ret = array();
+  $ret = '';
   if (!db_field_exists('migrate_status', 'arguments')) {
     db_add_field('migrate_status', 'arguments', array(
           'type' => 'blob',
@@ -286,7 +365,7 @@ function migrate_update_7007() {
           )
 
     );
-    $ret[] = t('Added arguments column to migrate_status table');
+    $ret = t('Added arguments column to migrate_status table');
   }
   return $ret;
 }
@@ -298,10 +377,9 @@ function migrate_update_7008() {
   // Updates can be run when the module is disabled, which would mean the
   // call to migrate_migrations() will fail. Just bail in that case...
   if (!module_exists('migrate')) {
-    throw new DrupalUpdateException(t('This update cannot be run while the Migrate ' .
-      'module is disabled - you must enable Migrate to run this update.'));
+    throw new DrupalUpdateException(t('This update cannot be run while the Migrate module is disabled - you must enable Migrate to run this update.'));
   }
-  $ret = array();
+  $ret = '';
   foreach (migrate_migrations() as $migration) {
     if (is_a($migration, 'Migration')) {
       // Since we're now tracking failed/ignored rows in the map table,
@@ -317,7 +395,7 @@ function migrate_update_7008() {
         $field_schema['not null'] = FALSE;
         $map_connection->schema()->changeField($map_table, $field, $field,
                                                $field_schema);
-        $ret[] = t('Changed !table.!field to be non-null',
+        $ret .= "\n" . t('Changed !table.!field to be non-null',
           array('!table' => $map_table, '!field' => $field));
       }
 
@@ -343,7 +421,7 @@ function migrate_update_7008() {
         $msg_marked = TRUE;
       }
       if ($msg_marked) {
-        $ret[] = t('Marked failures in !table', array('!table' => $map_table));
+        $ret .= "\n" . t('Marked failures in !table', array('!table' => $map_table));
       }
     }
   }
@@ -363,10 +441,11 @@ function migrate_update_7201() {
 }
 
 /**
- * Add rollback_action field to all map tables
+ * Add rollback_action field to all map tables in the Drupal database.
  */
 function migrate_update_7202() {
-  $ret = array();
+  // Note this won't catch any prefixed tables, or any stored in the source
+  // database - ensureTables() will take care of those.
   foreach (db_find_tables('migrate_map_%') as $tablename) {
     if (!db_field_exists($tablename, 'rollback_action')) {
       db_add_field($tablename, 'rollback_action', array(
@@ -379,6 +458,121 @@ function migrate_update_7202() {
       ));
     }
   }
-  $ret[] = t('Added rollback_action column to all map tables');
+  $ret = t('Added rollback_action column to all map tables');
   return $ret;
+}
+
+/**
+ * Add database tracking of per-group info.
+ */
+function migrate_update_7203() {
+  $ret = '';
+  if (!db_table_exists('migrate_group')) {
+    $ret .= t('Create migrate_group table') . "\n";
+    db_create_table('migrate_group', migrate_schema_group());
+  }
+  if (!db_field_exists('migrate_status', 'group_name')) {
+    $ret .= t('Add group relationship to migrate_status table'). "\n";
+    db_add_field('migrate_status', 'group_name', array(
+          'type' => 'varchar',
+          'length' => 255,
+          'not null' => TRUE,
+          'default' => 'default',
+          'description' => 'Name of group containing migration',
+        )
+    );
+    // Populate each migration's group_name field
+    $groups = array();
+    foreach (migrate_migrations() as $machine_name => $migration) {
+      $group_name = $migration->getGroup()->getName();
+      if (empty($group_name)) {
+        $group_name = 'default';
+      }
+      $groups[$group_name] = $group_name;
+      db_update('migrate_status')
+        ->fields(array('group_name' => $group_name))
+        ->condition('machine_name', $machine_name)
+        ->execute();
+    }
+    // Populate the migrate_group table
+    foreach ($groups as $group_name) {
+      $title = db_select('migrate_group', 'mg')
+               ->fields('mg', array('title'))
+               ->condition('name', $group_name)
+               ->execute()
+               ->fetchField();
+      if (!$title) {
+        db_insert('migrate_group')
+          ->fields(array(
+              'name' => $group_name,
+              'title' => $group_name,
+              'arguments' => serialize(array()),
+            ))
+          ->execute();
+      }
+    }
+  }
+  return $ret;
+}
+
+/**
+ * Add database tracking of field mappings.
+ */
+function migrate_update_7204() {
+  $ret = '';
+  if (!db_table_exists('migrate_field_mapping')) {
+    $ret = t('Create migrate_field_mapping table');
+    db_create_table('migrate_field_mapping', migrate_schema_field_mapping());
+  }
+  return $ret;
+}
+
+/**
+ * Remove obsolete autoregistration disablement.
+ */
+function migrate_update_7205() {
+  variable_del('migrate_disable_autoregistration');
+}
+
+/**
+ * Replace three-column PK with a simple serial.
+ */
+function migrate_update_7206() {
+  if (!db_field_exists('migrate_field_mapping', 'fmid')) {
+    db_drop_primary_key('migrate_field_mapping');
+    db_add_field('migrate_field_mapping', 'fmid',
+      array(
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'Unique ID for the field mapping row',
+      ),
+      array(
+        'primary key' => array('fmid'),
+      )
+    );
+  }
+}
+
+/**
+ * Make sure we remove an empty 'default' group created by the previous updates.
+ */
+function migrate_update_7207() {
+  $rows = db_select('migrate_group', 'mg')
+          ->fields('mg', array('name'))
+          ->condition('name', 'default')
+          ->execute()
+          ->rowCount();
+  if ($rows > 0) {
+    $rows = db_select('migrate_status', 'ms')
+            ->fields('ms', array('machine_name'))
+            ->condition('group_name', 'default')
+            ->execute()
+            ->rowCount();
+    if ($rows == 0) {
+      db_delete('migrate_group')
+      ->condition('name', 'default')
+      ->execute();
+    }
+  }
 }

--- a/docroot/sites/all/modules/migration/migrate/migrate.module
+++ b/docroot/sites/all/modules/migration/migrate/migrate.module
@@ -15,16 +15,24 @@
 
 define('MIGRATE_API_VERSION', 2);
 
+define('MIGRATE_ACCESS_BASIC', 'migration information');
+define('MIGRATE_ACCESS_ADVANCED', 'advanced migration information');
+
 /**
  * Retrieve a list of all active migrations, ordered by dependencies. To be
  * recognized, a class must be non-abstract, and derived from MigrationBase.
  *
+ * @param $reset
+ *  If TRUE, the static cache of migrations will be flushed before attempting to
+ *  reinstantiate all active migrations. This can be important for script runs
+ *  where migration classes may be dynamically registered.
+ *
  * @return
  *  Array of migration objects, keyed by the machine name.
  */
-function migrate_migrations() {
+function migrate_migrations($reset = NULL) {
   static $migrations = array();
-  if (!empty($migrations)) {
+  if (!empty($migrations) && empty($reset)) {
     return $migrations;
   }
 
@@ -32,31 +40,30 @@ function migrate_migrations() {
   // make sure any dynamic migrations defined in hook_migrate_api() get registered.
   migrate_get_module_apis(TRUE);
 
+  $dependencies_list = array();
   $dependent_migrations = array();
   $required_migrations = array();
 
   $result = db_select('migrate_status', 'ms')
-            ->fields('ms', array('machine_name', 'class_name', 'arguments'))
+            ->fields('ms', array('machine_name', 'class_name'))
             ->execute();
   foreach ($result as $row) {
     if (class_exists($row->class_name)) {
       $reflect = new ReflectionClass($row->class_name);
       if (!$reflect->isAbstract() && $reflect->isSubclassOf('MigrationBase')) {
-        $arguments = unserialize($row->arguments);
-        if (!$arguments || !is_array($arguments)) {
-          $arguments = array();
-        }
-        $migration = MigrationBase::getInstance($row->machine_name,
-          $row->class_name, $arguments);
-        $dependencies = $migration->getDependencies();
-        if (count($dependencies) > 0) {
-          // Set classes with dependencies aside for reordering
-          $dependent_migrations[$row->machine_name] = $migration;
-          $required_migrations += $dependencies;
-        }
-        else {
-          // No dependencies, just add
-          $migrations[$row->machine_name] = $migration;
+        $migration = MigrationBase::getInstance($row->machine_name);
+        if ($migration) {
+          $dependencies = $migration->getDependencies();
+          $dependencies_list[$row->machine_name] = $dependencies;
+          if (count($dependencies) > 0) {
+            // Set classes with dependencies aside for reordering
+            $dependent_migrations[$row->machine_name] = $migration;
+            $required_migrations += $dependencies;
+          }
+          else {
+            // No dependencies, just add
+            $migrations[$row->machine_name] = $migration;
+          }
         }
       }
       else {
@@ -70,32 +77,10 @@ function migrate_migrations() {
     }
   }
 
-  // Scan modules with dependencies - we'll take 20 passes at it before
-  // giving up
-  // TODO: Can we share code with _migrate_class_list()?
-  $iterations = 0;
-  while (count($dependent_migrations) > 0) {
-    if ($iterations++ > 20) {
-      $migration_names = implode(',', array_keys($dependent_migrations));
-      throw new MigrateException(t('Failure to sort migration list - most likely due ' .
-            'to circular dependencies involving !migration_names',
-      array('!migration_names' => $migration_names)));
-    }
-    foreach ($dependent_migrations as $name => $migration) {
-      $ready = TRUE;
-      // Scan all the dependencies for this class and make sure they're all
-      // in the final list
-      foreach ($migration->getDependencies() as $dependency) {
-        if (!isset($migrations[$dependency])) {
-          $ready = FALSE;
-          break;
-        }
-      }
-      if ($ready) {
-        // Yes they are! Move this class to the final list
-        $migrations[$name] = $migration;
-        unset($dependent_migrations[$name]);
-      }
+  $ordered_migrations = migrate_order_dependencies($dependencies_list);
+  foreach ($ordered_migrations as $name) {
+    if (!isset($migrations[$name])) {
+      $migrations[$name] = $dependent_migrations[$name];
     }
   }
 
@@ -108,11 +93,18 @@ function migrate_migrations() {
     $final_migrations[$name] = array();
   }
 
-  // Fill in the grouped list
+  // Fill in the grouped list.
   foreach ($migrations as $machine_name => $migration) {
-    $final_migrations[$migration->getGroup()->getName()][$machine_name] = $migration;
+    if (!method_exists($migration, 'getGroup')) {
+      MigrationBase::displayMessage(t('Migration !machine_name is not a valid Migration dependency.', array(
+        '!machine_name' => $machine_name,
+      )));
+    }
+    else {
+      $final_migrations[$migration->getGroup()->getName()][$machine_name] = $migration;
+    }
   }
-  // Then flatten the list
+  // Flatten the grouped list.
   $migrations = array();
   foreach ($final_migrations as $group_name => $group_migrations) {
     foreach ($group_migrations as $machine_name => $migration) {
@@ -121,59 +113,6 @@ function migrate_migrations() {
   }
 
   return $migrations;
-}
-
-/**
- * On request, scan the Drupal code registry for any new migration classes
- * for us to register in migrate_status.
- */
-function migrate_autoregister() {
-  // Make sure the registry is up-to-date on all available classes.
-  require_once 'includes/registry.inc';
-  _registry_update();
-
-  // Get list of modules implementing Migrate API
-  $modules = array_keys(migrate_get_module_apis(TRUE));
-
-  // Get list of classes we already know about
-  $existing_classes = db_select('migrate_status', 'ms')
-                      ->fields('ms', array('class_name'))
-                      ->execute()
-                      ->fetchCol();
-
-  // Discover class names registered with Drupal by modules implementing our API
-  $result = db_select('registry', 'r')
-            ->fields('r', array('name'))
-            ->condition('type', 'class')
-            ->condition('module', $modules, 'IN')
-            ->condition('filename', '%.test', 'NOT LIKE')
-            ->execute();
-
-  foreach ($result as $record) {
-    $class_name = $record->name;
-    // If we already know about this class, skip it
-    if (isset($existing_classes[$class_name])) {
-      continue;
-    }
-
-    // Validate it's an implemented subclass of the parent class
-    // Ignore errors
-    try {
-      $class = new ReflectionClass($class_name);
-    }
-    catch (Exception $e) {
-      continue;
-    }
-    if (!$class->isAbstract() && $class->isSubclassOf('MigrationBase')) {
-      // Verify that it's not a dynamic class (the implementor will be responsible
-      // for registering those).
-      $dynamic = call_user_func(array($class_name, 'isDynamic'));
-      if (!$dynamic) {
-        // OK, this is a new non-dynamic migration class, register it
-        MigrationBase::registerMigration($class_name);
-      }
-    }
-  }
 }
 
 /**
@@ -216,8 +155,6 @@ function migrate_handler_invoke_all($destination, $method) {
 
 /**
  * Invoke any available handlers attached to a given field type.
- * If any handlers have dependencies defined, they will be invoked after
- * the specified handlers.
  *
  * @param $entity
  *  The object we are building up before calling example_save().
@@ -231,18 +168,21 @@ function migrate_handler_invoke_all($destination, $method) {
  * @param $method
  *  Handler method to call (defaults to prepare()).
  */
-function migrate_field_handler_invoke_all($entity, array $field_info, array $instance,
-    array $values, $method = 'prepare') {
+function migrate_field_handler_invoke_all($entity, array $field_info,
+    array $instance, array $values, $method = 'prepare') {
   $return = array();
   $type = $field_info['type'];
   $class_list = _migrate_class_list('MigrateFieldHandler');
-  $disabled = unserialize(variable_get('migrate_disabled_handlers', serialize(array())));
+  $disabled = unserialize(variable_get('migrate_disabled_handlers',
+                                       serialize(array())));
+  $handler_called = FALSE;
   foreach ($class_list as $class_name => $handler) {
     if (!in_array($class_name, $disabled) && $handler->handlesType($type)
         && method_exists($handler, $method)) {
       migrate_instrument_start($class_name . '->' . $method);
       $result = call_user_func_array(array($handler, $method),
         array($entity, $field_info, $instance, $values));
+      $handler_called = TRUE;
       migrate_instrument_stop($class_name . '->' . $method);
       if (isset($result) && is_array($result)) {
         $return = array_merge_recursive($return, $result);
@@ -250,6 +190,20 @@ function migrate_field_handler_invoke_all($entity, array $field_info, array $ins
       elseif (isset($result)) {
         $return[] = $result;
       }
+    }
+  }
+
+  if (!$handler_called && $method == 'prepare') {
+    $handler = new MigrateDefaultFieldHandler();
+    migrate_instrument_start('MigrateDefaultFieldHandler->prepare');
+    $result = call_user_func_array(array($handler, 'prepare'),
+      array($entity, $field_info, $instance, $values));
+    migrate_instrument_stop('MigrateDefaultFieldHandler->prepare');
+    if (isset($result) && is_array($result)) {
+      $return = array_merge_recursive($return, $result);
+    }
+    elseif (isset($result)) {
+      $return[] = $result;
     }
   }
   return $return;
@@ -269,10 +223,9 @@ function migrate_field_handler_invoke_all($entity, array $field_info, array $ins
 function _migrate_class_list($parent_class) {
   // Get info on modules implementing Migrate API
   static $module_info;
-  if (!isset($modules)) {
+  if (!isset($module_info)) {
     $module_info = migrate_get_module_apis();
   }
-  $modules = array_keys($module_info);
 
   static $class_lists = array();
   if (!isset($class_lists[$parent_class])) {
@@ -291,90 +244,6 @@ function _migrate_class_list($parent_class) {
         }
       }
     }
-    // Avoid scrounging the registry for handler classes if possible.
-    if (variable_get('migrate_disable_autoregistration', FALSE)) {
-      return $class_lists[$parent_class];
-    }
-    $dependent_classes = array();
-    $required_classes = array();
-    // Discover class names registered with Drupal by modules implementing our API
-    $result = db_select('registry', 'r')
-              ->fields('r', array('name'))
-              ->condition('type', 'class')
-              ->condition('module', $modules, 'IN')
-              ->condition('filename', '%.test', 'NOT LIKE')
-              ->execute();
-
-    foreach ($result as $record) {
-      // Validate it's an implemented subclass of the parent class
-      // We can get funky errors here, ignore them (and the class that caused them)
-      try {
-        $class = new ReflectionClass($record->name);
-      }
-      catch (Exception $e) {
-        continue;
-      }
-      if (!$class->isAbstract() && $class->isSubclassOf($parent_class)) {
-        // If the constructor has required parameters, this may fail. We will
-        // silently ignore - it is up to the implementor of such a class to
-        // instantiate it in hook_migrations_alter().
-        try {
-          $object = new $record->name;
-        }
-        catch (Exception $e) {
-          unset($object);
-        }
-        if (isset($object)) {
-          $dependencies = $object->getDependencies();
-          if (count($dependencies) > 0) {
-            // Set classes with dependencies aside for reordering
-            $dependent_classes[$record->name] = $object;
-            $required_classes += $dependencies;
-          }
-          else {
-            // No dependencies, just add
-            $class_lists[$parent_class][$record->name] = $object;
-          }
-        }
-      }
-    }
-
-    // Validate that each depended-on class at least exists
-    foreach ($required_classes as $class_name) {
-      if ((!isset($dependent_classes[$class_name])) && !isset($class_lists[$parent_class][$class_name])) {
-        throw new MigrateException(t('Dependency on non-existent class !class - make sure ' .
-            'you have added the file defining !class to the .info file.',
-          array('!class' => $class_name)));
-      }
-    }
-
-    // Scan modules with dependencies - we'll take 20 passes at it before
-    // giving up
-    $iterations = 0;
-    while (count($dependent_classes) > 0) {
-      if ($iterations++ > 20) {
-        $class_names = implode(',', array_keys($dependent_classes));
-        throw new MigrateException(t('Failure to sort class list - most likely due ' .
-            'to circular dependencies involving !class_names.',
-          array('!class_names' => $class_names)));
-      }
-      foreach ($dependent_classes as $name => $object) {
-        $ready = TRUE;
-        // Scan all the dependencies for this class and make sure they're all
-        // in the final list
-        foreach ($object->getDependencies() as $dependency) {
-          if (!isset($class_lists[$parent_class][$dependency])) {
-            $ready = FALSE;
-            break;
-          }
-        }
-        if ($ready) {
-          // Yes they are! Move this class to the final list
-          $class_lists[$parent_class][$name] = $object;
-          unset($dependent_classes[$name]);
-        }
-      }
-    }
   }
   return $class_lists[$parent_class];
 }
@@ -387,7 +256,24 @@ function migrate_hook_info() {
   $hooks['migrate_api'] = array(
     'group' => 'migrate',
   );
+  $hooks['migrate_api_alter'] = array(
+    'group' => 'migrate',
+  );
   return $hooks;
+}
+
+/**
+ * Implementation of hook_permission().
+ */
+function migrate_permission() {
+  return array(
+    MIGRATE_ACCESS_BASIC => array(
+      'title' => t('Access to basic migration information'),
+    ),
+    MIGRATE_ACCESS_ADVANCED => array(
+      'title' => t('Access to advanced migration information'),
+    ),
+  );
 }
 
 /**
@@ -405,13 +291,6 @@ function migrate_get_module_apis($reset = FALSE) {
       $info = $function();
       if (isset($info['api']) && $info['api'] == MIGRATE_API_VERSION) {
         $cache[$module] = $info;
-        // Register any migrations defined via the hook.
-        if (isset($info['migrations']) && is_array($info['migrations'])) {
-          foreach ($info['migrations'] as $machine_name => $arguments) {
-            MigrationBase::registerMigration($arguments['class_name'],
-              $machine_name, $arguments);
-          }
-        }
       }
       else {
         drupal_set_message(t('%function supports Migrate API version %modversion,
@@ -420,9 +299,95 @@ function migrate_get_module_apis($reset = FALSE) {
                 '%version' => MIGRATE_API_VERSION)));
       }
     }
+
+    // Allow modules to alter the migration information.
+    drupal_alter('migrate_api', $cache);
   }
 
   return $cache;
+}
+
+/**
+ * Register any migrations defined in hook_migrate_api().
+ *
+ * @param array $machine_names
+ *  If populated, only (re)register the specified migrations.
+ */
+function migrate_static_registration($machine_names = array()) {
+  $module_info = migrate_get_module_apis(TRUE);
+  foreach ($module_info as $module => $info) {
+    // Register any groups defined via the hook.
+    if (isset($info['groups']) && is_array($info['groups'])) {
+      foreach ($info['groups'] as $name => $arguments) {
+        $title = $arguments['title'];
+        unset($arguments['title']);
+        MigrateGroup::register($name, $title, $arguments);
+      }
+    }
+    // Register any migrations defined via the hook.
+    if (isset($info['migrations']) && is_array($info['migrations'])) {
+      foreach ($info['migrations'] as $machine_name => $arguments) {
+        // If we have an explicit list to register, skip any not in the list.
+        if (!empty($machine_names) && !in_array($machine_name, $machine_names)) {
+          continue;
+        }
+        $class_name = $arguments['class_name'];
+        unset($arguments['class_name']);
+        // Call the right registerMigration implementation. Note that this means
+        // that classes that override registerMigration() must always call it
+        // directly, they cannot register those classes by defining them in
+        // hook_migrate_api() and expect their extension to be called.
+        if (is_subclass_of($class_name, 'Migration')) {
+          Migration::registerMigration($class_name, $machine_name, $arguments);
+        }
+        else {
+          MigrationBase::registerMigration($class_name, $machine_name, $arguments);
+        }
+      }
+    }
+
+  }
+}
+
+/**
+ * Do a topological sort on our dependencies graph.
+ */
+function migrate_order_dependencies($dependencies) {
+  $visited = array();
+  $list = array();
+
+  foreach (array_keys($dependencies) as $name) {
+    $visited[$name] = FALSE;
+  }
+
+  foreach (array_keys($dependencies) as $name) {
+    migrate_visit_dependent($dependencies, $name, $list, $visited);
+  }
+
+  return $list;
+}
+
+/**
+ * Depth-first search for independent migrations.
+ */
+function migrate_visit_dependent($dependencies, $name, &$list, &$visited) {
+  if ($visited[$name]) {
+    if ($list[$name]) {
+      return;
+    }
+    else {
+      throw new MigrateException(t('Failure to sort migration list due to circular dependencies involving %name.', array('%name' => $name)));
+    }
+  }
+
+  $visited[$name] = TRUE;
+  if (isset($dependencies[$name])) {
+    foreach ($dependencies[$name] as $dependent) {
+      migrate_visit_dependent($dependencies, $dependent, $list, $visited);
+    }
+  }
+
+  $list[$name] = $name;
 }
 
 /**
@@ -578,4 +543,29 @@ function migrate_overview() {
     $overview .= $result . ' ';
   }
   return $overview;
+}
+
+/**
+ * Implements hook_modules_enabled.
+ */
+function migrate_modules_enabled($modules) {
+  if (array_intersect($modules, module_implements('migrate_api'))) {
+    migrate_static_registration();
+  }
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function migrate_module_implements_alter(&$implementation, $hook) {
+  // Ensure that the Migration class exists, as different bootstrap phases may
+  // not have included migration.inc yet.
+  if (class_exists('Migration') && $migration = Migration::currentMigration()) {
+    $disable_hooks = $migration->getDisableHooks();
+    if (isset($disable_hooks[$hook])) {
+      foreach ($disable_hooks[$hook] as $module) {
+        unset($implementation[$module]);
+      }
+    }
+  }
 }

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/beer.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/beer.inc
@@ -16,34 +16,41 @@
  * - Comments to be attached to the beer nodes are described in the source
  *   migrate_example_beer_comment table.
  *
- * We will use the Migrate API to import and transform this data and turn it into
- * a working Drupal system.
+ * We will use the Migrate API to import and transform this data and turn it
+ * into a working Drupal site.
  */
 
 /**
  * To define a migration process from a set of source data to a particular
  * kind of Drupal object (for example, a specific node type), you define
  * a class derived from Migration. You must define a constructor to initialize
- * your migration object. By default, your class name will be the "machine name"
- * of the migration, by which you refer to it. Note that the machine name is
- * case-sensitive.
+ * your migration object.
+ *
+ * For your classes to be instantiated so they can be used to import content,
+ * you must register them - look at migrate_example.migrate.inc to see how
+ * registration works. Right now, it's important to understand that each
+ * migration will have a unique "machine name", which is displayed in the UI
+ * and is used to reference the migration in drush commands.
  *
  * In any serious migration project, you will find there are some options
  * which are common to the individual migrations you're implementing. You can
  * define an abstract intermediate class derived from Migration, then derive your
  * individual migrations from that, to share settings, utility functions, etc.
  */
-abstract class BasicExampleMigration extends DynamicMigration {
-  public function __construct() {
-    // Always call the parent constructor first for basic setup
-    parent::__construct();
+abstract class BasicExampleMigration extends Migration {
+  // A Migration constructor takes an array of arguments as its first parameter.
+  // The arguments must be passed through to the parent constructor.
+  public function __construct($arguments) {
+    parent::__construct($arguments);
 
     // With migrate_ui enabled, migration pages will indicate people involved in
     // the particular migration, with their role and contact info. We default the
     // list in the shared class; it can be overridden for specific migrations.
     $this->team = array(
-      new MigrateTeamMember('Liz Taster', 'ltaster@example.com', t('Product Owner')),
-      new MigrateTeamMember('Larry Brewer', 'lbrewer@example.com', t('Implementor')),
+      new MigrateTeamMember('Liz Taster', 'ltaster@example.com',
+                            t('Product Owner')),
+      new MigrateTeamMember('Larry Brewer', 'lbrewer@example.com',
+                            t('Implementor')),
     );
 
     // Individual mappings in a migration can be linked to a ticket or issue
@@ -62,23 +69,45 @@ abstract class BasicExampleMigration extends DynamicMigration {
  *    this will receive data that originated from the source and has been mapped
  *    by the Migration class, and create Drupal objects.
  *  $this->map - An instance of a class derived from MigrateMap, this will keep
- *    track of which source items have been imported and what destination objects
- *    they map to.
- *  Mappings - Use $this->addFieldMapping to tell the Migration class what source
- *    fields correspond to what destination fields, and additional information
- *    associated with the mappings.
+ *    track of which source items have been imported and what destination
+ *    objects they map to.
+ *  Field mappings - Use $this->addFieldMapping to tell the Migration class what
+ *    source fields correspond to what destination fields, and additional
+ *    information associated with the mappings.
  */
 class BeerTermMigration extends BasicExampleMigration {
-  public function __construct() {
-    parent::__construct();
-    // Human-friendly description of your migration process. Be as detailed as you
-    // like.
-    $this->description = t('Migrate styles from the source database to taxonomy terms');
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    // Human-friendly description of your migration process. Be as detailed as
+    // you like.
+    $this->description =
+      t('Migrate styles from the source database to taxonomy terms');
+
+    // In this example, we're using tables that have been added to the existing
+    // Drupal database but which are not Drupal tables. You can examine the
+    // various tables (starting here with migrate_example_beer_topic) using a
+    // database browser such as phpMyAdmin.
+    // First, we set up a query for this data. Note that by ordering on
+    // style_parent, we guarantee root terms are migrated first, so the
+    // parent_name mapping below will find that the parent exists.
+    $query = db_select('migrate_example_beer_topic', 'met')
+             ->fields('met', array('style', 'details', 'style_parent', 'region',
+                                   'hoppiness'))
+             // This sort assures that parents are saved before children.
+             ->orderBy('style_parent', 'ASC');
+
+    // Create a MigrateSource object, which manages retrieving the input data.
+    $this->source = new MigrateSourceSQL($query);
+
+    // Set up our destination - terms in the migrate_example_beer_styles
+    // vocabulary (note that we pass the machine name of the vocabulary).
+    $this->destination =
+      new MigrateDestinationTerm('migrate_example_beer_styles');
 
     // Create a map object for tracking the relationships between source rows
-    // and their resulting Drupal objects. Usually, you'll use the MigrateSQLMap
-    // class, which uses database tables for tracking. Pass the machine name
-    // (BeerTerm) of this migration to use in generating map and message tables.
+    // and their resulting Drupal objects. We will use the MigrateSQLMap class,
+    // which uses database tables for tracking. Pass the machine name (BeerTerm)
+    // of this migration to use in generating map and message table names.
     // And, pass schema definitions for the primary keys of the source and
     // destination - we need to be explicit for our source, but the destination
     // class knows its schema already.
@@ -93,28 +122,11 @@ class BeerTermMigration extends BasicExampleMigration {
         MigrateDestinationTerm::getKeySchema()
       );
 
-    // In this example, we're using tables that have been added to the existing
-    // Drupal database but which are not Drupal tables. You can examine the
-    // various tables (starting here with migrate_example_beer_topic) using a
-    // database browser like phpMyAdmin.
-    // First, we set up a query for this data. Note that by ordering on
-    // style_parent, we guarantee root terms are migrated first, so the
-    // parent_name mapping below will find that the parent exists.
-    $query = db_select('migrate_example_beer_topic', 'met')
-             ->fields('met', array('style', 'details', 'style_parent', 'region', 'hoppiness'))
-             // This sort assures that parents are saved before children.
-             ->orderBy('style_parent', 'ASC');
-
-    // Create a MigrateSource object, which manages retrieving the input data.
-    $this->source = new MigrateSourceSQL($query);
-
-    // Set up our destination - terms in the migrate_example_beer_styles vocabulary
-    $this->destination = new MigrateDestinationTerm('migrate_example_beer_styles');
-
     // Assign mappings TO destination fields FROM source fields. To discover
     // the names used in these calls, use the drush commands
-    // drush migrate-fields-destination BeerTerm
-    // drush migrate-fields-source BeerTerm
+    //  drush migrate-fields-destination BeerTerm
+    //  drush migrate-fields-source BeerTerm
+    // or review the detail pages in the UI.
     $this->addFieldMapping('name', 'style');
     $this->addFieldMapping('description', 'details');
 
@@ -127,12 +139,13 @@ class BeerTermMigration extends BasicExampleMigration {
     // migration info page when the migrate_ui module is enabled. The default
     // is 'Done', indicating active mappings which need no attention. A
     // suggested practice is to use groups of:
-    // Do Not Migrate (or DNM) to indicate source fields which are not being used,
-    //  or destination fields not to be populated by migration.
+    // Do Not Migrate (or DNM) to indicate source fields which are not being
+    //  used, or destination fields not to be populated by migration.
     // Client Issues to indicate input from the client is needed to determine
     //  how a given field is to be migrated.
     // Implementor Issues to indicate that the client has provided all the
-    //  necessary information, and now the implementor needs to complete the work.
+    //  necessary information, and now the implementor needs to complete the
+    //  work.
     $this->addFieldMapping(NULL, 'hoppiness')
          ->description(t('This info will not be maintained in Drupal'))
          ->issueGroup(t('DNM'));
@@ -141,10 +154,11 @@ class BeerTermMigration extends BasicExampleMigration {
     // MigrateFieldMapping::ISSUE_PRIORITY_OK). If you're using an issue
     // tracking system, and have defined issuePattern (see BasicExampleMigration
     // above), you can specify a ticket/issue number in the system on the
-    // mapping and migrate_ui will link directory to it.
+    // mapping and migrate_ui will link directly to it.
     $this->addFieldMapping(NULL, 'region')
          ->description('Will a field be added to the vocabulary for this?')
          ->issueGroup(t('Client Issues'))
+         // This priority wil cause the mapping to be highlighted in the UI.
          ->issuePriority(MigrateFieldMapping::ISSUE_PRIORITY_MEDIUM)
          ->issueNumber(770064);
 
@@ -152,8 +166,8 @@ class BeerTermMigration extends BasicExampleMigration {
     // explicitly - this makes sure that everyone understands exactly what is
     // being migrated and what is not. Also, migrate_ui highlights unmapped
     // fields, or mappings involving fields not in the source and destination,
-    // so if (for example) a new field is added to the destination field it's
-    // immediately visible, and you can find out if anything needs to be
+    // so if (for example) a new field is added to the destination typ it's
+    // immediately visible, and you can decide if anything needs to be
     // migrated into it.
     $this->addFieldMapping('format')
          ->issueGroup(t('DNM'));
@@ -163,11 +177,12 @@ class BeerTermMigration extends BasicExampleMigration {
          ->issueGroup(t('DNM'));
 
     // We conditionally DNM these fields, so your field mappings will be clean
-    // whether or not you have path and or pathauto enabled
-    if (module_exists('path')) {
+    // whether or not you have path and/or pathauto enabled.
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
       $this->addFieldMapping('path')
            ->issueGroup(t('DNM'));
-      if (module_exists('pathauto')) {
+      if (isset($destination_fields['pathauto'])) {
         $this->addFieldMapping('pathauto')
              ->issueGroup(t('DNM'));
       }
@@ -186,10 +201,15 @@ class BeerTermMigration extends BasicExampleMigration {
  * transformations of the data.
  */
 class BeerUserMigration extends BasicExampleMigration {
-  public function __construct() {
+  public function __construct($arguments) {
     // The basic setup is similar to BeerTermMigraiton
-    parent::__construct();
+    parent::__construct($arguments);
     $this->description = t('Beer Drinkers of the world');
+    $query = db_select('migrate_example_beer_account', 'mea')
+             ->fields('mea', array('aid', 'status', 'posted', 'name',
+               'nickname', 'password', 'mail', 'sex', 'beers'));
+    $this->source = new MigrateSourceSQL($query);
+    $this->destination = new MigrateDestinationUser();
     $this->map = new MigrateSQLMap($this->machineName,
         array('aid' => array(
               'type' => 'int',
@@ -199,18 +219,15 @@ class BeerUserMigration extends BasicExampleMigration {
         ),
         MigrateDestinationUser::getKeySchema()
     );
-    $query = db_select('migrate_example_beer_account', 'mea')
-             ->fields('mea', array('aid', 'status', 'posted', 'name', 'nickname', 'password', 'mail', 'sex', 'beers'));
-    $this->source = new MigrateSourceSQL($query);
-    $this->destination = new MigrateDestinationUser();
 
-    // One good way to organize your mappings is in three groups - mapped fields,
-    // unmapped source fields, and unmapped destination fields
+    // One good way to organize your mappings in the constructor is in three
+    // groups - mapped fields, unmapped source fields, and unmapped destination
+    // fields.
 
     // Mapped fields
 
     // This is a shortcut you can use when the source and destination field
-    // names are identical (i.e., the email address field is named 'mail' in
+    // names are identical (e.g., the email address field is named 'mail' in
     // both the source table and in Drupal).
     $this->addSimpleMappings(array('status', 'mail'));
 
@@ -224,7 +241,8 @@ class BeerUserMigration extends BasicExampleMigration {
     $this->addFieldMapping('name', 'name')
          ->dedupe('users', 'name');
 
-    // The migrate module automatically converts date/time strings to UNIX timestamps.
+    // The migrate module automatically converts date/time strings to UNIX
+    // timestamps.
     $this->addFieldMapping('created', 'posted');
 
     $this->addFieldMapping('pass', 'password');
@@ -246,6 +264,10 @@ class BeerUserMigration extends BasicExampleMigration {
       $this->addFieldMapping('field_migrate_example_favbeers', 'beers')
            ->separator('|');
     }
+    else {
+      $this->addFieldMapping(NULL, 'beers')
+           ->issueGroup(t('DNM'));
+    }
 
     // Unmapped source fields
     $this->addFieldMapping(NULL, 'nickname')
@@ -254,10 +276,20 @@ class BeerUserMigration extends BasicExampleMigration {
     // Unmapped destination fields
 
     // This is a shortcut you can use to mark several destination fields as DNM
-    // at once
-    $this->addUnmigratedDestinations(array('theme', 'signature', 'access', 'login',
-      'timezone', 'language', 'picture', 'is_new', 'signature_format', 'role_names',
-      'init', 'data'));
+    // at once.
+    $this->addUnmigratedDestinations(array(
+      'access',
+      'data',
+      'is_new',
+      'language',
+      'login',
+      'picture',
+      'role_names',
+      'signature',
+      'signature_format',
+      'theme',
+      'timezone',
+    ));
 
     // Oops, we made a typo - this should have been 'init'! If you have
     // migrate_ui enabled, look at the BeerUser info page - you'll see that it
@@ -267,10 +299,11 @@ class BeerUserMigration extends BasicExampleMigration {
     $this->addFieldMapping('int')
          ->issueGroup(t('DNM'));
 
-    if (module_exists('path')) {
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
       $this->addFieldMapping('path')
            ->issueGroup(t('DNM'));
-      if (module_exists('pathauto')) {
+      if (isset($destination_fields['pathauto'])) {
         $this->addFieldMapping('pathauto')
              ->issueGroup(t('DNM'));
       }
@@ -283,35 +316,19 @@ class BeerUserMigration extends BasicExampleMigration {
  * and creates Drupal nodes of type 'Beer' as destination.
  */
 class BeerNodeMigration extends BasicExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Beers of the world');
-
-    // You may optionally declare dependencies for your migration - other migrations
-    // which should run first. In this case, terms assigned to our nodes and
-    // the authors of the nodes should be migrated before the nodes themselves.
-    $this->dependencies = array('BeerTerm', 'BeerUser');
-
-    $this->map = new MigrateSQLMap($this->machineName,
-      array(
-        'bid' => array(
-          'type' => 'int',
-          'not null' => TRUE,
-          'description' => 'Beer ID.',
-          'alias' => 'b',
-        )
-      ),
-      MigrateDestinationNode::getKeySchema()
-    );
 
     // We have a more complicated query. The Migration class fundamentally
     // depends on taking a single source row and turning it into a single
     // Drupal object, so how do we deal with zero or more terms attached to
-    // each node? One way (demonstrated for MySQL) is to pull them into a single
+    // each node? One way (valid for MySQL only) is to pull them into a single
     // comma-separated list.
     $query = db_select('migrate_example_beer_node', 'b')
-             ->fields('b', array('bid', 'name', 'body', 'excerpt', 'aid', 'countries',
-              'image', 'image_alt', 'image_title', 'image_description'));
+             ->fields('b', array('bid', 'name', 'body', 'excerpt', 'aid',
+               'countries', 'image', 'image_alt', 'image_title',
+               'image_description'));
     $query->leftJoin('migrate_example_beer_topic_node', 'tb', 'b.bid = tb.bid');
     // Gives a single comma-separated list of related terms
     $query->groupBy('tb.bid');
@@ -331,6 +348,18 @@ class BeerNodeMigration extends BasicExampleMigration {
     // Set up our destination - nodes of type migrate_example_beer
     $this->destination = new MigrateDestinationNode('migrate_example_beer');
 
+    $this->map = new MigrateSQLMap($this->machineName,
+      array(
+        'bid' => array(
+          'type' => 'int',
+          'not null' => TRUE,
+          'description' => 'Beer ID.',
+          'alias' => 'b',
+        )
+      ),
+      MigrateDestinationNode::getKeySchema()
+    );
+
     // Mapped fields
     $this->addFieldMapping('title', 'name')
          ->description(t('Mapping beer name in source to node title'));
@@ -340,15 +369,6 @@ class BeerNodeMigration extends BasicExampleMigration {
          ->issueNumber(765736)
          ->issuePriority(MigrateFieldMapping::ISSUE_PRIORITY_LOW);
 
-    // To maintain node identities between the old and new systems (i.e., have
-    // the same unique IDs), map the ID column from the old system to nid and
-    // set is_new to TRUE. This works only if we're importing into a system that
-    // has no existing nodes with the nids being imported.
-    $this->addFieldMapping('nid', 'bid')
-         ->description(t('Preserve old beer ID as nid in Drupal'));
-    $this->addFieldMapping('is_new')
-         ->defaultValue(TRUE);
-
     // References to related objects (such as the author of the content) are
     // most likely going to be identifiers from the source data, not Drupal
     // identifiers (such as uids). You can use the mapping from the relevant
@@ -357,25 +377,37 @@ class BeerNodeMigration extends BasicExampleMigration {
     // find a corresponding uid for the aid, the owner will be the administrative
     // account.
     $this->addFieldMapping('uid', 'aid')
+         // Note this is the machine name of the user migration.
          ->sourceMigration('BeerUser')
          ->defaultValue(1);
 
-    // This is a multi-value text field
+    // This is a multi-value text field - in the source data the values are
+    // separated by |, so we tell migrate to split it by that character.
     $this->addFieldMapping('field_migrate_example_country', 'countries')
          ->separator('|');
-    // These are related terms, which by default will be looked up by name
+    // These are related terms, which by default will be looked up by name.
     $this->addFieldMapping('migrate_example_beer_styles', 'terms')
          ->separator(',');
 
-    // Some fields may have subfields such as text formats or summaries
-    // (equivalent to teasers in previous Drupal versions).
-    // These can be individually mapped as we see here.
+    // Some fields may have subfields such as text formats or summaries. These
+    // can be individually mapped as we see here.
     $this->addFieldMapping('body', 'body');
     $this->addFieldMapping('body:summary', 'excerpt');
 
-    // Copy an image file, write DB record to files table, and save in Field storage.
-    // We map the filename (relative to the source_dir below) to the field itself.
+    // File fields are more complex - the file needs to be copied, a Drupal
+    // file entity (file_managed table row) created, and the field populated.
+    // There are several different options involved. It's usually best to do
+    // migrate the files themselves in their own migration (see wine.inc for an
+    // example), but they can also be brought over through the field mapping.
+
+    // We map the filename (relative to the source_dir below) to the field
+    // itself.
     $this->addFieldMapping('field_migrate_example_image', 'image');
+    // The file_class determines how the 'image' value is interpreted, and what
+    // other options are available. In this case, MigrateFileUri indicates that
+    // the 'image' value is a URI.
+    $this->addFieldMapping('field_migrate_example_image:file_class')
+         ->defaultValue('MigrateFileUri');
     // Here we specify the directory containing the source files.
     $this->addFieldMapping('field_migrate_example_image:source_dir')
          ->defaultValue(drupal_get_path('module', 'migrate_example'));
@@ -387,24 +419,44 @@ class BeerNodeMigration extends BasicExampleMigration {
     $this->addUnmigratedSources(array('image_description'));
 
     // Unmapped destination fields
-    $this->addUnmigratedDestinations(array('created', 'changed', 'status',
-      'promote', 'revision', 'language', 'revision_uid', 'log', 'tnid',
-      'body:format', 'body:language', 'migrate_example_beer_styles:source_type',
-      'migrate_example_beer_styles:create_term', 'field_migrate_example_image:destination_dir',
-      'field_migrate_example_image:language', 'field_migrate_example_image:file_replace',
-      'field_migrate_example_image:preserve_files', 'field_migrate_example_country:language', 'comment',
-      'field_migrate_example_image:file_class', 'field_migrate_example_image:destination_file'));
+    // Some conventions we use here: with a long list of fields to ignore, we
+    // arrange them alphabetically, one distinct field per line (although
+    // subfields of the same field may be grouped on the same line), and indent
+    // subfields to distinguish them from top-level fields.
+    $this->addUnmigratedDestinations(array(
+        'body:format',
+      'changed',
+      'comment',
+      'created',
+        'field_migrate_example_image:destination_dir',
+        'field_migrate_example_image:destination_file',
+        'field_migrate_example_image:file_replace',
+        'field_migrate_example_image:preserve_files',
+        'field_migrate_example_image:urlencode',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_beer_styles:source_type',
+        'migrate_example_beer_styles:create_term',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'tnid',
+    ));
 
-    if (module_exists('path')) {
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
       $this->addFieldMapping('path')
            ->issueGroup(t('DNM'));
-      if (module_exists('pathauto')) {
+      if (isset($destination_fields['pathauto'])) {
         $this->addFieldMapping('pathauto')
              ->issueGroup(t('DNM'));
       }
     }
     if (module_exists('statistics')) {
-      $this->addUnmigratedDestinations(array('totalcount', 'daycount', 'timestamp'));
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
     }
   }
 }
@@ -414,10 +466,21 @@ class BeerNodeMigration extends BasicExampleMigration {
  * Drupal comment objects.
  */
 class BeerCommentMigration extends BasicExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = 'Comments about beers';
-    $this->dependencies = array('BeerUser', 'BeerNode');
+
+    $query = db_select('migrate_example_beer_comment', 'mec')
+             ->fields('mec', array('cid', 'cid_parent', 'name', 'mail', 'aid',
+               'body', 'bid', 'subject'))
+             ->orderBy('cid_parent', 'ASC');
+    $this->source = new MigrateSourceSQL($query);
+    // Note that the machine name passed for comment migrations is
+    // 'comment_node_' followed by the machine name of the node type these
+    // comments are attached to.
+    $this->destination =
+      new MigrateDestinationComment('comment_node_migrate_example_beer');
+
     $this->map = new MigrateSQLMap($this->machineName,
       array('cid' => array(
             'type' => 'int',
@@ -426,19 +489,14 @@ class BeerCommentMigration extends BasicExampleMigration {
          ),
       MigrateDestinationComment::getKeySchema()
     );
-    $query = db_select('migrate_example_beer_comment', 'mec')
-             ->fields('mec', array('cid', 'cid_parent', 'name', 'mail', 'aid', 'body', 'bid', 'subject'))
-             ->orderBy('cid_parent', 'ASC');
-    $this->source = new MigrateSourceSQL($query);
-    $this->destination = new MigrateDestinationComment('comment_node_migrate_example_beer');
 
     // Mapped fields
     $this->addSimpleMappings(array('name', 'subject', 'mail'));
     $this->addFieldMapping('status')
          ->defaultValue(COMMENT_PUBLISHED);
 
-    // We preserved bid => nid ids during BeerNode import so simple mapping suffices.
-    $this->addFieldMapping('nid', 'bid');
+    $this->addFieldMapping('nid', 'bid')
+         ->sourceMigration('BeerNode');
 
     $this->addFieldMapping('uid', 'aid')
          ->sourceMigration('BeerUser')
@@ -453,7 +511,24 @@ class BeerCommentMigration extends BasicExampleMigration {
     // No unmapped source fields
 
     // Unmapped destination fields
-    $this->addUnmigratedDestinations(array('hostname', 'created', 'changed',
-      'thread', 'homepage', 'language', 'comment_body:format', 'comment_body:language'));
+    $this->addUnmigratedDestinations(array(
+      'changed',
+        'comment_body:format',
+      'created',
+      'homepage',
+      'hostname',
+      'language',
+      'thread',
+    ));
+
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
+      $this->addFieldMapping('path')
+           ->issueGroup(t('DNM'));
+      if (isset($destination_fields['pathauto'])) {
+        $this->addFieldMapping('pathauto')
+             ->issueGroup(t('DNM'));
+      }
+    }
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/beer.install.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/beer.install.inc
@@ -47,10 +47,7 @@ function migrate_example_beer_uninstall() {
 }
 
 function migrate_example_beer_disable() {
-  Migration::deregisterMigration('BeerTerm');
-  Migration::deregisterMigration('BeerUser');
-  Migration::deregisterMigration('BeerNode');
-  Migration::deregisterMigration('BeerComment');
+  MigrateGroup::deregister('beer');
 }
 
 function migrate_example_beer_schema_node() {

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example.info
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example.info
@@ -1,6 +1,6 @@
 name = "Migrate Example"
 description = "Example migration data."
-package = "Development"
+package = "Migration"
 core = 7.x
 dependencies[] = taxonomy
 dependencies[] = image
@@ -12,16 +12,15 @@ dependencies[] = number
 ;node_reference is useful but not required
 ;dependencies[] = node_reference
 
-files[] = migrate_example.module
 files[] = beer.inc
 files[] = wine.inc
 
 ; For testing table_copy plugin. Since is infrequently used, we comment it out.
 ; files[] = example.table_copy.inc
 
-; Information added by drupal.org packaging script on 2012-11-07
-version = "7.x-2.5"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-2.8"
 core = "7.x"
 project = "migrate"
-datestamp = "1352299007"
+datestamp = "1435760949"
 

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example.install
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example.install
@@ -34,6 +34,7 @@ function migrate_example_install() {
   );
   $example_format = (object) $example_format;
   filter_format_save($example_format);
+  migrate_static_registration();
 }
 
 function migrate_example_uninstall() {

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example.migrate.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example.migrate.inc
@@ -9,39 +9,238 @@
 
 /*
  * You must implement hook_migrate_api(), setting the API level to 2, if you are
- * implementing any migration classes. As of Migrate 2.5, you should also
- * register your migration and handler classes explicitly here - the former
- * method of letting them get automatically registered on a cache clear will
- * break in certain environments (see http://drupal.org/node/1778952).
+ * implementing any migration classes. If your migration application is static -
+ * that is, you know at implementation time exactly what migrations must be
+ * instantiated - then you should register your migrations here. If your
+ * application is more dynamic (for example, if selections in the UI determine
+ * exactly what migrations need to be instantiated), then you would register
+ * your migrations using registerMigration() - see migrate_example_baseball for
+ * more information.
  */
 function migrate_example_migrate_api() {
+  // Usually field mappings are established by code in the migration constructor -
+  // a call to addFieldMapping(). They may also be passed as arguments when
+  // registering a migration - in this case, they are stored in the database
+  // and override any mappings for the same field in the code. To do this,
+  // construct the field mapping object and configure it similarly to when
+  // you call addFieldMapping, and pass your mappings as an array below.
+  $translate_mapping = new MigrateFieldMapping('translate', NULL);
+  $translate_mapping->defaultValue(0);
+  $ignore_mapping = new MigrateFieldMapping('migrate_example_beer_styles:ignore_case', NULL);
+  $ignore_mapping->defaultValue(1);
+
   $api = array(
+    // Required - tells the Migrate module that you are implementing version 2
+    // of the Migrate API.
     'api' => 2,
+    // Migrations can be organized into groups. The key used here will be the
+    // machine name of the group, which can be used in Drush:
+    //  drush migrate-import --group=wine
+    // The title is a required argument which is displayed for the group in the
+    // UI. You may also have additional arguments for any other data which is
+    // common to all migrations in the group.
+    'groups' => array(
+      'beer' => array(
+        'title' => t('Beer Imports'),
+      ),
+      'wine' => array(
+        'title' => t('Wine Imports'),
+      ),
+    ),
+
+    // Here we register the individual migrations. The keys (BeerTerm, BeerUser,
+    // etc.) are the machine names of the migrations, and the class_name
+    // argument is required. The group_name is optional (defaulting to 'default')
+    // but specifying it is a best practice.
     'migrations' => array(
-      'BeerTerm' => array('class_name' => 'BeerTermMigration'),
-      'BeerUser' => array('class_name' => 'BeerUserMigration'),
-      'BeerNode' => array('class_name' => 'BeerNodeMigration'),
-      'BeerComment' => array('class_name' => 'BeerCommentMigration'),
-      'WinePrep' => array('class_name' => 'WinePrepMigration'),
-      'WineVariety' => array('class_name' => 'WineVarietyMigration'),
-      'WineRegion' => array('class_name' => 'WineRegionMigration'),
-      'WineBestWith' => array('class_name' => 'WineBestWithMigration'),
-      'WineFileCopy' => array('class_name' => 'WineFileCopyMigration'),
-      'WineFileBlob' => array('class_name' => 'WineFileBlobMigration'),
-      'WineRole' => array('class_name' => 'WineRoleMigration'),
-      'WineUser' => array('class_name' => 'WineUserMigration'),
-      'WineProducer' => array('class_name' => 'WineProducerMigration'),
-      'WineProducerXML' => array('class_name' => 'WineProducerXMLMigration'),
-      'WineProducerMultiXML' => array('class_name' => 'WineProducerMultiXMLMigration'),
-      'WineProducerXMLPull' => array('class_name' => 'WineProducerXMLPullMigration'),
-      'WineWine' => array('class_name' => 'WineWineMigration'),
-      'WineComment' => array('class_name' => 'WineCommentMigration'),
-      'WineTable' => array('class_name' => 'WineTableMigration'),
-      'WineFinish' => array('class_name' => 'WineFinishMigration'),
-      'WineUpdates' => array('class_name' => 'WineUpdatesMigration'),
-      'WineCommentUpdates' => array('class_name' => 'WineCommentUpdatesMigration'),
-      'WineVarietyUpdates' => array('class_name' => 'WineVarietyUpdatesMigration'),
-      'WineUserUpdates' => array('class_name' => 'WineUserUpdatesMigration'),
+      'BeerTerm' => array(
+        'class_name' => 'BeerTermMigration',
+        'group_name' => 'beer',
+      ),
+      'BeerUser' => array(
+        'class_name' => 'BeerUserMigration',
+        'group_name' => 'beer',
+      ),
+      'BeerNode' => array(
+        'class_name' => 'BeerNodeMigration',
+        'group_name' => 'beer',
+        // You may optionally declare dependencies for your migration - other
+        // migrations which should run first. In this case, terms assigned to our
+        // nodes and the authors of the nodes should be migrated before the nodes
+        // themselves.
+        'dependencies' => array(
+          'BeerTerm',
+          'BeerUser',
+        ),
+        // Here is where we add field mappings which may override those
+        // specified in the group constructor.
+        'field_mappings' => array(
+          $translate_mapping,
+          $ignore_mapping,
+        ),
+      ),
+      'BeerComment' => array(
+        'class_name' => 'BeerCommentMigration',
+        'group_name' => 'beer',
+        'dependencies' => array(
+          'BeerUser',
+          'BeerNode',
+        ),
+      ),
+      'WinePrep' => array(
+        'class_name' => 'WinePrepMigration',
+        'group_name' => 'wine',
+      ),
+      'WineVariety' => array(
+        'class_name' => 'WineVarietyMigration',
+        'group_name' => 'wine',
+      ),
+      'WineRegion' => array(
+        'class_name' => 'WineRegionMigration',
+        'group_name' => 'wine',
+      ),
+      'WineBestWith' => array(
+        'class_name' => 'WineBestWithMigration',
+        'group_name' => 'wine',
+      ),
+      'WineFileCopy' => array(
+        'class_name' => 'WineFileCopyMigration',
+        'group_name' => 'wine',
+        'dependencies' => array('WinePrep'),
+      ),
+      'WineFileBlob' => array(
+        'class_name' => 'WineFileBlobMigration',
+        'group_name' => 'wine',
+        'dependencies' => array('WinePrep'),
+      ),
+      'WineRole' => array(
+        'class_name' => 'WineRoleMigration',
+        'group_name' => 'wine',
+        // TIP: Regular dependencies, besides enforcing (in the absence of
+        // --force) the run order of migrations, affect the sorting of
+        // migrations on display. You can use soft dependencies to affect just
+        // the display order when the migrations aren't technically required to
+        // run in a certain order. In this case, we want the role migration to
+        // appear after the file migrations.
+        'soft_dependencies' => array('WineFileCopy'),
+      ),
+      'WineUser' => array(
+        'class_name' => 'WineUserMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineFileCopy',
+          'WineRole',
+        ),
+      ),
+      'WineProducer' => array(
+        'class_name' => 'WineProducerMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineRegion',
+          'WineUser',
+        ),
+      ),
+      'WineProducerXML' => array(
+        'class_name' => 'WineProducerXMLMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineRegion',
+          'WineUser',
+        ),
+      ),
+      'WineProducerNamespaceXML' => array(
+        'class_name' => 'WineProducerNamespaceXMLMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineRegion',
+          'WineUser',
+        ),
+      ),
+      'WineProducerMultiXML' => array(
+        'class_name' => 'WineProducerMultiXMLMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineRegion',
+          'WineUser',
+        ),
+      ),
+      'WineProducerMultiNamespaceXML' => array(
+        'class_name' => 'WineProducerMultiNamespaceXMLMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineRegion',
+          'WineUser',
+        ),
+      ),
+      'WineProducerXMLPull' => array(
+        'class_name' => 'WineProducerXMLPullMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineRegion',
+          'WineUser',
+        ),
+      ),
+      'WineProducerNamespaceXMLPull' => array(
+        'class_name' => 'WineProducerNamespaceXMLPullMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineRegion',
+          'WineUser',
+        ),
+      ),
+      'WineWine' => array(
+        'class_name' => 'WineWineMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineRegion',
+          'WineVariety',
+          'WineBestWith',
+          'WineUser',
+          'WineProducer',
+        ),
+      ),
+      'WineComment' => array(
+        'class_name' => 'WineCommentMigration',
+        'group_name' => 'wine',
+        'dependencies' => array(
+          'WineUser',
+          'WineWine',
+        ),
+      ),
+      'WineTable' => array(
+        'class_name' => 'WineTableMigration',
+        'group_name' => 'wine',
+        'soft_dependencies' => array('WineComment'),
+      ),
+      'WineFinish' => array(
+        'class_name' => 'WineFinishMigration',
+        'group_name' => 'wine',
+        'dependencies' => array('WineComment'),
+      ),
+      'WineUpdates' => array(
+        'class_name' => 'WineUpdatesMigration',
+        'group_name' => 'wine',
+        'dependencies' => array('WineWine'),
+        'soft_dependencies' => array('WineFinish'),
+      ),
+      'WineCommentUpdates' => array(
+        'class_name' => 'WineCommentUpdatesMigration',
+        'group_name' => 'wine',
+        'dependencies' => array('WineComment'),
+        'soft_dependencies' => array('WineUpdates'),
+      ),
+      'WineVarietyUpdates' => array(
+        'class_name' => 'WineVarietyUpdatesMigration',
+        'group_name' => 'wine',
+        'dependencies' => array('WineVariety'),
+        'soft_dependencies' => array('WineUpdates'),
+      ),
+      'WineUserUpdates' => array(
+        'class_name' => 'WineUserUpdatesMigration',
+        'group_name' => 'wine',
+        'dependencies' => array('WineUser'),
+        'soft_dependencies' => array('WineUpdates'),
+      ),
     ),
   );
   return $api;

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example.module
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example.module
@@ -2,13 +2,13 @@
 
 /**
  * @file
- * THIS SPACE INTENTIONALLY LEFT BLANK.
+ * THIS FILE INTENTIONALLY LEFT BLANK.
  *
  * Yes, there is no code in the .module file. Migrate operates almost entirely
  * through classes, and by adding any files containing class definitions to the
  * .info file, those files are automatically included only when the classes they
  * contain are referenced. The one non-class piece you need to implement is
- * hook_migrate_api(), but because .migrate.inc is registered using hook_hook_info
- * by defining your implementation of that hook in mymodule.migrate.inc, it is
- * automatically invoked only when needed.
+ * hook_migrate_api(), but because .migrate.inc is registered using
+ * hook_hook_info, by defining your implementation of that hook in
+ * example.migrate.inc, it is automatically invoked only when needed.
  */

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example_oracle/migrate_example_oracle.info
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/migrate_example_oracle/migrate_example_oracle.info
@@ -8,12 +8,12 @@ features[field][] = "node-migrate_example_oracle-field_mainimage"
 features[node][] = "migrate_example_oracle"
 files[] = "migrate_example_oracle.migrate.inc"
 name = "Migrate example - Oracle"
-package = "Migrate Examples"
+package = "Migration"
 project = "migrate_example_oracle"
 
-; Information added by drupal.org packaging script on 2012-11-07
-version = "7.x-2.5"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-2.8"
 core = "7.x"
 project = "migrate"
-datestamp = "1352299007"
+datestamp = "1435760949"
 

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/wine.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/wine.inc
@@ -13,24 +13,20 @@
 /**
  * Abstract intermediate class holding common settings.
  */
-abstract class AdvancedExampleMigration extends DynamicMigration {
+abstract class AdvancedExampleMigration extends Migration {
+  /**
+   * Text format object for our migrate_example format.
+   * @var
+   */
   public $basicFormat;
 
-  public function __construct() {
-    // TIP: Migrations can be organized into groups. In this case, all the migrations
-    // derived from AdvancedExampleMigration will be part of the 'wine' group.
-    // This enables us to easily run just the wine example migrations:
-    //  drush migrate-import --group=wine
-    // The second argument to MigrateGroup::getInstance is an array of groups
-    // which should come before this when viewing migration statuses, or running
-    // migration operations using --all. Since the beer migrations in this module
-    // did not specify a group, it is in the 'default' group, so this constructor
-    // indicates that the wine migrations come after the beer migrations.
-    parent::__construct(MigrateGroup::getInstance('wine', array('default')));
+  public function __construct($arguments) {
+    parent::__construct($arguments);
 
     $this->team = array(
       new MigrateTeamMember('Jack Kramer', 'jkramer@example.com', t('Taster')),
-      new MigrateTeamMember('Linda Madison', 'lmadison@example.com', t('Winemaker')),
+      new MigrateTeamMember('Linda Madison', 'lmadison@example.com',
+                            t('Winemaker')),
     );
     $this->issuePattern = 'http://drupal.org/node/:id:';
 
@@ -39,34 +35,33 @@ abstract class AdvancedExampleMigration extends DynamicMigration {
 
     // We can do shared field mappings in the common class
     if (module_exists('path')) {
-        $this->addFieldMapping('path')
+      $this->addFieldMapping('path')
+           ->issueGroup(t('DNM'));
+      if (module_exists('pathauto')) {
+        $this->addFieldMapping('pathauto')
              ->issueGroup(t('DNM'));
-        if (module_exists('pathauto')) {
-          $this->addFieldMapping('pathauto')
-               ->issueGroup(t('DNM'));
-        }
       }
+    }
   }
 }
 
 /**
  * TIP: While usually you'll create true migrations - processes that copy data
- * from some source into Drupal - you can also define processing steps for either
- * the import or rollback stages that take other actions. In this case, we want
- * to disable auto_nodetitle while the migration steps run. We'll re-enable it
- * over in WineFinishMigration.
+ * from some source into Drupal - you can also define processing steps for
+ * either the import or rollback stages that take other actions. In this case,
+ * we want to disable auto_nodetitle while the migration steps run. We'll
+ * re-enable it over in WineFinishMigration.
  */
 class WinePrepMigration extends MigrationBase {
   // Track whether the auto_nodetitle was originally enabled so we know whether
   // to re-enable it. This is public so WineFinishMigration can reference it.
   public static $wasEnabled = FALSE;
 
-  public function __construct() {
-    // Because we're derived directly from migrationBase rather than AdvancedExampleMigration,
-    // we must specify the group again here.
-    parent::__construct(MigrateGroup::getInstance('wine', array('default')));
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('If auto_nodetitle is present, disable it for the duration');
   }
+
   // Define isComplete(), returning a boolean, to indicate whether dependent
   // migrations may proceed
   public function isComplete() {
@@ -78,6 +73,7 @@ class WinePrepMigration extends MigrationBase {
       return TRUE;
     }
   }
+
   // Implement any action you want to occur during an import process in an
   // import() method (alternatively, if you have an action which you want to
   // run during rollbacks, define a rollback() method).
@@ -91,17 +87,37 @@ class WinePrepMigration extends MigrationBase {
       self::$wasEnabled = FALSE;
       self::displayMessage(t('Auto_nodetitle is already disabled'), 'success');
     }
-    // Must return one of the MigrationBase RESULT constants
+    // import() must return one of the MigrationBase RESULT constants.
     return MigrationBase::RESULT_COMPLETED;
   }
 }
 
-// The term migrations are very similar - implement the commonalities here
+// The term migrations are very similar - implement the commonalities here (yes,
+// two layers of abstraction).
 abstract class WineTermMigration extends AdvancedExampleMigration {
-  public function __construct($type, $vocabulary_name, $description) {
-    parent::__construct();
+  // The type, vocabulary machine name, and description are the only
+  // differences among the incoming vocabularies, so pass them through the
+  // constructor - you'll see below that the individual term migrations classes
+  // thus become very simple.
+  public function __construct($arguments, $type, $vocabulary_name,
+                              $description) {
+    parent::__construct($arguments);
     $this->description = $description;
+
+    // Best practice as of Migrate 2.6 is to specify dependencies in
+    // hook_migrate_api. However, in this case, since we have a common class
+    // for a few different migrations, we'll specify this dependency here
+    // rather than repeatedly in hook_migrate_api().
     $this->dependencies = array('WinePrep');
+
+    $query = db_select('migrate_example_wine_categories', 'wc')
+             ->fields('wc', array('categoryid', 'name', 'details',
+                                  'category_parent', 'ordering'))
+             ->condition('type', $type)
+             // This sort assures that parents are saved before children.
+             ->orderBy('category_parent', 'ASC');
+    $this->source = new MigrateSourceSQL($query);
+    $this->destination = new MigrateDestinationTerm($vocabulary_name);
     $this->map = new MigrateSQLMap($this->machineName,
         array(
           'categoryid' => array('type' => 'int',
@@ -111,14 +127,6 @@ abstract class WineTermMigration extends AdvancedExampleMigration {
         ),
         MigrateDestinationTerm::getKeySchema()
       );
-
-    $query = db_select('migrate_example_wine_categories', 'wc')
-             ->fields('wc', array('categoryid', 'name', 'details', 'category_parent', 'ordering'))
-             ->condition('type', $type)
-             // This sort assures that parents are saved before children.
-             ->orderBy('category_parent', 'ASC');
-    $this->source = new MigrateSourceSQL($query);
-    $this->destination = new MigrateDestinationTerm($vocabulary_name);
 
     // Mapped fields
     $this->addFieldMapping('name', 'name');
@@ -138,134 +146,164 @@ abstract class WineTermMigration extends AdvancedExampleMigration {
 }
 
 class WineVarietyMigration extends WineTermMigration {
-  public function __construct() {
-    parent::__construct('variety', 'migrate_example_wine_varieties',
+  public function __construct($arguments) {
+    parent::__construct($arguments, 'variety', 'migrate_example_wine_varieties',
       t('Migrate varieties from the source database to taxonomy terms'));
   }
 }
 
 class WineRegionMigration extends WineTermMigration {
-  public function __construct() {
-    parent::__construct('region', 'migrate_example_wine_regions',
+  public function __construct($arguments) {
+    parent::__construct($arguments, 'region', 'migrate_example_wine_regions',
       t('Migrate regions from the source database to taxonomy terms'));
   }
 }
 
 class WineBestWithMigration extends WineTermMigration {
-  public function __construct() {
-    parent::__construct('best_with', 'migrate_example_wine_best_with',
+  public function __construct($arguments) {
+    parent::__construct($arguments, 'best_with', 'migrate_example_wine_best_with',
       t('Migrate "Best With" from the source database to taxonomy terms'));
   }
 }
 
 /**
- * TIP: Files can be migrated directly by themselves, by using the MigrateDestinationFile
- * class. This will copy the files themselves from the source, and set up the
- * Drupal file tables appropriately.
+ * TIP: Files can be migrated directly by themselves, by using the
+ * MigrateDestinationFile class. This will copy the files themselves from the
+ * source, and set up the Drupal file tables appropriately. Referencing them
+ * in, say, a node field later is then simple.
  */
 class WineFileCopyMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Profile images');
-    $this->dependencies = array('WinePrep');
-    $this->map = new MigrateSQLMap($this->machineName,
-        array('imageid' => array(
-                'type' => 'int',
-                'unsigned' => TRUE,
-                'not null' => TRUE,
-                'description' => 'Image ID.'
-                )
-             ),
-        MigrateDestinationFile::getKeySchema()
-    );
+
     $query = db_select('migrate_example_wine_files', 'wf')
              ->fields('wf', array('imageid', 'url'))
              ->isNull('wineid');
     $this->source = new MigrateSourceSQL($query);
-
     $this->destination = new MigrateDestinationFile();
+    $this->map = new MigrateSQLMap($this->machineName,
+        array('imageid' => array(
+              'type' => 'int',
+              'unsigned' => TRUE,
+              'not null' => TRUE,
+              'description' => 'Image ID.'
+              )
+           ),
+        MigrateDestinationFile::getKeySchema()
+    );
 
     // In the simplest case, just map the incoming URL to 'value'.
     $this->addFieldMapping('value', 'url');
 
-    $this->addUnmigratedDestinations(array('fid', 'uid', 'timestamp',
-      'destination_dir', 'destination_file', 'source_dir', 'preserve_files',
-      'file_replace'));
-    $this->removeFieldMapping('path');
+    $this->addUnmigratedDestinations(array(
+      'destination_dir',
+      'destination_file',
+      'fid',
+      'file_replace',
+      'preserve_files',
+      'source_dir',
+      'timestamp',
+      'uid',
+      'urlencode',
+    ));
+
     $this->removeFieldMapping('pathauto');
   }
 }
 
 /**
  * Migration class to test importing from a BLOB column into a file entity.
- * Typically, one would use this OR import into a File Field.
+ *
  * @see MigrateExampleOracleNode()
  */
 class WineFileBlobMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Example migration from BLOB column into files.');
-    $this->dependencies = array('WinePrep');
-    $this->map = new MigrateSQLMap($this->machineName,
-        array('imageid' => array(
-                'type' => 'int',
-                'unsigned' => TRUE,
-                'not null' => TRUE,
-                'description' => 'Image ID.'
-                )
-             ),
-        MigrateDestinationFile::getKeySchema()
-    );
+
     $query = db_select('migrate_example_wine_blobs', 'wf')
              ->fields('wf', array('imageid', 'imageblob'));
     $this->source = new MigrateSourceSQL($query);
 
     // Note that the WineFileCopyMigration example let the second argument,
-    // the file_class, to default to MigrateFileUri, indicating that the
+    // the file_class, default to MigrateFileUri, indicating that the
     // 'value' we're passing was a URI. In this case, we're passing a blob, so
     // tell the destination to expect it.
     $this->destination = new MigrateDestinationFile('file', 'MigrateFileBlob');
 
+    $this->map = new MigrateSQLMap($this->machineName,
+        array('imageid' => array(
+              'type' => 'int',
+              'unsigned' => TRUE,
+              'not null' => TRUE,
+              'description' => 'Image ID.'
+              )
+           ),
+        MigrateDestinationFile::getKeySchema()
+    );
+
     // Basic fields
-    $this->addFieldMapping('uid')
-         ->defaultValue(1);
-    // The destination filename must be specified for blobs
-    $this->addFieldMapping('destination_file')
-         ->defaultValue('druplicon.png');
     $this->addFieldMapping('value', 'imageblob')
          ->description('An image blob in the DB');
 
-    // Unmapped destination fields
-    $this->addUnmigratedDestinations(array('fid', 'timestamp',
-      'destination_dir', 'file_replace', 'preserve_files'));
+    // The destination filename must be specified for blobs
+    $this->addFieldMapping('destination_file')
+         ->defaultValue('druplicon.png');
 
-    // Our base class mapped these since most migrations use them, but not this
-    // one, so remove them
-    $this->removeFieldMapping('path');
+    $this->addFieldMapping('uid')
+         ->defaultValue(1);
+
+    // Unmapped destination fields
+    $this->addUnmigratedDestinations(array(
+      'destination_dir',
+      'fid',
+      'file_replace',
+      'preserve_files',
+      'timestamp',
+    ));
+
     $this->removeFieldMapping('pathauto');
   }
 }
 
 class WineRoleMigration extends XMLMigration {
-  public function __construct() {
-    parent::__construct(MigrateGroup::getInstance('wine', array('default')));
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('XML feed (multi items) of roles (positions)');
 
-    // TIP: Regular dependencies, besides enforcing (in the absence of --force)
-    // the run order of migrations, affect the sorting of migrations on display.
-    // You can use soft dependencies to affect just the display order when the
-    // migrations aren't technically required to run in a certain order. In this
-    // case, we want the role migration to appear after the file migration.
-    $this->softDependencies = array('WineFileCopy');
-
-    // There isn't a consistent way to automatically identify appropriate "fields"
-    // from an XML feed, so we pass an explicit list of source fields
+    // There isn't a consistent way to automatically identify appropriate
+    // "fields" from an XML feed, so we pass an explicit list of source fields
     $fields = array(
       'name' => t('Position name'),
     );
 
-    // The source ID here is the one retrieved from each data item in the XML file, and
-    // used to identify specific items
+    // IMPORTANT: Do not try this at home! We have included importable files
+    // with the migrate_example module so it can be very simply installed and
+    // run, but you should never include any data you want to keep private
+    // (especially user data like email addresses, phone numbers, etc.) in the
+    // module directory. Your source data should be outside of the webroot, and
+    // should not be anywhere where it may get committed into a revision control
+    // system.
+
+    // This can also be an URL instead of a local file path.
+    $xml_folder = DRUPAL_ROOT . '/' .
+                  drupal_get_path('module', 'migrate_example') . '/xml/';
+    $items_url = $xml_folder . 'positions.xml';
+    // This is the xpath identifying the items to be migrated, relative to the
+    // document.
+    $item_xpath = '/positions/position';
+    // This is the xpath relative to the individual items - thus the full xpath
+    // of an ID will be /positions/position/sourceid.
+    $item_ID_xpath = 'sourceid';
+
+    $items_class = new MigrateItemsXML($items_url, $item_xpath, $item_ID_xpath);
+    $this->source = new MigrateSourceMultiItems($items_class, $fields);
+
+    $this->destination = new MigrateDestinationRole();
+
+    // The source ID here is the one retrieved from each data item in the XML
+    // file, and used to identify specific items
     $this->map = new MigrateSQLMap($this->machineName,
       array(
         'sourceid' => array(
@@ -277,62 +315,43 @@ class WineRoleMigration extends XMLMigration {
       MigrateDestinationRole::getKeySchema()
     );
 
-    // IMPORTANT: Do not try this at home! We have included importable files
-    // with the migrate_example module so it can be very simply installed and
-    // run, but you should never include any data you want to keep private
-    // (especially user data like email addresses, phone numbers, etc.) in the
-    // module directory. Your source data should be outside of the webroot, and
-    // should not be anywhere where it may get committed into a revision control
-    // system.
-
-    // This can also be an URL instead of a file path.
-    $xml_folder = DRUPAL_ROOT . '/' . drupal_get_path('module', 'migrate_example') . '/xml/';
-    $items_url = $xml_folder . 'positions.xml';
-    $item_xpath = '/positions/position';  // relative to document
-    $item_ID_xpath = 'sourceid';         // relative to item_xpath and gets assembled
-                                         // into full path /producers/producer/sourceid
-
-    $items_class = new MigrateItemsXML($items_url, $item_xpath, $item_ID_xpath);
-    $this->source = new MigrateSourceMultiItems($items_class, $fields);
-
-    $this->destination = new MigrateDestinationRole();
-
     $this->addFieldMapping('name', 'name')
          ->xpath('name');
+
     $this->addUnmigratedDestinations(array('weight'));
   }
 }
 
 class WineUserMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Wine Drinkers of the world');
-    $this->dependencies = array('WinePrep', 'WineFileCopy', 'WineRole');
-    $this->map = new MigrateSQLMap($this->machineName,
-        array('accountid' => array(
-                'type' => 'int',
-                'unsigned' => TRUE,
-                'not null' => TRUE,
-                'description' => 'Account ID.'
-                )
-             ),
-        MigrateDestinationUser::getKeySchema()
-    );
+
     $query = db_select('migrate_example_wine_account', 'wa')
              ->fields('wa', array('accountid', 'status', 'posted', 'name',
                 'password', 'mail', 'last_access', 'last_login',
                 'original_mail', 'sig', 'sex', 'imageid', 'positions'));
     $this->source = new MigrateSourceSQL($query);
     $this->destination = new MigrateDestinationUser();
+    $this->map = new MigrateSQLMap($this->machineName,
+        array('accountid' => array(
+              'type' => 'int',
+              'unsigned' => TRUE,
+              'not null' => TRUE,
+              'description' => 'Account ID.'
+              )
+           ),
+        MigrateDestinationUser::getKeySchema()
+    );
 
     // Mapped fields
     $this->addSimpleMappings(array('name', 'status', 'mail'));
-    $this->addFieldMapping('created', 'posted')
-         ->description('See prepare method');
-    $this->addFieldMapping('access', 'last_access')
-         ->description('See prepare method');
-    $this->addFieldMapping('login', 'last_login')
-         ->description('See prepare method');
+    // Note that these date/time values are coming in as ISO strings, but
+    // Drupal uses UNIX timestamps. The user destination automatically
+    // translates them as necessary.
+    $this->addFieldMapping('created', 'posted');
+    $this->addFieldMapping('access', 'last_access');
+    $this->addFieldMapping('login', 'last_login');
     $this->addFieldMapping('pass', 'password');
     $this->addFieldMapping('roles', 'positions')
          ->separator(',')
@@ -349,22 +368,24 @@ class WineUserMigration extends AdvancedExampleMigration {
     // Unmapped source fields
 
     // Unmapped destination fields
-    $this->addUnmigratedDestinations(array('theme', 'timezone', 'language',
-      'is_new', 'field_migrate_example_favbeers', 'role_names', 'data'));
+    $this->addUnmigratedDestinations(array(
+      'data',
+      'is_new',
+      'language',
+      'role_names',
+      'theme',
+      'timezone',
+    ));
   }
 
   public function prepare(stdClass $account, stdClass $row) {
-    // Source dates are in ISO format.
-    // Because the mappings above have been applied, $account->created contains
-    // the date/time string now - we could also pass $row->posted here.
-    $account->created = strtotime($account->created);
-    $account->access = strtotime($account->access);
-    $account->login = strtotime($account->login);
-
     // Gender data comes in as M/F, needs to be saved as Male=0/Female=1
     // TIP: Note that the Migration prepare method is called after all other
     // prepare handlers. Most notably, the field handlers have had their way
-    // and created field arrays, so we have to save in the same format.
+    // and created field arrays, so we have to save in the same format. In this
+    // case, best practice would be to use a callback instead (see below), we're
+    // just demonstrating here what the $account object looks like at this
+    // stage.
     switch ($row->sex) {
       case 'm':
       case 'M':
@@ -382,10 +403,9 @@ class WineUserMigration extends AdvancedExampleMigration {
 }
 
 class WineProducerMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Wine producers of the world');
-    $this->dependencies = array('WineRegion', 'WineUser');
 
     $this->map = new MigrateSQLMap($this->machineName,
       array(
@@ -400,10 +420,11 @@ class WineProducerMigration extends AdvancedExampleMigration {
     );
 
     $query = db_select('migrate_example_wine_producer', 'p')
-             ->fields('p', array('producerid', 'name', 'body', 'excerpt', 'accountid'));
+             ->fields('p', array('producerid', 'name', 'body', 'excerpt',
+                                 'accountid'));
     // Region term is singletons, handled straighforwardly
     $query->leftJoin('migrate_example_wine_category_producer', 'reg',
-      "p.producerid = reg.producerid");
+      'p.producerid = reg.producerid');
     $query->addField('reg', 'categoryid', 'region');
 
     $this->source = new MigrateSourceSQL($query);
@@ -427,12 +448,27 @@ class WineProducerMigration extends AdvancedExampleMigration {
     // No unmapped source fields
 
     // Unmapped destination fields
-    $this->addUnmigratedDestinations(array('is_new', 'created', 'changed',
-      'status', 'promote', 'revision', 'language', 'revision_uid', 'log', 'tnid',
-      'body:format', 'body:language', 'migrate_example_wine_regions:create_term',
-      'comment'));
+    $this->addUnmigratedDestinations(array(
+        'body:format',
+      'changed',
+      'comment',
+      'created',
+      'is_new',
+      'language',
+      'log',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'tnid',
+      'translate',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+    ));
+
     if (module_exists('statistics')) {
-      $this->addUnmigratedDestinations(array('totalcount', 'daycount', 'timestamp'));
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
     }
   }
 }
@@ -446,19 +482,44 @@ class WineProducerMigration extends AdvancedExampleMigration {
  * from XMLMigration instead of Migration.
  */
 class WineProducerXMLMigration extends XMLMigration {
-  public function __construct() {
-    parent::__construct(MigrateGroup::getInstance('wine', array('default')));
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('XML feed of wine producers of the world');
-    $this->dependencies = array('WineRegion', 'WineUser');
 
-    // There isn't a consistent way to automatically identify appropriate "fields"
-    // from an XML feed, so we pass an explicit list of source fields
+    // There isn't a consistent way to automatically identify appropriate
+    // "fields" from an XML feed, so we pass an explicit list of source fields.
     $fields = array(
       'name' => t('Producer name'),
       'description' => t('Description of producer'),
       'authorid' => t('Numeric ID of the author'),
       'region' => t('Name of region'),
     );
+
+    // IMPORTANT: Do not try this at home! We have included importable files
+    // with the migrate_example module so it can be very simply installed and
+    // run, but you should never include any data you want to keep private
+    // (especially user data like email addresses, phone numbers, etc.) in the
+    // module directory. Your source data should be outside of the webroot, and
+    // should not be anywhere where it may get committed into a revision control
+    // system.
+
+    // This can also be an URL instead of a file path.
+    $xml_folder = DRUPAL_ROOT . '/' .
+                  drupal_get_path('module', 'migrate_example') . '/xml/';
+    $list_url = $xml_folder . 'index.xml';
+    // Each ID retrieved from the list URL will be plugged into :id in the
+    // item URL to fetch the specific objects.
+    $item_url = $xml_folder . ':id.xml';
+
+    // We use the MigrateSourceList class for any source where we obtain the
+    // list of IDs to process separately from the data for each item. The
+    // listing and item are represented by separate classes, so for example we
+    // could replace the XML listing with a file directory listing, or the XML
+    // item with a JSON item.
+    $this->source = new MigrateSourceList(new MigrateListXML($list_url),
+      new MigrateItemXML($item_url), $fields);
+
+    $this->destination = new MigrateDestinationNode('migrate_example_producer');
 
     // The source ID here is the one retrieved from the XML listing file, and
     // used to identify the specific item's file
@@ -473,35 +534,10 @@ class WineProducerXMLMigration extends XMLMigration {
       MigrateDestinationNode::getKeySchema()
     );
 
-    // IMPORTANT: Do not try this at home! We have included importable files
-    // with the migrate_example module so it can be very simply installed and
-    // run, but you should never include any data you want to keep private
-    // (especially user data like email addresses, phone numbers, etc.) in the
-    // module directory. Your source data should be outside of the webroot, and
-    // should not be anywhere where it may get committed into a revision control
-    // system.
-
-    // This can also be an URL instead of a file path.
-    $xml_folder = DRUPAL_ROOT . '/' . drupal_get_path('module', 'migrate_example') . '/xml/';
-    $list_url = $xml_folder . 'index.xml';
-    // Each ID retrieved from the list URL will be plugged into :id in the
-    // item URL to fetch the specific objects.
-    $item_url = $xml_folder . ':id.xml';
-
-    // We use the MigrateSourceList class for any source where we obtain the list
-    // of IDs to process separately from the data for each item. The listing
-    // and item are represented by separate classes, so for example we could
-    // replace the XML listing with a file directory listing, or the XML item
-    // with a JSON item.
-    $this->source = new MigrateSourceList(new MigrateListXML($list_url),
-      new MigrateItemXML($item_url), $fields);
-
-    $this->destination = new MigrateDestinationNode('migrate_example_producer');
-
     // TIP: Note that for XML sources, in addition to the source field passed to
     // addFieldMapping (the name under which it will be saved in the data row
-    // passed through the migration process) we specify the Xpath used to retrieve
-    // the value from the XML.
+    // passed through the migration process) we specify the Xpath used to
+    // retrieve the value from the XML.
     $this->addFieldMapping('title', 'name')
          ->xpath('/producer/name');
     $this->addFieldMapping('uid', 'authorid')
@@ -513,21 +549,151 @@ class WineProducerXMLMigration extends XMLMigration {
     $this->addFieldMapping('body', 'description')
          ->xpath('/producer/description');
 
-    $this->addUnmigratedDestinations(array('revision_uid', 'created', 'changed',
-      'status', 'promote', 'sticky', 'revision', 'log', 'language', 'tnid',
-      'is_new', 'body:summary', 'body:format', 'body:language',
-      'migrate_example_wine_regions:source_type', 'migrate_example_wine_regions:create_term',
-      'comment'));
-    if (module_exists('path')) {
+    $this->addUnmigratedDestinations(array(
+        'body:summary', 'body:format',
+      'changed',
+      'comment',
+      'created',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+        'migrate_example_wine_regions:source_type',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'sticky',
+      'tnid',
+      'translate',
+    ));
+
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
       $this->addFieldMapping('path')
            ->issueGroup(t('DNM'));
-      if (module_exists('pathauto')) {
+      if (isset($destination_fields['pathauto'])) {
         $this->addFieldMapping('pathauto')
              ->issueGroup(t('DNM'));
       }
     }
     if (module_exists('statistics')) {
-      $this->addUnmigratedDestinations(array('totalcount', 'daycount', 'timestamp'));
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
+    }
+  }
+}
+
+/**
+ * TIP: An example of importing from an XML feed with namespaces.
+ * See the files in the xml directory - index2.xml contains a list of IDs
+ * to import, and <id>.xml is the data for a given producer.
+ *
+ * Note that, if basing a migration on an XML source, you need to derive it
+ * from XMLMigration instead of Migration.
+ */
+class WineProducerNamespaceXMLMigration extends XMLMigration {
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    $this->description = t('Namespaced XML feed of wine producers of the world');
+
+    // There isn't a consistent way to automatically identify appropriate
+    // "fields" from an XML feed, so we pass an explicit list of source fields.
+    $fields = array(
+      'pr:name' => t('Producer name'),
+      'pr:description' => t('Description of producer'),
+      'pr:authorid' => t('Numeric ID of the author'),
+      'pr:region' => t('Name of region'),
+    );
+
+    // IMPORTANT: Do not try this at home! We have included importable files
+    // with the migrate_example module so it can be very simply installed and
+    // run, but you should never include any data you want to keep private
+    // (especially user data like email addresses, phone numbers, etc.) in the
+    // module directory. Your source data should be outside of the webroot, and
+    // should not be anywhere where it may get committed into a revision control
+    // system.
+
+    // This can also be an URL instead of a file path.
+    $xml_folder = DRUPAL_ROOT . '/' .
+                  drupal_get_path('module', 'migrate_example') . '/xml/';
+    $list_url = $xml_folder . 'index2.xml';
+    // Each ID retrieved from the list URL will be plugged into :id in the
+    // item URL to fetch the specific objects.
+    $item_url = $xml_folder . ':id.xml';
+
+    // We use the MigrateSourceList class for any source where we obtain the
+    // list of IDs to process separately from the data for each item. The
+    // listing and item are represented by separate classes, so for example we
+    // could replace the XML listing with a file directory listing, or the XML
+    // item with a JSON item.
+    $list = new MigrateListXML($list_url, array('wn' => 'http://www.wine.org/wine'));
+    $item = new MigrateItemXML($item_url, array('pr' => 'http://www.wine.org/wine-producers'));
+    $this->source = new MigrateSourceList($list, $item, $fields);
+
+    $this->destination = new MigrateDestinationNode('migrate_example_producer');
+
+    // The source ID here is the one retrieved from the XML listing file, and
+    // used to identify the specific item's file
+    $this->map = new MigrateSQLMap($this->machineName,
+      array(
+        'sourceid' => array(
+          'type' => 'varchar',
+          'length' => 4,
+          'not null' => TRUE,
+        )
+      ),
+      MigrateDestinationNode::getKeySchema()
+    );
+
+    // TIP: Note that for XML sources, in addition to the source field passed to
+    // addFieldMapping (the name under which it will be saved in the data row
+    // passed through the migration process) we specify the Xpath used to
+    // retrieve the value from the XML.
+    $this->addFieldMapping('title', 'pr:name')
+         ->xpath('/pr:producer/pr:name');
+    $this->addFieldMapping('uid', 'pr:authorid')
+         ->xpath('/pr:producer/pr:authorid')
+         ->sourceMigration('WineUser')
+         ->defaultValue(1);
+    $this->addFieldMapping('migrate_example_wine_regions', 'pr:region')
+         ->xpath('/pr:producer/pr:region');
+    $this->addFieldMapping('body', 'pr:description')
+         ->xpath('/pr:producer/pr:description');
+
+    $this->addUnmigratedDestinations(array(
+        'body:summary', 'body:format',
+      'changed',
+      'comment',
+      'created',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+        'migrate_example_wine_regions:source_type',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'sticky',
+      'tnid',
+      'translate',
+    ));
+
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
+      $this->addFieldMapping('path')
+           ->issueGroup(t('DNM'));
+      if (isset($destination_fields['pathauto'])) {
+        $this->addFieldMapping('pathauto')
+             ->issueGroup(t('DNM'));
+      }
+    }
+    if (module_exists('statistics')) {
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
     }
   }
 }
@@ -542,31 +708,18 @@ class WineProducerXMLMigration extends XMLMigration {
  * from XMLMigration instead of Migration.
  */
 class WineProducerMultiXMLMigration extends XMLMigration {
-  public function __construct() {
-    parent::__construct(MigrateGroup::getInstance('wine', array('default')));
-    $this->description = t('XML feed (multi items) of wine producers of the world');
-    $this->dependencies = array('WineRegion', 'WineUser');
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    $this->description =
+      t('XML feed (multi items) of wine producers of the world');
 
-    // There isn't a consistent way to automatically identify appropriate "fields"
-    // from an XML feed, so we pass an explicit list of source fields
+    // There isn't a consistent way to automatically identify appropriate
+    // "fields" from an XML feed, so we pass an explicit list of source fields.
     $fields = array(
       'name' => t('Producer name'),
       'description' => t('Description of producer'),
       'authorid' => t('Numeric ID of the author'),
       'region' => t('Name of region'),
-    );
-
-    // The source ID here is the one retrieved from each data item in the XML file, and
-    // used to identify specific items
-    $this->map = new MigrateSQLMap($this->machineName,
-      array(
-        'sourceid' => array(
-          'type' => 'varchar',
-          'length' => 4,
-          'not null' => TRUE,
-        )
-      ),
-      MigrateDestinationNode::getKeySchema()
     );
 
     // IMPORTANT: Do not try this at home! We have included importable files
@@ -581,29 +734,44 @@ class WineProducerMultiXMLMigration extends XMLMigration {
     $xml_folder = DRUPAL_ROOT . '/' . drupal_get_path('module', 'migrate_example') . '/xml/';
     $items_url = $xml_folder . 'producers.xml';
 
-    // We use the MigrateSourceMultiItems class for any source where we obtain the list
-    // of IDs to process and the data for each item from the same file. Typically the data
-    // for an item is not contained in a single line within the source file. Examples include
-    // multiple items defined in a single xml file or a single json file where in both cases
-    // the id is part of the item.
+    // We use the MigrateSourceMultiItems class for any source where we obtain
+    // the list of IDs to process and the data for each item from the same
+    // file. Examples include multiple items defined in a single xml file or a
+    // single json file where in both cases the id is part of the item.
 
-    $item_xpath = '/producers/producer';  // relative to document
-
-    $item_ID_xpath = 'sourceid';         // relative to item_xpath and gets assembled
-                                         // into full path /producers/producer/sourceid
+    // This is the xpath identifying the items to be migrated, relative to the
+    // document.
+    $item_xpath = '/producers/producer';
+    // This is the xpath relative to the individual items - thus the full xpath
+    // of an ID will be /producers/producer/sourceid.
+    $item_ID_xpath = 'sourceid';
 
     $items_class = new MigrateItemsXML($items_url, $item_xpath, $item_ID_xpath);
     $this->source = new MigrateSourceMultiItems($items_class, $fields);
 
     $this->destination = new MigrateDestinationNode('migrate_example_producer');
 
+    // The source ID here is the one retrieved from each data item in the XML
+    // file, and used to identify specific items
+    $this->map = new MigrateSQLMap($this->machineName,
+      array(
+        'sourceid' => array(
+          'type' => 'varchar',
+          'length' => 4,
+          'not null' => TRUE,
+        )
+      ),
+      MigrateDestinationNode::getKeySchema()
+    );
+
     // TIP: Note that for XML sources, in addition to the source field passed to
     // addFieldMapping (the name under which it will be saved in the data row
-    // passed through the migration process) we specify the Xpath used to retrieve
-    // the value from the XML.
-    // TIP: Note that all xpaths for fields begin at the last element of the item
-    // xpath since each item xml chunk is processed individually.
-    // (ex. xpath=name is equivalent to a full xpath of /producers/producer/name)
+    // passed through the migration process) we specify the Xpath used to
+    // retrieve the value from the XML.
+    // TIP: Note that all xpaths for fields begin at the last element of the
+    // item xpath since each item xml chunk is processed individually.
+    // (ex. xpath=name is equivalent to a full xpath of
+    // /producers/producer/name).
     $this->addFieldMapping('title', 'name')
          ->xpath('name');
     $this->addFieldMapping('uid', 'authorid')
@@ -615,54 +783,64 @@ class WineProducerMultiXMLMigration extends XMLMigration {
     $this->addFieldMapping('body', 'description')
          ->xpath('description');
 
-    $this->addUnmigratedDestinations(array('revision_uid', 'created', 'changed',
-      'status', 'promote', 'sticky', 'revision', 'log', 'language', 'tnid',
-      'is_new', 'body:summary', 'body:format', 'body:language',
-      'migrate_example_wine_regions:source_type', 'migrate_example_wine_regions:create_term',
-      'comment'));
-    if (module_exists('path')) {
+    $this->addUnmigratedDestinations(array(
+        'body:summary', 'body:format',
+      'changed',
+      'comment',
+      'created',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+        'migrate_example_wine_regions:source_type',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'sticky',
+      'tnid',
+      'translate',
+    ));
+
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
       $this->addFieldMapping('path')
            ->issueGroup(t('DNM'));
-      if (module_exists('pathauto')) {
+      if (isset($destination_fields['pathauto'])) {
         $this->addFieldMapping('pathauto')
              ->issueGroup(t('DNM'));
       }
     }
     if (module_exists('statistics')) {
-      $this->addUnmigratedDestinations(array('totalcount', 'daycount', 'timestamp'));
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
     }
   }
 }
 
 /**
- * TIP: An alternative approach using MigrateSourceSQL. This uses a different
- * XML library, which advances element-by-element through the XML file rather
- * than reading in the whole file. This source will work better with large XML
- * files, but is slower for small files and has a more restrictive query lanaguage
- * for selecting the elements to process.
+ * TIP: An example of importing from an XML feed with namespaces, where both
+ * the id and the data to import are in the same file.  The id is a part of
+ * the data. See the file in the xml directory - producers3.xml which contains
+ * all IDs and producer data for this example.
+ *
+ * Note that, if basing a migration on an XML source, you need to derive it
+ * from XMLMigration instead of Migration.
  */
-class WineProducerXMLPullMigration extends XMLMigration {
-  public function __construct() {
-    parent::__construct(MigrateGroup::getInstance('wine', array('default')));
-    $this->description = t('XML feed (pull) of wine producers of the world');
-    $this->dependencies = array('WineRegion', 'WineUser');
+class WineProducerMultiNamespaceXMLMigration extends XMLMigration {
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    $this->description =
+      t('Namespaced XML feed (multi items) of wine producers of the world');
 
+    // There isn't a consistent way to automatically identify appropriate
+    // "fields" from an XML feed, so we pass an explicit list of source fields.
     $fields = array(
-      'name' => t('Producer name'),
-      'description' => t('Description of producer'),
-      'authorid' => t('Numeric ID of the author'),
-      'region' => t('Name of region'),
-    );
-
-    $this->map = new MigrateSQLMap($this->machineName,
-      array(
-        'sourceid' => array(
-          'type' => 'varchar',
-          'length' => 4,
-          'not null' => TRUE,
-        )
-      ),
-      MigrateDestinationNode::getKeySchema()
+      'pr:name' => t('Producer name'),
+      'pr:description' => t('Description of producer'),
+      'pr:authorid' => t('Numeric ID of the author'),
+      'pr:region' => t('Name of region'),
     );
 
     // IMPORTANT: Do not try this at home! We have included importable files
@@ -675,21 +853,153 @@ class WineProducerXMLPullMigration extends XMLMigration {
 
     // This can also be an URL instead of a file path.
     $xml_folder = DRUPAL_ROOT . '/' . drupal_get_path('module', 'migrate_example') . '/xml/';
+    $items_url = $xml_folder . 'producers3.xml';
+
+    // We use the MigrateSourceMultiItems class for any source where we obtain
+    // the list of IDs to process and the data for each item from the same
+    // file. Examples include multiple items defined in a single xml file or a
+    // single json file where in both cases the id is part of the item.
+
+    // This is the xpath identifying the items to be migrated, relative to the
+    // document.
+    $item_xpath = '/pr:producers/pr:producer';
+    // This is the xpath relative to the individual items - thus the full xpath
+    // of an ID will be /producers/producer/sourceid.
+    $item_ID_xpath = 'pr:sourceid';
+    // All XML namespaces used in the XML file need to be defined here too.
+    $namespaces = array('pr' => 'http://www.wine.org/wine-producers');
+
+    $items_class = new MigrateItemsXML($items_url, $item_xpath, $item_ID_xpath, $namespaces);
+    $this->source = new MigrateSourceMultiItems($items_class, $fields);
+
+    $this->destination = new MigrateDestinationNode('migrate_example_producer');
+
+    // The source ID here is the one retrieved from each data item in the XML
+    // file, and used to identify specific items
+    $this->map = new MigrateSQLMap($this->machineName,
+      array(
+        'sourceid' => array(
+          'type' => 'varchar',
+          'length' => 4,
+          'not null' => TRUE,
+        )
+      ),
+      MigrateDestinationNode::getKeySchema()
+    );
+
+    // TIP: Note that for XML sources, in addition to the source field passed to
+    // addFieldMapping (the name under which it will be saved in the data row
+    // passed through the migration process) we specify the Xpath used to
+    // retrieve the value from the XML.
+    // TIP: Note that all xpaths for fields begin at the last element of the
+    // item xpath since each item xml chunk is processed individually.
+    // (ex. xpath=name is equivalent to a full xpath of
+    // /producers/producer/name).
+    $this->addFieldMapping('title', 'pr:name')
+         ->xpath('pr:name');
+    $this->addFieldMapping('uid', 'pr:authorid')
+         ->xpath('pr:authorid')
+         ->sourceMigration('WineUser')
+         ->defaultValue(1);
+    $this->addFieldMapping('migrate_example_wine_regions', 'pr:region')
+         ->xpath('pr:region');
+    $this->addFieldMapping('body', 'pr:description')
+         ->xpath('pr:description');
+
+    $this->addUnmigratedDestinations(array(
+        'body:summary', 'body:format',
+      'changed',
+      'comment',
+      'created',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+        'migrate_example_wine_regions:source_type',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'sticky',
+      'tnid',
+      'translate',
+    ));
+
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
+      $this->addFieldMapping('path')
+           ->issueGroup(t('DNM'));
+      if (isset($destination_fields['pathauto'])) {
+        $this->addFieldMapping('pathauto')
+             ->issueGroup(t('DNM'));
+      }
+    }
+    if (module_exists('statistics')) {
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
+    }
+  }
+}
+
+/**
+ * TIP: An alternative approach using MigrateSourceSQL. This uses a different
+ * XML library, which advances element-by-element through the XML file rather
+ * than reading in the whole file. This source will work better with large XML
+ * files, but is slower for small files and has a more restrictive query
+ * language for selecting the elements to process.
+ */
+class WineProducerXMLPullMigration extends XMLMigration {
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    $this->description = t('XML feed (pull) of wine producers of the world');
+
+    $fields = array(
+      'name' => t('Producer name'),
+      'description' => t('Description of producer'),
+      'authorid' => t('Numeric ID of the author'),
+      'region' => t('Name of region'),
+    );
+
+    // IMPORTANT: Do not try this at home! We have included importable files
+    // with the migrate_example module so it can be very simply installed and
+    // run, but you should never include any data you want to keep private
+    // (especially user data like email addresses, phone numbers, etc.) in the
+    // module directory. Your source data should be outside of the webroot, and
+    // should not be anywhere where it may get committed into a revision control
+    // system.
+
+    // This can also be an URL instead of a local file path.
+    $xml_folder = DRUPAL_ROOT . '/' .
+                  drupal_get_path('module', 'migrate_example') . '/xml/';
     $items_url = $xml_folder . 'producers2.xml';
 
-    // As with MigrateSourceMultiItems, this applies where there is not a separate
-    // list of IDs to process - the source XML file is entirely self-contained.
-    // For the ID path, and xpath for each component, we can use the full xpath
-    // syntax as usual. However, the syntax to select the elements that correspond
-    // to objects to import is more limited. It must be a fully-qualified path
-    // to the element (i.e., /producers/producer rather than just //producer).
+    // As with MigrateSourceMultiItems, this applies where there is not a
+    // separate list of IDs to process - the source XML file is entirely
+    // self-contained. For the ID path, and xpath for each component, we can
+    // use the full xpath syntax as usual. However, the syntax to select the
+    // elements that correspond to objects to import is more limited. It must
+    // be a fully-qualified path to the element (i.e.,
+    // /producers/producer rather than just //producer).
     $item_xpath = '/producers/producer';  // relative to document
     $item_ID_xpath = 'sourceid';          // relative to item_xpath
 
-    $this->source = new MigrateSourceXML($items_url, $item_xpath, $item_ID_xpath,
-      $fields);
+    $this->source = new MigrateSourceXML($items_url, $item_xpath,
+                                         $item_ID_xpath, $fields);
 
     $this->destination = new MigrateDestinationNode('migrate_example_producer');
+
+    $this->map = new MigrateSQLMap($this->machineName,
+      array(
+        'sourceid' => array(
+          'type' => 'varchar',
+          'length' => 4,
+          'not null' => TRUE,
+        )
+      ),
+      MigrateDestinationNode::getKeySchema()
+    );
+
     $this->addFieldMapping('title', 'name')
          ->xpath('name');
     $this->addFieldMapping('uid', 'authorid')
@@ -701,32 +1011,208 @@ class WineProducerXMLPullMigration extends XMLMigration {
     $this->addFieldMapping('body', 'description')
          ->xpath('description');
 
-    $this->addUnmigratedDestinations(array('revision_uid', 'created', 'changed',
-      'status', 'promote', 'sticky', 'revision', 'log', 'language', 'tnid',
-      'is_new', 'body:summary', 'body:format', 'body:language',
-      'migrate_example_wine_regions:source_type', 'migrate_example_wine_regions:create_term',
-      'comment'));
-    if (module_exists('path')) {
+    $this->addUnmigratedDestinations(array(
+        'body:summary', 'body:format',
+      'changed',
+      'comment',
+      'created',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+        'migrate_example_wine_regions:source_type',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'sticky',
+      'tnid',
+      'translate',
+    ));
+
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
       $this->addFieldMapping('path')
            ->issueGroup(t('DNM'));
-      if (module_exists('pathauto')) {
+      if (isset($destination_fields['pathauto'])) {
         $this->addFieldMapping('pathauto')
              ->issueGroup(t('DNM'));
       }
     }
     if (module_exists('statistics')) {
-      $this->addUnmigratedDestinations(array('totalcount', 'daycount', 'timestamp'));
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
+    }
+  }
+}
+
+/**
+ * TIP: An alternative approach using MigrateSourceSQL. This uses a different
+ * XML library, which advances element-by-element through the XML file rather
+ * than reading in the whole file. This source will work better with large XML
+ * files, but is slower for small files and has a more restrictive query
+ * language for selecting the elements to process.
+ */
+class WineProducerNamespaceXMLPullMigration extends XMLMigration {
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    $this->description = t('XML feed with namespaces (pull) of wine producers of the world');
+
+    $fields = array(
+      'pr:name' => t('Producer name'),
+      'pr:description' => t('Description of producer'),
+      'pr:authorid' => t('Numeric ID of the author'),
+      'pr:region' => t('Name of region'),
+    );
+
+    // IMPORTANT: Do not try this at home! We have included importable files
+    // with the migrate_example module so it can be very simply installed and
+    // run, but you should never include any data you want to keep private
+    // (especially user data like email addresses, phone numbers, etc.) in the
+    // module directory. Your source data should be outside of the webroot, and
+    // should not be anywhere where it may get committed into a revision control
+    // system.
+
+    // This can also be an URL instead of a local file path.
+    $xml_folder = DRUPAL_ROOT . '/' .
+                  drupal_get_path('module', 'migrate_example') . '/xml/';
+    $items_url = $xml_folder . 'producers4.xml';
+
+    // As with MigrateSourceMultiItems, this applies where there is not a
+    // separate list of IDs to process - the source XML file is entirely
+    // self-contained. For the ID path, and xpath for each component, we can
+    // use the full xpath syntax as usual. However, the syntax to select the
+    // elements that correspond to objects to import is more limited. It must
+    // be a fully-qualified path to the element (i.e.,
+    // /producers/producer rather than just //producer).
+    $item_xpath = '/pr:producers/pr:producer';  // relative to document
+    $item_ID_xpath = 'pr:sourceid';          // relative to item_xpath
+    $namespaces = array('pr' => 'http://www.wine.org/wine-producers');
+
+    $this->source = new MigrateSourceXML($items_url, $item_xpath,
+                                         $item_ID_xpath, $fields,
+                                         array(), $namespaces);
+
+    $this->destination = new MigrateDestinationNode('migrate_example_producer');
+
+    $this->map = new MigrateSQLMap($this->machineName,
+      array(
+        'sourceid' => array(
+          'type' => 'varchar',
+          'length' => 4,
+          'not null' => TRUE,
+        )
+      ),
+      MigrateDestinationNode::getKeySchema()
+    );
+
+    $this->addFieldMapping('title', 'pr:name')
+         ->xpath('pr:name');
+    $this->addFieldMapping('uid', 'pr:authorid')
+         ->xpath('pr:authorid')
+         ->sourceMigration('WineUser')
+         ->defaultValue(1);
+    $this->addFieldMapping('migrate_example_wine_regions', 'pr:region')
+         ->xpath('pr:region');
+    $this->addFieldMapping('body', 'pr:description')
+         ->xpath('pr:description');
+
+    $this->addUnmigratedDestinations(array(
+        'body:summary', 'body:format',
+      'changed',
+      'comment',
+      'created',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+        'migrate_example_wine_regions:source_type',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'sticky',
+      'tnid',
+      'translate',
+    ));
+
+    $destination_fields = $this->destination->fields();
+    if (isset($destination_fields['path'])) {
+      $this->addFieldMapping('path')
+           ->issueGroup(t('DNM'));
+      if (isset($destination_fields['pathauto'])) {
+        $this->addFieldMapping('pathauto')
+             ->issueGroup(t('DNM'));
+      }
+    }
+    if (module_exists('statistics')) {
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
     }
   }
 }
 
 // TODO: Add node_reference field pointing to producer
 class WineWineMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Wines of the world');
-    $this->dependencies = array('WineVariety', 'WineRegion',
-      'WineBestWith', 'WineUser', 'WineProducer');
+
+    $query = db_select('migrate_example_wine', 'w')
+             ->fields('w', array('wineid', 'name', 'body', 'excerpt',
+               'accountid', 'posted', 'last_changed', 'variety', 'region',
+               'rating'));
+    $query->leftJoin('migrate_example_wine_category_wine', 'cwbw',
+      "w.wineid = cwbw.wineid");
+    $query->leftJoin('migrate_example_wine_categories', 'bw',
+      "cwbw.categoryid = bw.categoryid AND bw.type = 'best_with'");
+    // Gives a single comma-separated list of related terms
+    $query->groupBy('w.wineid');
+    $query->addExpression('GROUP_CONCAT(bw.categoryid)', 'best_with');
+
+    $count_query = db_select('migrate_example_wine', 'w');
+    $count_query->addExpression('COUNT(wineid)', 'cnt');
+
+    // TIP: By passing an array of source fields to the MigrateSourceSQL
+    // constructor, we can modify the descriptions of source fields (which just
+    // default, for SQL migrations, to table_alias.column_name), as well as add
+    // additional fields (which may be populated in prepareRow()).
+    $source_fields = array(
+      'wineid' => t('Wine ID in the old system'),
+      'name' => t('The name of the wine'),
+      'best_vintages' => t('What years were best for this wine?'),
+      'url' => t('Image URLs attached to this wine; populated in prepareRow()'),
+      'image_alt' =>
+        t('Image alt text attached to this wine; populated in prepareRow()'),
+      'image_title' =>
+        t('Image titles attached to this wine; populated in prepareRow()'),
+    );
+
+    // TIP: By default, each time a migration is run, any previously unprocessed
+    // source items are imported (along with any previously-imported items
+    // marked for update). If the source data contains a timestamp that is set
+    // to the creation time of each new item, as well as set to the update time
+    // for any existing items that are updated, then you can have those updated
+    // items automatically reimported by setting the field as your highwater
+    // field.
+    $this->highwaterField = array(
+      'name' => 'last_changed', // Column to be used as highwater mark
+      'alias' => 'w',           // Table alias containing that column
+      'type' => 'int',          // By default, highwater marks are assumed to
+                                // be lexicographically sortable (e.g.,
+                                // '2011-05-19 17:53:12'). To properly deal with
+                                // integer highwater marks (such as UNIX
+                                // timestamps), indicate so here.
+    );
+
+    // Note that it is important to process rows in the order of the highwater
+    // mark.
+    $query->orderBy('last_changed');
+
+    $this->source = new MigrateSourceSQL($query, $source_fields, $count_query);
+    $this->destination = new MigrateDestinationNode('migrate_example_wine');
 
     // You can add a 'track_last_imported' option to the map, to record the
     // timestamp of when each item was last imported in the map table.
@@ -741,56 +1227,9 @@ class WineWineMigration extends AdvancedExampleMigration {
         )
       ),
       MigrateDestinationNode::getKeySchema(),
-      'default',
+      'default', // The SQL connection where the map/message tables are created.
       array('track_last_imported' => TRUE)
     );
-
-    $query = db_select('migrate_example_wine', 'w')
-             ->fields('w', array('wineid', 'name', 'body', 'excerpt', 'accountid',
-              'posted', 'last_changed', 'variety', 'region', 'rating'));
-    $query->leftJoin('migrate_example_wine_category_wine', 'cwbw',
-      "w.wineid = cwbw.wineid");
-    $query->leftJoin('migrate_example_wine_categories', 'bw',
-      "cwbw.categoryid = bw.categoryid AND bw.type = 'best_with'");
-    // Gives a single comma-separated list of related terms
-    $query->groupBy('w.wineid');
-    $query->addExpression('GROUP_CONCAT(bw.categoryid)', 'best_with');
-
-    $count_query = db_select('migrate_example_wine', 'w');
-    $count_query->addExpression('COUNT(wineid)', 'cnt');
-
-    // TIP: By passing an array of source fields to the MigrateSourceSQL constructor,
-    // we can modify the descriptions of source fields (which just default, for
-    // SQL migrations, to table_alias.column_name), as well as add additional fields
-    // (which may be populated in prepareRow()).
-    $source_fields = array(
-      'wineid' => t('Wine ID in the old system'),
-      'name' => t('The name of the wine'),
-      'best_vintages' => t('What years were best for this wine?'),
-      'url' => t('Image URLs attached to this wine; populated in prepareRow()'),
-      'image_alt' => t('Image alt text attached to this wine; populated in prepareRow()'),
-      'image_title' => t('Image titles attached to this wine; populated in prepareRow()'),
-    );
-
-    // TIP: By default, each time a migration is run, any previously unimported source items
-    // are imported (along with any previously-imported items marked for update). If the
-    // source data contains a timestamp that is set to the creation time of each new item,
-    // as well as set to the update time for any existing items that are updated, then
-    // you can have those updated items automatically reimported by setting the field as
-    // your highwater field.
-    $this->highwaterField = array(
-      'name' => 'last_changed', // Column to be used as highwater mark
-      'alias' => 'w',           // Table alias containing that column
-      'type' => 'int',          // By default, highwater marks are assumed to be lexicographically
-                                // sortable (e.g., '2011-05-19 17:53:12'). To properly
-                                // deal with integer highwater marks (such as UNIX
-                                // timestamps), indicate so here.
-    );
-    // Note that it is important to process rows in the order of the highwater mark
-    $query->orderBy('last_changed');
-
-    $this->source = new MigrateSourceSQL($query, $source_fields, $count_query);
-    $this->destination = new MigrateDestinationNode('migrate_example_wine');
 
     // Mapped fields
     $this->addFieldMapping('title', 'name')
@@ -815,15 +1254,17 @@ class WineWineMigration extends AdvancedExampleMigration {
          ->sourceMigration('WineBestWith');
     $this->addFieldMapping('migrate_example_wine_best_with:source_type')
          ->defaultValue('tid');
+
     $this->addFieldMapping('field_migrate_example_wine_ratin', 'rating');
     $this->addFieldMapping('field_migrate_example_top_vintag', 'best_vintages');
 
-    // TIP: You can apply one or more functions to a source value using ->callbacks().
-    // The function must take a single argument and return a value which is a
-    // transformation of the argument. As this example shows, you can have multiple
-    // callbacks, and they can either be straight functions or class methods. In
-    // this case, our custom method prepends 'review: ' to the body, and then we
-    // call a standard Drupal function to uppercase the whole body.
+    // TIP: You can apply one or more functions to a source value using
+    // ->callbacks(). The function must take a single argument and return a
+    // value which is a transformation of the argument. As this example shows,
+    // you can have multiple callbacks, and they can either be straight
+    // functions or class methods. In this case, our custom method prepends
+    // 'review: ' to the body, and then we call a standard Drupal function to
+    // uppercase the whole body.
     $this->addFieldMapping('body', 'body')
          ->callbacks(array($this, 'addTitlePrefix'), 'drupal_strtoupper');
     $this->addFieldMapping('body:summary', 'excerpt');
@@ -840,23 +1281,43 @@ class WineWineMigration extends AdvancedExampleMigration {
 
     $this->addFieldMapping('sticky')
          ->defaultValue(0);
-    // These are already UNIX timestamps, so just pass through
+
     $this->addFieldMapping('created', 'posted');
     $this->addFieldMapping('changed', 'last_changed');
 
-    // No unmapped source fields
+    // Unmapped source fields
+    $this->addUnmigratedSources(array('last_changed'));
 
     // Unmapped destination fields
-    $this->addUnmigratedDestinations(array('revision_uid', 'status', 'promote',
-      'revision', 'log', 'language', 'tnid', 'is_new', 'body:format',
-      'body:language', 'migrate_example_wine_regions:create_term', 'comment',
-      'migrate_example_wine_varieties:create_term', 'migrate_example_wine_best_with:create_term',
-      'field_migrate_example_image:language', 'field_migrate_example_image:preserve_files',
-      'field_migrate_example_image:source_dir', 'field_migrate_example_image:destination_dir',
-      'field_migrate_example_image:destination_file', 'field_migrate_example_image:file_class',
+    $this->addUnmigratedDestinations(array(
+        'body:format',
+      'comment',
+        'field_migrate_example_image:destination_dir',
+        'field_migrate_example_image:destination_file',
+        'field_migrate_example_image:file_class',
+        'field_migrate_example_image:preserve_files',
+        'field_migrate_example_image:source_dir',
+        'field_migrate_example_image:urlencode',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_wine_best_with:create_term',
+        'migrate_example_wine_best_with:ignore_case',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+        'migrate_example_wine_varieties:create_term',
+        'migrate_example_wine_varieties:ignore_case',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'tnid',
+      'translate',
     ));
+
     if (module_exists('statistics')) {
-      $this->addUnmigratedDestinations(array('totalcount', 'daycount', 'timestamp'));
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
     }
   }
 
@@ -865,11 +1326,19 @@ class WineWineMigration extends AdvancedExampleMigration {
   }
 
   // TIP: Implement a prepareRow() method to manipulate the source row between
-  // retrieval from the database and the automatic applicaton of mappings
+  // retrieval from the database and the automatic applicaton of mappings.
   public function prepareRow($current_row) {
-    // We used the MySQL GROUP_CONCAT function above to handle a multi-value source
-    // field - more portably, we query the related table with multiple values here,
-    // so the values can run through the mapping process
+    // Always start your prepareRow implementation with this clause. You need to
+    // be sure your parent classes have their chance at the row, and that if
+    // they return FALSE (indicating the row should be skipped) you pass that
+    // on.
+    if (parent::prepareRow($current_row) === FALSE) {
+      return FALSE;
+    }
+
+    // We used the MySQL GROUP_CONCAT function above to handle a multi-value
+    // source field - more portably, we query the related table with multiple
+    // values here, so the values can run through the mapping process.
     $source_id = $current_row->wineid;
     $result = db_select('migrate_example_wine_vintages', 'v')
               ->fields('v', array('vintage'))
@@ -895,6 +1364,7 @@ class WineWineMigration extends AdvancedExampleMigration {
       $current_row->image_title[] = $row->image_title;
     }
 */
+
     // We could also have used this function to decide to skip a row, in cases
     // where that couldn't easily be done through the original query. Simply
     // return FALSE in such cases.
@@ -903,10 +1373,18 @@ class WineWineMigration extends AdvancedExampleMigration {
 }
 
 class WineCommentMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = 'Comments about wines';
-    $this->dependencies = array('WineUser', 'WineWine');
+
+    $query = db_select('migrate_example_wine_comment', 'wc')
+             ->fields('wc', array('commentid', 'comment_parent', 'name', 'mail',
+              'accountid', 'body', 'wineid', 'subject', 'commenthost',
+              'userpage', 'posted', 'lastchanged'))
+             ->orderBy('comment_parent');
+    $this->source = new MigrateSourceSQL($query);
+    $this->destination =
+      new MigrateDestinationComment('comment_node_migrate_example_wine');
     $this->map = new MigrateSQLMap($this->machineName,
       array('commentid' => array(
               'type' => 'int',
@@ -916,13 +1394,6 @@ class WineCommentMigration extends AdvancedExampleMigration {
            ),
         MigrateDestinationComment::getKeySchema()
       );
-    $query = db_select('migrate_example_wine_comment', 'wc')
-             ->fields('wc', array('commentid', 'comment_parent', 'name', 'mail',
-              'accountid', 'body', 'wineid', 'subject', 'commenthost', 'userpage',
-              'posted', 'lastchanged'))
-             ->orderBy('comment_parent');
-    $this->source = new MigrateSourceSQL($query);
-    $this->destination = new MigrateDestinationComment('comment_node_migrate_example_wine');
 
     // Mapped fields
     $this->addSimpleMappings(array('name', 'subject', 'mail'));
@@ -945,35 +1416,40 @@ class WineCommentMigration extends AdvancedExampleMigration {
     // No unmapped source fields
 
     // Unmapped destination fields
-    $this->addUnmigratedDestinations(array('thread', 'language',
-      'comment_body:format', 'comment_body:language'));
-    $this->removeFieldMapping('path');
+    $this->addUnmigratedDestinations(array(
+        'comment_body:format',
+      'language',
+      'thread',
+    ));
+
     $this->removeFieldMapping('pathauto');
   }
 }
 
 // TIP: An easy way to simply migrate into a Drupal table (i.e., one defined
 // through the Schema API) is to use the MigrateDestinationTable destination.
-// Just pass the table name to getKeySchema and the MigrateDestinationTable constructor.
+// Just pass the table name to getKeySchema and the MigrateDestinationTable
+// constructor.
 class WineTableMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = 'Miscellaneous table data';
-    $this->softDependencies = array('WineComment');
+
     $table_name = 'migrate_example_wine_table_dest';
-    $this->map = new MigrateSQLMap($this->machineName,
-      array('fooid' => array(
-              'type' => 'int',
-              'unsigned' => TRUE,
-              'not null' => TRUE,
-             )
-           ),
-        MigrateDestinationTable::getKeySchema($table_name)
-      );
+
     $query = db_select('migrate_example_wine_table_source', 't')
              ->fields('t', array('fooid', 'field1', 'field2'));
     $this->source = new MigrateSourceSQL($query);
     $this->destination = new MigrateDestinationTable($table_name);
+    $this->map = new MigrateSQLMap($this->machineName,
+      array('fooid' => array(
+            'type' => 'int',
+            'unsigned' => TRUE,
+            'not null' => TRUE,
+           )
+         ),
+        MigrateDestinationTable::getKeySchema($table_name)
+      );
 
     // Mapped fields
     $this->addFieldMapping('drupal_text', 'field1');
@@ -986,24 +1462,21 @@ class WineTableMigration extends AdvancedExampleMigration {
 }
 
 /**
- * This migration works with WinePrepMigration to make ensure auto_nodetitle
- * is re-enabled if we disabled it.
+ * This migration works with WinePrepMigration to make sure auto_nodetitle is
+ * re-enabled if we disabled it.
  */
 class WineFinishMigration extends MigrationBase {
-  public function __construct() {
-    parent::__construct(MigrateGroup::getInstance('wine', array('default')));
-    $this->description = t('If auto_nodetitle is present and was previously enabled,
-      re-enable it');
-    $this->dependencies = array('WineComment');
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    $this->description =
+      t('If auto_nodetitle is present and was previously enabled, re-enable it');
   }
+
   public function isComplete() {
-    if (module_exists('auto_nodetitle')) {
-      return TRUE;
-    }
-    else {
-      return FALSE;
-    }
+    // There is no incomplete state for this operation.
+    return TRUE;
   }
+
   public function import() {
     if (!module_exists('auto_nodetitle')) {
       if (WinePrepMigration::$wasEnabled) {
@@ -1011,11 +1484,13 @@ class WineFinishMigration extends MigrationBase {
         self::displayMessage(t('Re-enabled auto_nodetitle module'), 'success');
       }
       else {
-        self::displayMessage(t('auto_nodetitle was not originally enabled'), 'success');
+        self::displayMessage(t('auto_nodetitle was not originally enabled'),
+                             'success');
       }
     }
     else {
-      self::displayMessage(t('Auto_nodetitle module already enabled'), 'success');
+      self::displayMessage(t('Auto_nodetitle module already enabled'),
+                           'success');
     }
     return Migration::RESULT_COMPLETED;
   }
@@ -1026,12 +1501,14 @@ class WineFinishMigration extends MigrationBase {
  * to update existing content (in this case, revised wine ratings)
  */
 class WineUpdatesMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Update wine ratings');
-    $this->dependencies = array('WineWine');
-    $this->softDependencies = array('WineFinish');
 
+    $query = db_select('migrate_example_wine_updates', 'w')
+             ->fields('w', array('wineid', 'rating'));
+    $this->source = new MigrateSourceSQL($query);
+    $this->destination = new MigrateDestinationNode('migrate_example_wine');
     $this->map = new MigrateSQLMap($this->machineName,
       array(
         'wineid' => array(
@@ -1045,15 +1522,10 @@ class WineUpdatesMigration extends AdvancedExampleMigration {
       MigrateDestinationNode::getKeySchema()
     );
 
-    $query = db_select('migrate_example_wine_updates', 'w')
-             ->fields('w', array('wineid', 'rating'));
-
-    $this->source = new MigrateSourceSQL($query);
-    $this->destination = new MigrateDestinationNode('migrate_example_wine');
-
-    // Indicate we're updating existing data. The default, Migration::SOURCE, would
-    // cause existing nodes to be completely replaced by the source data. In this
-    // case, the existing node will be loaded and only the rating altered.
+    // Indicate we're updating existing data. The default, Migration::SOURCE,
+    // would cause existing nodes to be completely replaced by the source data.
+    // In this case, the existing node will be loaded and only the rating
+    // altered.
     $this->systemOfRecord = Migration::DESTINATION;
 
     // Mapped fields
@@ -1066,7 +1538,8 @@ class WineUpdatesMigration extends AdvancedExampleMigration {
 
     // No unmapped source fields
 
-    // Unmapped destination fields
+    // Unmapped destination fields - these will be left unchanged in this case
+    // (normally they would be overwritten with their default values).
     $this->addFieldMapping('uid');
     $this->addFieldMapping('migrate_example_wine_varieties');
     $this->addFieldMapping('migrate_example_wine_regions');
@@ -1076,42 +1549,66 @@ class WineUpdatesMigration extends AdvancedExampleMigration {
     $this->addFieldMapping('sticky');
     $this->addFieldMapping('created');
     $this->addFieldMapping('changed');
-    $this->addUnmigratedDestinations(array('title', 'revision_uid', 'status', 'promote',
-      'revision', 'log', 'language', 'tnid', 'is_new', 'body:format', 'body:summary',
-      'body:language', 'migrate_example_wine_regions:source_type',
-      'migrate_example_wine_regions:create_term', 'comment',
-      'migrate_example_wine_varieties:source_type', 'migrate_example_wine_varieties:create_term',
-      'migrate_example_wine_best_with:source_type', 'migrate_example_wine_best_with:create_term',
-      'field_migrate_example_image:language', 'field_migrate_example_image:destination_dir',
-      'field_migrate_example_image:alt', 'field_migrate_example_image:title',
-      'field_migrate_example_image:file_class', 'field_migrate_example_image:file_replace',
-      'field_migrate_example_image:preserve_files', 'field_migrate_example_image:destination_file',
-      'field_migrate_example_image:source_dir', 'field_migrate_example_top_vintag'));
+    $this->addUnmigratedDestinations(array(
+      'body:format', 'body:summary',
+      'comment',
+        'field_migrate_example_image:alt',
+        'field_migrate_example_image:destination_dir',
+        'field_migrate_example_image:destination_file',
+        'field_migrate_example_image:file_class',
+        'field_migrate_example_image:file_replace',
+        'field_migrate_example_image:preserve_files',
+        'field_migrate_example_image:source_dir',
+        'field_migrate_example_image:title',
+        'field_migrate_example_image:urlencode',
+        'field_migrate_example_top_vintag',
+      'is_new',
+      'language',
+      'log',
+        'migrate_example_wine_best_with:source_type',
+        'migrate_example_wine_best_with:create_term',
+        'migrate_example_wine_best_with:ignore_case',
+        'migrate_example_wine_regions:source_type',
+        'migrate_example_wine_regions:create_term',
+        'migrate_example_wine_regions:ignore_case',
+        'migrate_example_wine_varieties:source_type',
+        'migrate_example_wine_varieties:create_term',
+        'migrate_example_wine_varieties:ignore_case',
+      'promote',
+      'revision',
+      'revision_uid',
+      'status',
+      'title',
+      'tnid',
+      'translate',
+    ));
     if (module_exists('statistics')) {
-      $this->addUnmigratedDestinations(array('totalcount', 'daycount', 'timestamp'));
+      $this->addUnmigratedDestinations(
+        array('totalcount', 'daycount', 'timestamp'));
     }
   }
 }
 
 class WineCommentUpdatesMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = 'Update wine comments';
-    $this->dependencies = array('WineComment');
-    $this->softDependencies = array('WineUpdates');
-    $this->map = new MigrateSQLMap($this->machineName,
-      array('commentid' => array(
-              'type' => 'int',
-              'unsigned' => TRUE,
-              'not null' => TRUE,
-             )
-           ),
-        MigrateDestinationComment::getKeySchema()
-      );
+
     $query = db_select('migrate_example_wine_comment_updates', 'wc')
              ->fields('wc', array('commentid', 'subject'));
     $this->source = new MigrateSourceSQL($query);
-    $this->destination = new MigrateDestinationComment('comment_node_migrate_example_wine');
+    $this->destination =
+      new MigrateDestinationComment('comment_node_migrate_example_wine');
+    $this->map = new MigrateSQLMap($this->machineName,
+      array('commentid' => array(
+            'type' => 'int',
+            'unsigned' => TRUE,
+            'not null' => TRUE,
+           )
+         ),
+        MigrateDestinationComment::getKeySchema()
+      );
+
     $this->systemOfRecord = Migration::DESTINATION;
 
     // Mapped fields
@@ -1122,30 +1619,37 @@ class WineCommentUpdatesMigration extends AdvancedExampleMigration {
     // No unmapped source fields
 
     // Unmapped destination fields
-    $this->addFieldMapping('name');
-    $this->addFieldMapping('mail');
-    $this->addFieldMapping('status');
-    $this->addFieldMapping('nid');
-    $this->addFieldMapping('uid');
-    $this->addFieldMapping('pid');
-    $this->addFieldMapping('comment_body');
-    $this->addFieldMapping('hostname');
-    $this->addFieldMapping('created');
-    $this->addFieldMapping('changed');
-    $this->addFieldMapping('homepage');
-    $this->addUnmigratedDestinations(array('thread', 'language',
-      'comment_body:format', 'comment_body:language'));
-    $this->removeFieldMapping('path');
+    $this->addUnmigratedDestinations(array(
+      'changed',
+      'comment_body', 'comment_body:format',
+      'created',
+      'homepage',
+      'hostname',
+      'language',
+      'mail',
+      'name',
+      'nid',
+      'pid',
+      'status',
+      'thread',
+      'uid',
+    ));
+
     $this->removeFieldMapping('pathauto');
   }
 }
 
 class WineVarietyUpdatesMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
-    $this->description = t('Migrate varieties from the source database to taxonomy terms');
-    $this->dependencies = array('WineVariety');
-    $this->softDependencies = array('WineUpdates');
+  public function __construct($arguments) {
+    parent::__construct($arguments);
+    $this->description =
+      t('Migrate varieties from the source database to taxonomy terms');
+
+    $query = db_select('migrate_example_wine_variety_updates', 'wc')
+             ->fields('wc', array('categoryid', 'details'));
+    $this->source = new MigrateSourceSQL($query);
+    $this->destination =
+      new MigrateDestinationTerm('migrate_example_wine_varieties');
     $this->map = new MigrateSQLMap($this->machineName,
         array(
           'categoryid' => array('type' => 'int',
@@ -1156,10 +1660,6 @@ class WineVarietyUpdatesMigration extends AdvancedExampleMigration {
         MigrateDestinationTerm::getKeySchema()
       );
 
-    $query = db_select('migrate_example_wine_variety_updates', 'wc')
-             ->fields('wc', array('categoryid', 'details'));
-    $this->source = new MigrateSourceSQL($query);
-    $this->destination = new MigrateDestinationTerm('migrate_example_wine_varieties');
     $this->systemOfRecord = Migration::DESTINATION;
 
     // Mapped fields
@@ -1170,36 +1670,36 @@ class WineVarietyUpdatesMigration extends AdvancedExampleMigration {
     // Unmapped source fields
 
     // Unmapped destination fields
-    $this->addFieldMapping('name');
-    $this->addFieldMapping('parent');
-    $this->addFieldMapping('weight');
-    $this->addFieldMapping('format');
-    $this->addFieldMapping('parent_name')
-         ->issueGroup(t('DNM'));
+    $this->addUnmigratedDestinations(array(
+      'format',
+      'name',
+      'parent',
+      'parent_name',
+      'weight',
+    ));
   }
 }
 
-
 class WineUserUpdatesMigration extends AdvancedExampleMigration {
-  public function __construct() {
-    parent::__construct();
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Account updates');
-    $this->dependencies = array('WineUser');
-    $this->softDependencies = array('WineUpdates');
-    $this->map = new MigrateSQLMap($this->machineName,
-        array('accountid' => array(
-                'type' => 'int',
-                'unsigned' => TRUE,
-                'not null' => TRUE,
-                'description' => 'Account ID.'
-                )
-             ),
-        MigrateDestinationUser::getKeySchema()
-    );
+
     $query = db_select('migrate_example_wine_account_updates', 'wa')
              ->fields('wa', array('accountid', 'sex'));
     $this->source = new MigrateSourceSQL($query);
     $this->destination = new MigrateDestinationUser();
+    $this->map = new MigrateSQLMap($this->machineName,
+        array('accountid' => array(
+              'type' => 'int',
+              'unsigned' => TRUE,
+              'not null' => TRUE,
+              'description' => 'Account ID.'
+              )
+           ),
+        MigrateDestinationUser::getKeySchema()
+    );
+
     $this->systemOfRecord = Migration::DESTINATION;
 
     // Mapped fields
@@ -1211,20 +1711,26 @@ class WineUserUpdatesMigration extends AdvancedExampleMigration {
     // Unmapped source fields
 
     // Unmapped destination fields
-    $this->addFieldMapping('name');
-    $this->addFieldMapping('status');
-    $this->addFieldMapping('created');
-    $this->addFieldMapping('access');
-    $this->addFieldMapping('login');
-    $this->addFieldMapping('mail');
-    $this->addFieldMapping('pass');
-    $this->addFieldMapping('roles');
-    $this->addFieldMapping('signature');
-    $this->addFieldMapping('signature_format');
-    $this->addFieldMapping('init');
-    $this->addUnmigratedDestinations(array('theme', 'timezone', 'language',
-      'picture', 'is_new', 'field_migrate_example_favbeers'));
-    $this->removeFieldMapping('path');
+    $this->addUnmigratedDestinations(array(
+      'access',
+      'created',
+      'data',
+      'init',
+      'is_new',
+      'language',
+      'login',
+      'mail',
+      'name',
+      'pass',
+      'picture',
+      'role_names',
+      'roles',
+      'signature',
+      'signature_format',
+      'status',
+      'theme',
+      'timezone',
+    ));
   }
 
   public function prepare(stdClass $account, stdClass $row) {

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/wine.install.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/wine.install.inc
@@ -65,26 +65,7 @@ function migrate_example_wine_uninstall() {
 }
 
 function migrate_example_wine_disable() {
-  MigrationBase::deregisterMigration('WinePrep');
-  Migration::deregisterMigration('WineFileCopy');
-  Migration::deregisterMigration('WineFileBlob');
-  Migration::deregisterMigration('WineRegion');
-  Migration::deregisterMigration('WineUser');
-  Migration::deregisterMigration('WineVariety');
-  Migration::deregisterMigration('WineBestWith');
-  Migration::deregisterMigration('WineProducer');
-  Migration::deregisterMigration('WineProducerXML');
-  Migration::deregisterMigration('WineProducerXMLPull');
-  Migration::deregisterMigration('WineProducerMultiXML');
-  Migration::deregisterMigration('WineWine');
-  Migration::deregisterMigration('WineComment');
-  MigrationBase::deregisterMigration('WineFinish');
-  Migration::deregisterMigration('WineUpdates');
-  Migration::deregisterMigration('WineUserUpdates');
-  Migration::deregisterMigration('WineVarietyUpdates');
-  Migration::deregisterMigration('WineCommentUpdates');
-  Migration::deregisterMigration('WineRole');
-  Migration::deregisterMigration('WineTable');
+  MigrateGroup::deregister('wine');
 }
 
 function migrate_example_wine_schema_wine() {
@@ -1212,7 +1193,7 @@ function migrate_example_wine_data_files() {
   $query = db_insert('migrate_example_wine_files')
     ->fields($fields);
   $data = array(
-    array(1, 'http://drupal.org/sites/all/modules/drupalorg/drupalorg/images/association-individual.png', NULL, NULL, NULL),
+    array(1, 'http://placekitten.com/200/200', NULL, NULL, NULL),
     array(2, 'http://cyrve.com/files/penguin.jpeg', 'Penguin alt', 'Penguin title', 1),
     array(3, 'http://cyrve.com/files/rioja.jpeg', 'Rioja alt', 'Rioja title', 2),
     array(4, 'http://cyrve.com/files/boutisse_0.jpeg', 'Boutisse alt', 'Boutisse title', 2),

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/xml/0002.xml
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/xml/0002.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pr:producer xmlns:pr="http://www.wine.org/wine-producers">
+  <pr:name>Château Latour</pr:name>
+  <pr:description>Makers of grand vin Chateau Latour, Les Forts de Latour and Pauillac</pr:description>
+  <pr:authorid>3</pr:authorid>
+  <pr:region>Bordeaux</pr:region>
+</pr:producer>

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/xml/index2.xml
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/xml/index2.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wn:content xmlns:wn="http://www.wine.org/wine">
+  <wn:sourceid>0002</wn:sourceid>
+</wn:content>

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/xml/producers3.xml
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/xml/producers3.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pr:producers xmlns:pr="http://www.wine.org/wine-producers">
+  <pr:producer>
+    <pr:sourceid>0009</pr:sourceid>
+    <pr:name>Château Feytit Clinet</pr:name>
+    <pr:description>Good things, they say, come in small packages; this is certainly the case at Château Feyit Clinet, the maker of thelabel Pomerol.</pr:description>
+    <pr:authorid>1</pr:authorid>
+    <pr:region>Pomerol</pr:region>
+  </pr:producer>
+  <pr:producer>
+    <pr:sourceid>0010</pr:sourceid>
+    <pr:name>Château Doisy-Védrines</pr:name>
+    <pr:description>Blessed with ancient vines, the fruit here is often subject to high levels of Botrytis (or noble rot), which shrinks the grapes and concentrates sugar levels in the remaining juice.</pr:description>
+    <pr:authorid>3</pr:authorid>
+    <pr:region>Barsac</pr:region>
+  </pr:producer>
+</pr:producers>

--- a/docroot/sites/all/modules/migration/migrate/migrate_example/xml/producers4.xml
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example/xml/producers4.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pr:producers xmlns:pr="http://www.wine.org/wine-producers">
+  <pr:producer>
+    <pr:sourceid>0009</pr:sourceid>
+    <pr:name>Château Bourgneuf</pr:name>
+    <pr:description>Showing attractive red and dark fruits, cherry and plum, it is rich and even slightly racy, before concluding with classic Pomerol concentration and focus.</pr:description>
+    <pr:authorid>3</pr:authorid>
+    <pr:region>Pomerol</pr:region>
+  </pr:producer>
+  <pr:producer>
+    <pr:sourceid>0010</pr:sourceid>
+    <pr:name>Château Doisy-Daëne</pr:name>
+    <pr:description>Medium bodied, with elegance rather than density there is a wide spectrum of flavours; apples, peaches, lemongrass and a touch of white spice. Delicious now.</pr:description>
+    <pr:authorid>9</pr:authorid>
+    <pr:region>Barsac</pr:region>
+  </pr:producer>
+</pr:producers>

--- a/docroot/sites/all/modules/migration/migrate/migrate_example_baseball/migrate_example_baseball.features.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example_baseball/migrate_example_baseball.features.inc
@@ -6,7 +6,7 @@
 function migrate_example_baseball_node_info() {
   $items = array(
     'migrate_example_baseball' => array(
-      'name' => t('migrate_example_baseball'),
+      'name' => t('Migrate example - Baseball'),
       'base' => 'node_content',
       'description' => t('A baseball box score'),
       'has_title' => '1',

--- a/docroot/sites/all/modules/migration/migrate/migrate_example_baseball/migrate_example_baseball.info
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example_baseball/migrate_example_baseball.info
@@ -21,12 +21,12 @@ features[field][] = "node-migrate_example_baseball-field_visiting_team"
 features[node][] = "migrate_example_baseball"
 files[] = "migrate_example_baseball.migrate.inc"
 name = "migrate_example_baseball"
-package = "Migrate Examples"
+package = "Migration"
 php = "5.2.4"
 
-; Information added by drupal.org packaging script on 2012-11-07
-version = "7.x-2.5"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-2.8"
 core = "7.x"
 project = "migrate"
-datestamp = "1352299007"
+datestamp = "1435760949"
 

--- a/docroot/sites/all/modules/migration/migrate/migrate_example_baseball/migrate_example_baseball.install
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example_baseball/migrate_example_baseball.install
@@ -9,10 +9,10 @@ function migrate_example_baseball_enable() {
   $path = dirname(__FILE__) . '/data';
   migrate_example_baseball_get_files($path);
   for ($i=0; $i<=9; $i++) {
-    $file = 'gl200' . $i . '.txt';
+    $file = 'GL200' . $i . '.TXT';
     Migration::registerMigration('GameBaseball',
       pathinfo($file, PATHINFO_FILENAME),
-      array('source_file' => $path . '/' . $file));
+      array('source_file' => $path . '/' . $file, 'group_name' => 'baseball'));
   }
 }
 
@@ -53,14 +53,7 @@ function migrate_example_baseball_uninstall() {
 }
 
 function migrate_example_baseball_disable() {
-  for ($i=0; $i<=9; $i++) {
-    $file = 'gl200' . $i . '.txt';
-    Migration::deregisterMigration(pathinfo($file, PATHINFO_FILENAME));
-    $filename = dirname(__FILE__) . '/data/' . $file;
-    if (file_exists($filename)) {
-      unlink($filename);
-    }
-  }
+  MigrateGroup::deregister('baseball');
 }
 
 /**

--- a/docroot/sites/all/modules/migration/migrate/migrate_example_baseball/migrate_example_baseball.migrate.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_example_baseball/migrate_example_baseball.migrate.inc
@@ -13,17 +13,21 @@
 function migrate_example_baseball_migrate_api() {
   $api = array(
     'api' => 2,
+    'groups' => array(
+      'baseball' => array(
+        'title' => t('Baseball'),
+      ),
+    ),
   );
   return $api;
 }
 
 /**
- * A dynamic migration that is reused for each source CSV file.
+ * A migration that is reused for each source CSV file.
  */
-class GameBaseball extends DynamicMigration {
-  public function __construct(array $arguments) {
-    $this->arguments = $arguments;
-    parent::__construct();
+class GameBaseball extends Migration {
+  public function __construct($arguments) {
+    parent::__construct($arguments);
     $this->description = t('Import box scores from CSV file.');
 
     // Create a map object for tracking the relationships between source rows
@@ -81,7 +85,7 @@ class GameBaseball extends DynamicMigration {
     }
   }
 
-  function csvcolumns() {
+  protected function csvcolumns() {
     // Note: Remember to subtract 1 from column number at http://www.retrosheet.org/gamelogs/glfields.txt
     $columns[0] = array('start_date', 'Date of game');
     $columns[3] = array('visiting_team', 'Visiting team');
@@ -102,7 +106,7 @@ class GameBaseball extends DynamicMigration {
     return $columns;
   }
 
-  function prepareRow($row) {
+  public function prepareRow($row) {
     // Collect all the batters into one multi-value field.
     for ($i=1; $i <= 9; $i++ ) {
       $key = "visiting_batter_$i";
@@ -123,7 +127,7 @@ class GameBaseball extends DynamicMigration {
                                       PATHINFO_FILENAME));
   }
 
-  function fields() {
+  public function fields() {
     return array(
       'title' => 'A composite field made during prepareRow().',
       'home_batters' => 'An array of batters, populated during prepareRow().',

--- a/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.info
+++ b/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.info
@@ -1,14 +1,14 @@
 name = "Migrate UI"
 description = "UI for managing migration processes"
-package = "Development"
-;configure = admin/config/development/migrate
+package = "Migration"
+configure = admin/content/migrate/configure
 core = 7.x
 dependencies[] = migrate
-files[] = migrate_ui.module
+files[] = migrate_ui.wizard.inc
 
-; Information added by drupal.org packaging script on 2012-11-07
-version = "7.x-2.5"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-2.8"
 core = "7.x"
 project = "migrate"
-datestamp = "1352299007"
+datestamp = "1435760949"
 

--- a/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.install
+++ b/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.install
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @file
+ * Install/update function for migrate_ui.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function migrate_ui_install() {
+  migrate_ui_set_weight();
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function migrate_ui_uninstall() {
+  variable_del('migrate_import_method');
+  variable_del('migrate_drush_path');
+  variable_del('migrate_drush_mail');
+  variable_del('migrate_drush_mail_subject');
+  variable_del('migrate_drush_mail_body');
+}
+
+/**
+ * Make sure we have a higher weight than node.
+ */
+function migrate_ui_update_7201() {
+  migrate_ui_set_weight();
+}
+
+/**
+ * Sets the weight of migrate_ui higher than node, so Import links come after
+ * "Add content" at admin/content.
+ */
+function migrate_ui_set_weight() {
+  $node_weight = db_select('system', 's')
+                 ->fields('s', array('weight'))
+                 ->condition('name', 'node')
+                 ->execute()
+                 ->fetchField();
+  db_update('system')
+    ->fields(array('weight' => $node_weight + 1))
+    ->condition('name', 'migrate_ui')
+    ->execute();
+}
+
+/**
+ * If WordPress Migrate has background imports via drush enabled, copy the
+ * configuration to the new general Migrate support.
+ */
+function migrate_ui_update_7202() {
+  $drush_command = variable_get('wordpress_migrate_drush', '');
+  if ($drush_command) {
+    variable_set('migrate_drush_path', $drush_command);
+    // Consolidate these two variables into import method - 0 means immediate
+    // only, 1 means drush only, 2 means offer both options.
+    $import_method = variable_get('wordpress_migrate_import_method', 0);
+    $force_drush = variable_get('wordpress_migrate_force_drush', FALSE);
+    if (!$force_drush) {
+      $import_method = 2;
+    }
+    variable_set('migrate_import_method', $import_method);
+    variable_set('migrate_drush_mail',
+                 variable_get('wordpress_migrate_notification', 0));
+    variable_set('migrate_drush_mail_subject',
+                 variable_get('wordpress_migrate_notification_subject', ''));
+    variable_set('migrate_drush_mail_body',
+                 variable_get('wordpress_migrate_notification_body', ''));
+  }
+}

--- a/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.module
+++ b/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.module
@@ -1,23 +1,10 @@
 <?php
 
-define('MIGRATE_ACCESS_BASIC', 'migration information');
-
 function migrate_ui_help($path, $arg) {
   switch ($path) {
-    case 'admin/migrate':
-      return t('The current status of each migration defined in this system. Click on a migration name for details on its configuration.');
+    case 'admin/content/migrate':
+      return t('The current status of each migration group defined in this system. Click on a group name for details on its configuration.');
   }
-}
-
-/**
- * Implementation of hook_permission().
- */
-function migrate_ui_permission() {
-  return array(
-    MIGRATE_ACCESS_BASIC => array(
-      'title' => t('Basic access to migration information'),
-    ),
-  );
 }
 
 /**
@@ -27,67 +14,171 @@ function migrate_ui_menu() {
   $items = array();
 
   $items['admin/content/migrate'] = array(
-    'title' => 'Migrate',
     'type' => MENU_LOCAL_TASK | MENU_NORMAL_ITEM,
-    'description' => 'Monitor the creation of Drupal content from source data',
-    'page callback' => 'migrate_ui_dashboard',
+    'title' => 'Migrate',
+    'description' => 'Manage importing of data into your Drupal site',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('migrate_ui_migrate_dashboard'),
     'access arguments' => array(MIGRATE_ACCESS_BASIC),
+    'access callback' => 'user_access',
     'file' => 'migrate_ui.pages.inc',
   );
-  $items['admin/content/migrate/dashboard'] = array(
-    'title' => 'Migrate',
+  $items['admin/content/migrate/groups'] = array(
+    'title' => 'Dashboard',
     'type' => MENU_DEFAULT_LOCAL_TASK,
     'weight' => -10,
   );
-  $items['admin/content/migrate/registration'] = array(
-    'title' => 'Registration',
+
+  $items['admin/content/migrate/configure'] = array(
+    'title' => 'Configuration',
     'type' => MENU_LOCAL_TASK,
-    'description' => 'Configure class registration',
-    'page callback' => 'migrate_ui_registration',
-    'access arguments' => array(MIGRATE_ACCESS_BASIC),
+    'description' => 'Configure migration settings',
+    'page callback' => 'migrate_ui_configure',
+    'access arguments' => array(MIGRATE_ACCESS_ADVANCED),
     'file' => 'migrate_ui.pages.inc',
-    'weight' => 5,
+    'weight' => 100,
   );
-  $items['admin/content/migrate/handlers'] = array(
-    'title' => 'Handlers',
-    'type' => MENU_LOCAL_TASK,
-    'description' => 'Configure migration handlers',
-    'page callback' => 'migrate_ui_handlers',
-    'access arguments' => array(MIGRATE_ACCESS_BASIC),
-    'file' => 'migrate_ui.pages.inc',
-    'weight' => 10,
-  );
-  $items['admin/content/migrate/messages/%migration'] = array(
-    'title callback' => '_migrate_ui_title',
-    'title arguments' => array(4),
-    'description' => 'View messages from a migration',
-    'page callback' => 'migrate_ui_messages',
-    'page arguments' => array(4),
-    'access arguments' => array(MIGRATE_ACCESS_BASIC),
-    'file' => 'migrate_ui.pages.inc',
-  );
-  $items['admin/content/migrate/%migration'] = array(
-    'title callback' => '_migrate_ui_title',
-    'title arguments' => array(3),
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('migrate_migration_info', 3),
-    'access arguments' => array(MIGRATE_ACCESS_BASIC),
-    'file' => 'migrate_ui.pages.inc',
-  );
+
+  // Add tabs for each implemented migration wizard.
+  $wizards = migrate_ui_wizards();
+  foreach ($wizards as $wizard_class => $wizard) {
+    $items["admin/content/migrate/new/$wizard_class"] = array(
+      'type' => MENU_LOCAL_TASK,
+      'title' => 'Import from @source_title',
+      'title arguments' => array('@source_title' => $wizard->getSourceName()),
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('migrate_ui_wizard', $wizard_class),
+      'access arguments' => array(MIGRATE_ACCESS_BASIC),
+      'file' => 'migrate_ui.wizard.inc',
+    );
+  }
+
+  $items['admin/content/migrate/groups/%'] =
+    array(
+      'title callback' => 'migrate_ui_migrate_group_title',
+      'title arguments' => array(4),
+      'type' => MENU_NORMAL_ITEM,
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('migrate_ui_migrate_group', 4),
+      'access arguments' => array(MIGRATE_ACCESS_BASIC),
+      'file' => 'migrate_ui.pages.inc',
+    );
+
+  $items['admin/content/migrate/groups/%/%'] =
+    array(
+      'title callback' => 'migrate_ui_migrate_migration_title',
+      'title arguments' => array(5),
+      'type' => MENU_NORMAL_ITEM,
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('migrate_migration_info', 4, 5),
+      'access arguments' => array(MIGRATE_ACCESS_BASIC),
+      'file' => 'migrate_ui.pages.inc',
+    );
+
+  $items['admin/content/migrate/groups/%/%/view'] =
+    array(
+      'title' => 'View',
+      'type' => MENU_DEFAULT_LOCAL_TASK,
+      'weight' => -10,
+    );
+
+  $items['admin/content/migrate/groups/%/%/edit'] =
+    array(
+      'type' => MENU_LOCAL_TASK,
+      'title' => 'Edit',
+      'description' => 'Edit migration mappings',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('migrate_ui_edit_mappings', 4, 5),
+      'access arguments' => array(MIGRATE_ACCESS_ADVANCED),
+      'file' => 'migrate_ui.pages.inc',
+    );
+
+  $items['admin/content/migrate/groups/%/%/messages'] =
+    array(
+      'type' => MENU_LOCAL_TASK,
+      'title' => 'Messages',
+      'description' => 'View messages from a migration',
+      'page callback' => 'migrate_ui_messages',
+      'page arguments' => array(4, 5),
+      'access arguments' => array(MIGRATE_ACCESS_ADVANCED),
+      'file' => 'migrate_ui.pages.inc',
+    );
 
   return $items;
 }
 
-// A menu load callback.
-function migration_load($machine_name) {
-  if ($machine_name) {
-    return Migration::getInstance($machine_name);
-  }
+/**
+ * Title callback for the migrate group view page.
+ */
+function migrate_ui_migrate_group_title($group_name) {
+  $group = MigrateGroup::getInstance($group_name);
+  return $group->getTitle();
 }
 
-function _migrate_ui_title($migration) {
-  if (is_string($migration)) {
-    $migration = migration_load($migration);
+/**
+ * Title callback for the migration view page.
+ */
+function migrate_ui_migrate_migration_title($migration_name) {
+  return $migration_name;
+}
+
+/**
+* Implements hook_theme()
+*
+* @return array
+*/
+function migrate_ui_theme() {
+  return array(
+    'migrate_ui_field_mapping_form' => array(
+      'arguments' => array('field_mappings' => NULL),
+      'render element' => 'field_mappings',
+      'file' => '/migrate_ui.pages.inc',
+    ),
+    'migrate_ui_field_mapping_dependencies' => array(
+      'arguments' => array('dependencies' => NULL),
+      'render element' => 'dependencies',
+      'file' => '/migrate_ui.pages.inc',
+    ),
+  );
+}
+
+/**
+ * Implementation of hook_mail().
+ *
+ * @param $key
+ * @param $message
+ * @param $params
+ */
+function migrate_ui_mail($key, &$message, $params) {
+  $options['language'] = $message['language'];
+  user_mail_tokens($variables, array(), $options);
+  $langcode = $message['language']->language;
+  $subject = variable_get('migrate_drush_mail_subject', '');
+  $message['subject'] = t($subject, array(), array('langcode' => $langcode));
+  $body = variable_get('migrate_drush_mail_body', '');
+  $body .= "\n" . $params['output'];
+  $message['body'][] = t($body, array(), array('langcode' => $langcode));
+}
+
+/**
+ * Get info on all modules supporting a migration wizard.
+ *
+ * @return array
+ *  key: machine_name for a particular wizard implementation. Used in the menu
+ *    link.
+ *  value: Wizard configuration array containing:
+ *    source_title -
+ */
+function migrate_ui_wizards() {
+  $module_apis = migrate_get_module_apis();
+  $wizards = array();
+  foreach ($module_apis as $info) {
+    if (isset($info['wizard classes']) && is_array($info['wizard classes'])) {
+      foreach ($info['wizard classes'] as $wizard_class) {
+        $wizard_class = strtolower($wizard_class);
+        $wizards[$wizard_class] = new $wizard_class;
+      }
+    }
   }
-  return $migration->getMachineName();
+  return $wizards;
 }

--- a/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.pages.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.pages.inc
@@ -1,44 +1,155 @@
 <?php
-
 /**
  * @file
+ * Pages for managing migration processes.
  */
 
 /**
- * Menu callback
+ * Form for managing migration groups.
  */
-function migrate_ui_dashboard() {
-  drupal_set_title(t('Migrate'));
-  return drupal_get_form('migrate_ui_dashboard_form');
-}
+function migrate_ui_migrate_dashboard($form, &$form_state) {
+  drupal_set_title(t('Migrate dashboard'));
 
-/**
- * Form for reviewing migrations.
- */
-function migrate_ui_dashboard_form($form, &$form_state) {
   $build = array();
 
   $build['overview'] = array(
     '#prefix' => '<div>',
-    '#markup' => migrate_overview(),
+    '#markup' => filter_xss_admin(migrate_overview()),
     '#suffix' => '</div>',
   );
 
   $header = array(
+    'machinename' => array('data' => t('Group')),
     'status' => array('data' => t('Status')),
-    'machinename' => array('data' => t('Migration')),
-    'importrows' => array('data' => t('Total rows')),
-    'imported' => array('data' => t('Imported')),
-    'unimported' => array('data' => t('Unimported')),
-    'messages' => array('data' => t('Messages')),
-    'lastthroughput' => array('data' => t('Throughput')),
-    'lastimported' => array('data' => t('Last imported')),
+    'source_system' => array('data' => t('Source system')),
   );
+
+  $result = db_select('migrate_group', 'mg')
+            ->fields('mg', array('name', 'title', 'arguments'))
+            ->execute();
+  $rows = array();
+  foreach ($result as $group_row) {
+    $row = array();
+    $migration_result = db_select('migrate_status', 'ms')
+                        ->fields('ms', array('machine_name', 'status', 'arguments'))
+                        ->condition('group_name', $group_row->name)
+                        ->execute();
+    if (!$migration_result) {
+      continue;
+    }
+    $status = t('Idle');
+    $idle = TRUE;
+    $machine_names = array();
+    foreach ($migration_result as $migration_row) {
+      switch ($migration_row->status) {
+        case MigrationBase::STATUS_IMPORTING:
+          $status = t('Importing');
+          $idle = FALSE;
+          break;
+        case MigrationBase::STATUS_ROLLING_BACK:
+          $status = t('Rolling back');
+          $idle = FALSE;
+          break;
+        case MigrationBase::STATUS_STOPPING:
+          $status = t('Stopping');
+          $idle = FALSE;
+          break;
+      }
+      $machine_names[] = $migration_row->machine_name;
+    }
+
+    // If we're not in the middle of an operaton, what's the status of the import?
+    if ($idle) {
+      $ready = TRUE;
+      $complete = TRUE;
+      foreach ($machine_names as $machine_name) {
+        $migration = Migration::getInstance($machine_name);
+        if (!$migration) {
+          continue;
+        }
+        if (method_exists($migration, 'sourceCount') && method_exists($migration, 'processedCount')) {
+          $source_count = $migration->sourceCount();
+          $processed_count = $migration->processedCount();
+          if ($processed_count > 0) {
+            $ready = FALSE;
+            if (!$complete) {
+              break;
+            }
+          }
+          if ($processed_count != $source_count) {
+            $complete = FALSE;
+            if (!$ready) {
+              break;
+            }
+          }
+        }
+      }
+      if ($ready) {
+        $status = t('Ready to import');
+      }
+      elseif ($complete) {
+        $status = t('Import complete');
+      }
+      else {
+        $status = t('Import incomplete, not currently running');
+      }
+    }
+
+    $row['status'] = $status;
+    $row['machinename'] =
+      l($group_row->title, 'admin/content/migrate/groups/' . $group_row->name);
+    $arguments = unserialize($group_row->arguments);
+    if (!empty($arguments['source_system'])) {
+      $row['source_system'] = filter_xss_admin($arguments['source_system']);
+    }
+    else {
+      $row['source_system'] = '';
+    }
+    $rows[$group_row->name] = $row;
+  }
+
+  $build['dashboard']['tasks'] = array(
+    '#type' => 'tableselect',
+    '#header' => $header,
+    '#options' => $rows,
+    '#tree' => TRUE,
+    '#empty' => t('No migration groups defined.'),
+  );
+  $build['operations'] = _migrate_ui_migrate_operations();
+
+  return $build;
+}
+
+/**
+ * Menu callback
+ */
+function migrate_ui_migrate_group($form, &$form_state, $group_name) {
+  $group = MigrateGroup::getInstance($group_name);
+  $build = array();
+
+  $header = array(
+    'machinename' => array('data' => t('Task')),
+    'status' => array('data' => t('Status')),
+    'importrows' => array('data' => t('Items')),
+    'imported' => array('data' => t('Imported')),
+    'unprocessed' => array('data' => t('Unprocessed')),
+  );
+  if (user_access(MIGRATE_ACCESS_ADVANCED)) {
+    $header += array(
+      'messages' => array('data' => t('Messages')),
+      'lastthroughput' => array('data' => t('Throughput')),
+      'lastimported' => array('data' => t('Last imported')),
+    );
+  }
 
   $migrations = migrate_migrations();
 
   $rows = array();
   foreach ($migrations as $migration) {
+    $current_group = $migration->getGroup()->getName();
+    if ($current_group != $group_name) {
+      continue;
+    }
     $row = array();
     $has_counts = TRUE;
     if (method_exists($migration, 'sourceCount')) {
@@ -61,10 +172,10 @@ function migrate_ui_dashboard_form($form, &$form_state) {
       $imported = t('N/A');
     }
     if ($has_counts) {
-      $unimported = $total - $processed;
+      $unprocessed = $total - $processed;
     }
     else {
-      $unimported = t('N/A');
+      $unprocessed = t('N/A');
     }
     $status = $migration->getStatus();
     switch ($status) {
@@ -90,116 +201,154 @@ function migrate_ui_dashboard_form($form, &$form_state) {
 
     $row['status'] = $status;
     $machine_name = $migration->getMachineName();
-    $row['machinename'] =
-      l($machine_name, 'admin/content/migrate/' . $machine_name);
-    $row['importrows'] = $total;
-    $row['imported'] = $imported;
-    $row['unimported'] = $unimported;
-
-    if (is_subclass_of($migration, 'Migration')) {
-      $num_messages = $migration->messageCount();
-      $row['messages'] = $num_messages ? l($num_messages, 'admin/content/migrate/messages/' . $machine_name) : 0;
+    $name_length = strlen($machine_name);
+    $group_length = strlen($group_name);
+    if ($name_length != $group_length &&
+        !strncasecmp($group_name, $machine_name, $group_length)) {
+      $display_name = substr($machine_name, $group_length);
     }
     else {
-      $row['messages'] = t('N/A');
+      $display_name = $machine_name;
     }
-    if (method_exists($migration, 'getLastThroughput')) {
-      $rate = $migration->getLastThroughput();
-      if ($rate == '') {
-        $row['lastthroughput'] = t('Unknown');
-      }
-      elseif ($status == MigrationBase::STATUS_IDLE) {
-        $row['lastthroughput'] = t('!rate/min', array('!rate' => $rate));
+    $row['machinename'] =
+      l($display_name, "admin/content/migrate/groups/$group_name/$machine_name");
+    $row['importrows'] = (int) $total;
+    $row['imported'] = (int) $imported;
+    $row['unprocessed'] = (int) $unprocessed;
+    if (user_access(MIGRATE_ACCESS_ADVANCED)) {
+      if (is_subclass_of($migration, 'Migration')) {
+        $num_messages = $migration->messageCount();
+        $row['messages'] = $num_messages ?
+          l($num_messages, "admin/content/migrate/groups/$group_name/$machine_name/messages")
+          : 0;
       }
       else {
-        if ($rate > 0) {
-          $row['lastthroughput'] = t('!rate/min, !time remaining', array('!rate' => $rate, '!time' => format_interval((60*$unimported) / $rate)));
+        $row['messages'] = t('N/A');
+      }
+      if (method_exists($migration, 'getLastThroughput')) {
+        $rate = $migration->getLastThroughput();
+        if ($rate == '') {
+          $row['lastthroughput'] = t('Unknown');
         }
         else {
-          $row['lastthroughput'] = t('!rate/min, unknown time remaining', array('!rate' => $rate));
+          $row['lastthroughput'] = t('@rate/min', array('@rate' => $rate));
         }
       }
+      else {
+        $row['lastthroughput'] = t('N/A');
+      }
+      $row['lastimported'] = check_plain($migration->getLastImported());
     }
-    else {
-      $row['lastthroughput'] = t('N/A');
-    }
-    $row['lastimported'] = $migration->getLastImported();
     $rows[$machine_name] = $row;
   }
 
-  $build['dashboard'] = array(
+  $build['dashboard']['migrations'] = array(
     '#type' => 'tableselect',
     '#header' => $header,
     '#options' => $rows,
-    '#empty' => t('No migrations'),
+    '#tree' => TRUE,
+    '#empty' => t('No tasks are defined for this migration group.'),
   );
 
+  $build['operations'] = _migrate_ui_migrate_operations();
+
+  return $build;
+}
+
+/**
+ * @return array
+ */
+function _migrate_ui_migrate_operations() {
   // Build the 'Update options' form.
-  $build['operations'] = array(
+  $operations = array(
     '#type' => 'fieldset',
     '#title' => t('Operations'),
   );
 
-  $options = array(
-    'import' => t('Import'),
-    'rollback' => t('Rollback'),
-    'rollback_and_import' => t('Rollback and import'),
+  //
+  switch (variable_get('migrate_import_method', 0)) {
+    case 1:
+      $options = array(
+        'import_background' => t('Import'),
+        'rollback_background' => t('Rollback'),
+      );
+      break;
+    case 2:
+      $options = array(
+        'import_immediate' => t('Import immediately'),
+        'import_background' => t('Import in background'),
+        'rollback_immediate' => t('Rollback immediately'),
+        'rollback_background' => t('Rollback in background'),
+      );
+      break;
+    case 0:
+    default:
+      $options = array(
+        'import_immediate' => t('Import'),
+        'rollback_immediate' => t('Rollback'),
+      );
+    break;
+  }
+
+  $options += array(
     'stop' => t('Stop'),
     'reset' => t('Reset'),
+    'deregister' => t('Remove migration settings'),
   );
-  $build['operations']['operation'] = array(
+  $operations['operation'] = array(
     '#type' => 'select',
     '#title' => t('Operation'),
     '#title_display' => 'invisible',
     '#options' => $options,
   );
-  $build['operations']['submit'] = array(
+  $operations['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Execute'),
-    '#validate' => array('migrate_ui_dashboard_validate'),
-    '#submit' => array('migrate_ui_dashboard_submit'),
+    '#validate' => array('migrate_ui_migrate_validate'),
+    '#submit' => array('migrate_ui_migrate_submit'),
   );
-  $build['operations']['description'] = array(
+  $operations['description'] = array(
     '#prefix' => '<p>',
     '#markup' => t(
-      'Choose an operation to run on all migrations selected above:
+      'Choose an operation to run on all selections above:
        <ul>
-         <li>Import - Imports all previously unimported records from the source, plus
+         <li>Import<br /> Imports all previously unprocessed records from the source, plus
              any records marked for update, into destination Drupal objects.</li>
-         <li>Rollback - Deletes all Drupal objects created by the migration.</li>
-         <li>Rollback and import - Performs the Rollback operation, immediately
-             followed by the Import operation.</li>
-         <li>Stop - Cleanly interrupts any import or rollback processes that may
+         <li>Rollback<br /> Deletes all Drupal objects created by the import.</li>
+         <li>Stop<br /> Cleanly interrupts any import or rollback processes that may
              currently be running.</li>
-         <li>Reset - Sometimes a migration process may fail to stop cleanly, and be
+         <li>Reset<br /> Sometimes a process may fail to stop cleanly, and be
              left stuck in an Importing or Rolling Back status. Choose Reset to clear
              the status and permit other operations to proceed.</li>
+         <li>Remove migration settings<br /> Removes all information about a migration group
+             or task, while preserving any content that has already been imported.</li>
        </ul>'
     ),
     '#postfix' => '</p>',
   );
 
-  $build['operations']['options'] = array(
+  $operations['options'] = array(
     '#type' => 'fieldset',
     '#title' => t('Options'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
+    '#access' => user_access(MIGRATE_ACCESS_ADVANCED),
   );
-  $build['operations']['options']['update'] = array(
+  $operations['options']['update'] = array(
     '#type' => 'checkbox',
     '#title' => t('Update'),
-    '#description' => t('Check this box to update all previously-migrated content
+    '#description' => t('Check this box to update all previously-imported content
       in addition to importing new content. Leave unchecked to only import
       new content'),
   );
-  $build['operations']['options']['force'] = array(
+  $operations['options']['force'] = array(
     '#type' => 'checkbox',
     '#title' => t('Ignore dependencies'),
     '#description' => t('Check this box to ignore dependencies when running imports
-      - all migrations will run whether or not their dependent migrations have
+      - all tasks will run whether or not their dependent tasks have
       completed.'),
   );
-  $build['operations']['options']['limit'] = array(
+  $operations['options']['limit'] = array(
     '#tree' => TRUE,
     '#type' => 'fieldset',
     '#attributes' => array('class' => array('container-inline')),
@@ -215,56 +364,110 @@ function migrate_ui_dashboard_form($form, &$form_state) {
         'seconds' => t('seconds'),
       ),
       '#description' => t('Set a limit of how many items to process for
-        each migration, or how long each should run.'),
+        each migration task, or how long each should run.'),
     ),
   );
 
-  return $build;
+  return $operations;
 }
 
 /**
  * Validate callback for the dashboard form.
  */
-function migrate_ui_dashboard_validate($form, &$form_state) {
-  // Error if there are no items to select.
-  if (!is_array($form_state['values']['dashboard']) || !count(array_filter($form_state['values']['dashboard']))) {
-    form_set_error('', t('No items selected.'));
+function migrate_ui_migrate_validate($form, &$form_state) {
+  $migrations = _migrate_ui_selected_migrations($form_state['values']);
+  if (empty($migrations)) {
+    if (isset($form_state['values']['migrations'])) {
+      form_set_error('', t('No items selected.'));
+    }
   }
+}
+
+/**
+ * Determine what migrations are selected (whether directly on a group page, or
+ * via group selections on the dashboard).
+ *
+ * @param $values
+ *
+ * @return array
+ */
+function _migrate_ui_selected_migrations($values) {
+  if (isset($values['migrations'])) {
+    // From the specific group page, just take them in order (they were already
+    // sorted by dependencies).
+    $machine_names = array_filter($values['migrations']);
+  }
+  else {
+    // From the groups page, we need to use migrate_migrations to be sure we've
+    // got the tasks for each group in dependency order.
+    $tasks = array_filter($values['tasks']);
+    $migrations = migrate_migrations();
+    $machine_names = array();
+    foreach ($migrations as $migration) {
+      $group_name = $migration->getGroup()->getName();
+      if (in_array($group_name, $tasks)) {
+        $machine_names[] = $migration->getMachineName();
+      }
+    }
+  }
+  return $machine_names;
 }
 
 /**
  * Submit callback for the dashboard form.
  */
-function migrate_ui_dashboard_submit($form, &$form_state) {
-  $operation = $form_state['values']['operation'];
-  $limit = $form_state['values']['limit'];
-  $update = $form_state['values']['update'];
-  $force = $form_state['values']['force'];
-  $machine_names = array_filter($form_state['values']['dashboard']);
+function migrate_ui_migrate_submit($form, &$form_state) {
+  $values = $form_state['values'];
+  $operation = $values['operation'];
+
+  $limit = $values['limit'];
+
+  if (isset($values['update'])) {
+    $update = $values['update'];
+  }
+  else {
+    $update = 0;
+  }
+  if (isset($values['force'])) {
+    $force = $values['force'];
+  }
+  else {
+    $force = 0;
+  }
+  $machine_names = _migrate_ui_selected_migrations($values);
   $operations = array();
 
   // Rollback in reverse order.
-  if (in_array($operation, array('rollback', 'rollback_and_import'))) {
+  if (in_array($operation, array('rollback_immediate', 'deregister'))) {
     $machine_names = array_reverse($machine_names);
-    foreach ($machine_names as $machine_name) {
-      $operations[] = array('migrate_ui_batch', array('rollback', $machine_name, $limit, $force));
-    }
-    // Reset order of machines names in preparation for final operation.
-    $machine_names = array_reverse($machine_names);
-    $operation = ($operation == 'rollback_and_import') ? 'import' : NULL;
   }
 
-  // Perform non-rollback operation, if one exists.
-  if ($operation) {
-    foreach ($machine_names as $machine_name) {
-      $migration = Migration::getInstance($machine_name);
+  // Special case: when deregistering a group, go through the group API
+  if ($operation == 'deregister' && isset($values['tasks'])) {
+    foreach ($values['tasks'] as $task) {
+      MigrateGroup::deregister($task);
+    }
+    return;
+  }
+
+  $drush_arguments = array();
+  foreach ($machine_names as $machine_name) {
+    $migration = Migration::getInstance($machine_name);
+    if ($migration) {
       switch ($operation) {
-        case 'import':
+        case 'import_immediate':
           // Update (if necessary) once, before starting
           if ($update && method_exists($migration, 'prepareUpdate')) {
             $migration->prepareUpdate();
           }
-          $operations[] = array('migrate_ui_batch', array($operation, $machine_name, $limit, $force));
+          $operations[] = array('migrate_ui_batch', array('import', $machine_name, $limit, $force));
+          break;
+        case 'rollback_immediate':
+          $operations[] = array('migrate_ui_batch', array('rollback', $machine_name, $limit, $force));
+          break;
+        case 'import_background':
+        case 'rollback_background':
+          $drush_arguments[] = $machine_name;
           break;
         case 'stop':
           $migration->stopProcess();
@@ -272,26 +475,83 @@ function migrate_ui_dashboard_submit($form, &$form_state) {
         case 'reset':
           $migration->resetStatus();
           break;
+        case 'deregister':
+          migrate_ui_deregister_migration($machine_name);
+          break;
       }
     }
   }
 
-  // Only rollback and import operations will need to go through Batch API.
+  // Only immediate rollback and import operations will need to go through Batch API.
   if (count($operations) > 0) {
     $batch = array(
       'operations' => $operations,
-      'title' => t('Migration processing'),
+      'title' => t('Import processing'),
       'file' => drupal_get_path('module', 'migrate_ui') . '/migrate_ui.pages.inc',
-      'init_message' => t('Starting migration process'),
+      'init_message' => t('Starting import process'),
       'progress_message' => t(''),
-      'error_message' => t('An error occurred. Some or all of the migrate processing has failed.'),
+      'error_message' => t('An error occurred. Some or all of the import processing has failed.'),
       'finished' => 'migrate_ui_batch_finish',
     );
     batch_set($batch);
   }
+  elseif (count($drush_arguments) > 0) {
+    $drush_path = trim(variable_get('migrate_drush_path', ''));
+    // Check that $drush_path works. See migrate_ui_configure_form().
+    if (!is_executable($drush_path)) {
+      $message = t('To enable running operations in the background with <a href="@drush">drush</a>, (which is <a href="@recommended">recommended</a>), some configuration must be done on the server. See the <a href="@config">documentation</a> on <a href="@dorg">drupal.org</a>.',
+        array(
+          '@drush' => 'http://drupal.org/project/drush',
+          '@recommended' => 'http://drupal.org/node/1806824',
+          '@config' => 'http://drupal.org/node/1958170',
+          '@dorg' => 'http://drupal.org/',
+        )
+      );
+      drupal_set_message($message);
+      return;
+    }
+    $uri = $GLOBALS['base_url'];
+    $uid = $GLOBALS['user']->uid;
+    if ($operation == 'import_background') {
+      $command = 'mi';
+      $log_suffix = '.import.log';
+    }
+    else {
+      $command = 'mr';
+      $log_suffix = '.rollback.log';
+    }
+    $migrations = implode(',', $drush_arguments);
+    $drush_command = "$drush_path $command $migrations --user=$uid --uri=$uri " .
+      '--root=' . DRUPAL_ROOT;
+    if ($force) {
+      $drush_command .= ' --force';
+    }
+    if ($update) {
+      $drush_command .= ' --update';
+    }
+    if (variable_get('migrate_drush_mail', 0)) {
+      $drush_command .= ' --notify';
+    }
+    if (!empty($limit['value'])) {
+      $limit = $limit['value'] . ' ' . $limit['unit'];
+      $drush_command .= " --limit=\"$limit\"";
+    }
+    $log_file = drupal_realpath('temporary://' . $drush_arguments[0] . $log_suffix);
+    $drush_command .= " >$log_file 2>&1 &";
+    exec($drush_command, $output, $status);
+    if (variable_get('migrate_drush_mail', 0)) {
+      drupal_set_message('Your operation is running in the background. You will receive an email message when it is complete.');
+    }
+    else {
+      drupal_set_message('Your operation is running in the background. You may '.
+        'refresh the dashboard page to check on its progress.');
+    }
+  }
 }
 
 /**
+ * Implements callback_batch_operation().
+ *
  * Process all enabled migration processes in a browser, using the Batch API
  * to break it into manageable chunks.
  *
@@ -314,11 +574,18 @@ function migrate_ui_batch($operation, $machine_name, $limit, $force = FALSE, &$c
   }
 
   $migration = Migration::getInstance($machine_name);
+  if (!$migration) {
+    $context['finished'] = 1;
+    return;
+  }
 
   // Messages generated by migration processes will be captured in this global
   global $_migrate_messages;
   $_migrate_messages = array();
   Migration::setDisplayFunction('migrate_ui_capture_message');
+
+  // Try to allocate enough time to run the full operation.
+  $migration->setBatchTimeLimit();
 
   // Perform the requested operation
   switch ($operation) {
@@ -351,11 +618,13 @@ function migrate_ui_batch($operation, $machine_name, $limit, $force = FALSE, &$c
       }
       break;
     case MigrationBase::RESULT_SKIPPED:
-      $_migrate_messages[] = t("Skipped !name due to unfulfilled dependencies: !depends",
-        array(
-          '!name' => $machine_name,
-          '!depends' => implode(", ", $migration->incompleteDependencies()),
-        ));
+      $_migrate_messages[] = array(
+        'message' => t("Skipped !name due to unfulfilled dependencies: !depends",
+          array(
+            '!name' => $machine_name,
+            '!depends' => implode(", ", $migration->incompleteDependencies()),
+          ))
+        );
       $context['finished'] = 1;
       break;
     case MigrationBase::RESULT_STOPPED:
@@ -369,20 +638,22 @@ function migrate_ui_batch($operation, $machine_name, $limit, $force = FALSE, &$c
   }
 
   // Add any messages generated in this batch to the cumulative list
-  foreach ($_migrate_messages as $message) {
-    $context['results'][] = $message;
+  foreach ($_migrate_messages as $message_data) {
+    $context['results'][] = $message_data;
   }
 
   // While in progress, show the cumulative list of messages
   $full_message = '';
-  foreach ($context['results'] as $message) {
-    $full_message .= $message . '<br />';
+  foreach ($context['results'] as $message_data) {
+    $full_message .= $message_data['message'] . '<br />';
   }
   $context['message'] = $full_message;
 }
 
 /**
- * Batch API finished callback - report results
+ * Implements callback_batch_finished().
+ *
+ * Report results.
  *
  * @param $success
  *  Ignored
@@ -393,76 +664,58 @@ function migrate_ui_batch($operation, $machine_name, $limit, $force = FALSE, &$c
  */
 function migrate_ui_batch_finish($success, $results, $operations) {
   unset($results['stopped']);
-  foreach ($results as $result) {
-    drupal_set_message($result);
-  }
-}
 
-function migrate_ui_capture_message($message, $level) {
-  if ($level != 'debug') {
-    global $_migrate_messages;
-    $_migrate_messages[] = $message;
+  foreach ($results as $result) {
+    // Migration::progressMessage() uses message levels that don't match what
+    // drupal_set_message() expects.
+    if (isset($result['level'])) {
+      if ($result['level'] == 'completed') {
+        $level = 'status';
+      }
+      elseif ($result['level'] == 'failed') {
+        $level = 'error';
+      }
+      else {
+        $level = $result['level'];
+      }
+    }
+    else {
+      $level = NULL;
+    }
+
+    drupal_set_message($result['message'], $level);
   }
 }
 
 /**
- * Menu callback for messages page
+ * Store a message to be displayed later.
+ *
+ * Ignore the message if $level is set to 'debug'.
+ *
+ * @param string $message
+ *   the message to be displayed
+ * @param string $level
+ *   the type of the message: 'debug', 'completed', 'failed', or a valid $type
+ *   used by drupal_set_message()
  */
-function migrate_ui_messages($migration) {
-  $build = $rows = array();
-
-  $header = array(
-    array('data' => t('Source ID'), 'field' => 'sourceid1', 'sort' => 'asc'),
-    array('data' => t('Level'), 'field' => 'level'),
-    array('data' => t('Message'), 'field' => 'message'),
-  );
-
-  if (is_string($migration)) {
-    $migration = migration_load($migration);
-  }
-
-  // TODO: need a general MigrateMap API
-  $messages = $migration->getMap()->getConnection()
-              ->select($migration->getMap()->getMessageTable(), 'msg')
-              ->extend('PagerDefault')
-              ->extend('TableSort')
-              ->orderByHeader($header)
-              ->limit(500)
-              ->fields('msg')
-              ->execute();
-
-  foreach ($messages as $message) {
-    $classes[] = $message->level <= MigrationBase::MESSAGE_WARNING ? 'migrate-error' : '';
-    $rows[] = array(
-      array('data' => $message->sourceid1, 'class' => $classes), // TODO: deal with compound keys
-      array('data' => $migration->getMessageLevelName($message->level), 'class' => $classes),
-      array('data' => $message->message, 'class' => $classes),
+function migrate_ui_capture_message($message, $level) {
+  if ($level != 'debug') {
+    // Store each message as an array with keys 'message' and 'level'.
+    global $_migrate_messages;
+    $_migrate_messages[] = array(
+      'message' => filter_xss_admin($message),
+      'level' => check_plain($level),
     );
-    unset($classes);
   }
-
-  $build['messages'] = array(
-    '#theme' => 'table',
-    '#header' => $header,
-    '#rows' => $rows,
-    '#empty' => t('No messages'),
-    '#attached' => array(
-      'css' => array(drupal_get_path('module', 'migrate_ui') . '/migrate_ui.css'),
-    ),
-  );
-  $build['migrate_ui_pager'] = array('#theme' => 'pager');
-  return $build;
 }
 
 /**
  * Menu callback function for migration view page.
  */
-function migrate_migration_info($form, $form_state, $migration) {
-  if (is_string($migration)) {
-    $migration = migration_load($migration);
-  }
+function migrate_migration_info($form, $form_state, $group_name, $migration_name) {
+  $migration = Migration::getInstance($migration_name);
 
-  $has_mappings = method_exists($migration, 'getFieldMappings');
+  $has_mappings = $migration && method_exists($migration, 'getFieldMappings');
   $form = array();
 
   if ($has_mappings) {
@@ -495,6 +748,10 @@ function migrate_migration_info($form, $form_state, $migration) {
     '#group' => 'detail',
   );
 
+  if (!$migration) {
+    return $form;
+  }
+
   $team = array();
   foreach ($migration->getTeam() as $member) {
     $email_address = $member->getEmailAddress();
@@ -505,8 +762,8 @@ function migrate_migration_info($form, $form_state, $migration) {
   foreach ($team as $group => $list) {
     $form['overview'][$group] = array(
       '#type' => 'item',
-      '#title' => $group,
-      '#markup' => implode(', ', $list),
+      '#title' => filter_xss_admin($group),
+      '#markup' => filter_xss_admin(implode(', ', $list)),
     );
   }
 
@@ -514,7 +771,7 @@ function migrate_migration_info($form, $form_state, $migration) {
   if (count($dependencies) > 0) {
     $form['overview']['dependencies'] = array(
       '#title' => t('Dependencies') ,
-      '#markup' => implode(', ', $dependencies),
+      '#markup' => filter_xss_admin(implode(', ', $dependencies)),
       '#type' => 'item',
     );
   }
@@ -522,10 +779,16 @@ function migrate_migration_info($form, $form_state, $migration) {
   if (count($soft_dependencies) > 0) {
     $form['overview']['soft_dependencies'] = array(
       '#title' => t('Soft Dependencies'),
-      '#markup' => implode(', ', $soft_dependencies),
+      '#markup' => filter_xss_admin(implode(', ', $soft_dependencies)),
       '#type' => 'item',
     );
   }
+
+  $form['overview']['group'] = array(
+    '#title' => t('Group:'),
+    '#markup' => filter_xss_admin($migration->getGroup()->getTitle()),
+    '#type' => 'item',
+  );
 
   if ($has_mappings) {
     switch ($migration->getSystemOfRecord()) {
@@ -548,7 +811,7 @@ function migrate_migration_info($form, $form_state, $migration) {
 
   $form['overview']['description'] = array(
     '#title' => t('Description:'),
-    '#markup' => $migration->getDescription(),
+    '#markup' => filter_xss_admin($migration->getDescription()),
     '#type' => 'item',
   );
 
@@ -559,8 +822,8 @@ function migrate_migration_info($form, $form_state, $migration) {
       '#title' => t('Destination'),
       '#group' => 'detail',
       '#description' =>
-        t('<p>These are the fields available in the destination of this
-           migration. The machine names listed here are those available to be used
+        t('<p>These are the fields available in the destination of this migration
+           task. The machine names listed here are those available to be used
            as the first parameter to $this->addFieldMapping() in your Migration
            class constructor. <span class="error">Unmapped fields are red</span>.</p>'),
     );
@@ -568,7 +831,7 @@ function migrate_migration_info($form, $form_state, $migration) {
     $form['destination']['type'] = array(
       '#type' => 'item',
       '#title' => t('Type'),
-      '#markup' => (string)$destination,
+      '#markup' => filter_xss_admin((string) $destination),
     );
     $dest_key = $destination->getKeySchema();
     $header = array(t('Machine name'), t('Description'));
@@ -583,7 +846,10 @@ function migrate_migration_info($form, $form_state, $migration) {
         // Add class for mapped/unmapped. Used in summary.
         $classes[] = !isset($destination_fields[$machine_name]) ? 'migrate-error' : '';
       }
-      $rows[] = array(array('data' => $machine_name, 'class' => $classes), array('data' => $description, 'class' => $classes));
+      $rows[] = array(
+        array('data' => check_plain($machine_name), 'class' => $classes),
+        array('data' => filter_xss_admin($description), 'class' => $classes),
+      );
     }
     $classes = array();
 
@@ -600,8 +866,8 @@ function migrate_migration_info($form, $form_state, $migration) {
       '#title' => t('Source'),
       '#group' => 'detail',
       '#description' =>
-        t('<p>These are the fields available from the source of this
-           migration. The machine names listed here are those available to be used
+        t('<p>These are the fields available from the source of this migration
+           task. The machine names listed here are those available to be used
            as the second parameter to $this->addFieldMapping() in your Migration
            class constructor. <span class="error">Unmapped fields are red</span>.</p>'),
     );
@@ -609,7 +875,7 @@ function migrate_migration_info($form, $form_state, $migration) {
     $form['source']['query'] = array(
       '#type' => 'item',
       '#title' => t('Query'),
-      '#markup' => '<pre>' . $source . '</pre>',
+      '#markup' => '<pre>' . filter_xss_admin($source) . '</pre>',
     );
     $source_key = $migration->getMap()->getSourceKey();
     $header = array(t('Machine name'), t('Description'));
@@ -623,7 +889,10 @@ function migrate_migration_info($form, $form_state, $migration) {
         // Add class for mapped/unmapped. Used in summary.
         $classes = !isset($source_fields[$machine_name]) ? 'migrate-error' : '';
       }
-      $rows[] = array(array('data' => $machine_name, 'class' => $classes), array('data' => $description, 'class' => $classes));
+      $rows[] = array(
+        array('data' => check_plain($machine_name), 'class' => $classes),
+        array('data' => filter_xss_admin($description), 'class' => $classes),
+      );
     }
     $classes = array();
 
@@ -648,16 +917,16 @@ function migrate_migration_info($form, $form_state, $migration) {
       if (!is_null($source_field) && !isset($source_fields[$source_field])) {
         drupal_set_message(t('"!source" was used as source field in the
           "!destination" mapping but is not in list of source fields', array(
-            '!source' => $source_field,
-            '!destination' => $destination_field
+            '!source' => filter_xss_admin($source_field),
+            '!destination' => filter_xss_admin($destination_field),
           )),
         'warning');
       }
       if (!is_null($destination_field) && !isset($destination_fields[$destination_field])) {
         drupal_set_message(t('"!destination" was used as destination field in
           "!source" mapping but is not in list of destination fields', array(
-            '!source' => $source_field,
-            '!destination' => $destination_field)),
+            '!source' => filter_xss_admin($source_field),
+            '!destination' => filter_xss_admin($destination_field))),
         'warning');
       }
       $descriptions[$mapping->getIssueGroup()][] = $mapping;
@@ -667,7 +936,7 @@ function migrate_migration_info($form, $form_state, $migration) {
     foreach ($descriptions as $group => $mappings) {
       $form[$group] = array(
         '#type' => 'fieldset',
-        '#title' => t('Mapping: !group', array('!group' => $group)),
+        '#title' => t('Mapping: !group', array('!group' => filter_xss_admin($group))),
         '#group' => 'detail',
         '#attributes' => array('class' => array('migrate-mapping')),
       );
@@ -679,7 +948,7 @@ function migrate_migration_info($form, $form_state, $migration) {
         }
         $issue_priority = $mapping->getIssuePriority();
         if (!is_null($issue_priority)) {
-          $classes[] = 'migrate-priority-' . $issue_priority;
+          $classes[] = 'migrate-priority-' . drupal_html_class($issue_priority);
           $priority = MigrateFieldMapping::$priorities[$issue_priority];
           $issue_pattern = $migration->getIssuePattern();
           $issue_number = $mapping->getIssueNumber();
@@ -695,12 +964,19 @@ function migrate_migration_info($form, $form_state, $migration) {
           $priority = t('OK');
           $classes[] = 'migrate-priority-' . 1;
         }
+        $destination_field = $mapping->getDestinationField();
+        $source_field = $mapping->getSourceField();
+        // Highlight any mappings overridden in the database.
+        if ($mapping->getMappingSource() == MigrateFieldMapping::MAPPING_SOURCE_DB) {
+          $destination_field = "<em>$destination_field</em>";
+          $source_field = "<em>$source_field</em>";
+        }
         $row = array(
-          array('data' => $mapping->getDestinationField(), 'class' => $classes),
-          array('data' => $mapping->getSourceField(), 'class' => $classes),
-          array('data' => $default, 'class' => $classes),
-          array('data' => $mapping->getDescription(),  'class' => $classes),
-          array('data' => $priority, 'class' => $classes),
+          array('data' => filter_xss_admin($destination_field), 'class' => $classes),
+          array('data' => filter_xss_admin($source_field), 'class' => $classes),
+          array('data' => filter_xss_admin($default), 'class' => $classes),
+          array('data' => filter_xss_admin($mapping->getDescription()), 'class' => $classes),
+          array('data' => filter_xss_admin($priority), 'class' => $classes),
         );
         $rows[] = $row;
         $classes = array();
@@ -716,101 +992,905 @@ function migrate_migration_info($form, $form_state, $migration) {
 }
 
 /**
- * Menu callback
+ * Page callback to edit field mappings for a given migration.
+ *
+ * @param $form
+ * @param $form_state
+ * @param $group_name
+ * @param $migration_name
+ *
+ * @return array
  */
-function migrate_ui_registration() {
-  drupal_set_title(t('Migration class registration'));
-  return drupal_get_form('migrate_ui_registration_form');
-}
+function migrate_ui_edit_mappings($form, $form_state, $group_name,
+                                  $migration_name) {
+  drupal_set_title(t('Edit !migration', array('!migration' => filter_xss_admin($migration_name))));
 
-/**
- * Form for reviewing migrations.
- */
-function migrate_ui_registration_form($form, &$form_state) {
-  $build = array();
+  $form = array();
+  $form['#tree'] = TRUE;
 
+  $form['machine_name'] = array(
+    '#type' => 'value',
+    '#value' => $migration_name,
+  );
 
-  if (variable_get('migrate_disable_autoregistration', FALSE)) {
-    $description = t('You currently have automatic class registration turned off.
-      This means that any Migration classes, destination handler classes, or
-      field handlers must be explicitly registered, either through hook_migrate_api()
-      or by calling MigrationBase::registerMigration(). You may enable automatic
-      class registration by clicking this button - however, it\'s important to
-      note that in some environments registration may fail with errors like
-      "<em>Class \'views_handler_field\' not found</em>".');
-    $button_label = t('Enable automatic registration');
+  $migration = Migration::getInstance($migration_name);
+  if (!$migration) {
+    return $form;
   }
-  else {
-    $description = t('You currently have automatic class registration turned on.
-      This means that any Migration classes, destination handler classes, or
-      field handlers not explicitly registered, either through hook_migrate_api()
-      or by calling MigrationBase::registerMigration(), can be registered by
-      clicking the <strong>Register</strong> button below. It\'s important to
-      note that in some environments registration may fail with errors like
-      "<em>Class \'views_handler_field\' not found</em>" - in those cases, you
-      can click the <strong>Disable automatic registration</strong> button below,
-      but you must be sure that your classes are explicitly registered.');
-    $button_label = t('Disable automatic registration');
+
+  $source_migration_options = array('-1' => t(''),);
+  $all_dependencies = array();
+  foreach (migrate_migrations() as $machine_name => $migration_info) {
+    $source_migration_options[$machine_name] = $machine_name;
+    $dependencies = $migration_info->getDependencies();
+    if (!empty($dependencies)) {
+      $all_dependencies[$machine_name] = $dependencies;
+    }
   }
-  $build['registration'] = array(
+
+  if (is_a($migration, 'Migration')) {
+    $source_fields = $migration->getSource()->fields();
+    $dest_fields = $migration->getDestination()->fields($migration);
+    $dest_key = $migration->getDestination()->getKeySchema();
+    $field_mappings = $migration->getFieldMappings();
+
+    $form['field_mappings'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Field mappings'),
+      '#collapsible' => TRUE,
+      '#description' => t('For each field available in your Drupal destination, select the source field used to populate it. You can enter a default value to be applied to the destination when there is no source field, or the source field is empty in a given source item. Check the DNM (Do Not Migrate) box for destination fields you do not want populated by migration. Note that any changes you make here override any field mappings defined by the underlying migration module. Clicking the Revert button will remove all such overrides.'),
+      '#theme' => array('migrate_ui_field_mapping_form'),
+      '#prefix' => '<div id="field-mappings">',
+      '#suffix' => '</div>',
+    );
+
+    // So the theme function knows whether to include the xpath column.
+    $form['field_mappings']['#is_xml_migration'] = is_a($migration, 'XMLMigration');
+
+    $form['source_fields'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Source fields'),
+      '#collapsible' => TRUE,
+      '#description' => t('Check off any source fields that are not being mapped to destination fields. They will be removed from the select lists above.'),
+    );
+
+    $base_options = array(
+      '-1' => t(''),
+    );
+
+    $field_options = array();
+    foreach ($source_fields as $name => $description) {
+      // Clean up the source field description
+      if (is_array($description)) {
+        $description = reset($description);
+      }
+      $description = strip_tags($description);
+      // Limit the description length
+      if (strlen($description) > 50) {
+        $short_description = substr($description, 0, 50) . '...';
+      }
+      else {
+        $short_description = $description;
+      }
+      if (user_access(MIGRATE_ACCESS_ADVANCED)) {
+        $label_format = '!description [!source_field]';
+      }
+      else {
+        $label_format = '!description';
+      }
+      $label = t($label_format, array(
+        '!source_field' => filter_xss_admin($name),
+        '!description' => filter_xss_admin($description),
+      ));
+      $short_label = t($label_format, array(
+        '!source_field' => filter_xss_admin($name),
+        '!description' => filter_xss_admin($short_description),
+      ));
+
+      $dnm_value = 0;
+
+      // Check for a click of the DNM box...
+      if (isset($form_state['values']) &&
+          $form_state['values']['source_fields'][$name] == 1) {
+        $dnm_value = 1;
+      }
+      else {
+        // ... or a source-only mapping with the DNM issue group.
+        foreach ($field_mappings as $mapping) {
+          if ($mapping->getSourceField() == $name &&
+              $mapping->getIssueGroup() == t('DNM')) {
+            $dnm_value = 1;
+          }
+        }
+      }
+
+      // So, if this field is not marked DNM, include it in possible source
+      // options in the field mappings.
+      if (!$dnm_value) {
+        $field_options[$name] = $short_label;
+      }
+
+      $form['source_fields'][$name] = array(
+        '#type' => 'checkbox',
+        '#title' => $label,
+        '#default_value' => $dnm_value,
+      );
+    }
+
+    if (isset($field_mappings['is_new'])) {
+      $default_is_new = $field_mappings['is_new']->getDefaultValue();
+    } else {
+      $default_is_new = 0;
+    }
+    foreach ($dest_fields as $name => $description) {
+      // Don't map the destination key unless is_new = 1 (ie, TRUE)
+      if (isset($dest_key[$name]) && $default_is_new == 0) {
+        continue;
+      }
+
+      if (is_array($description)) {
+        $description = reset($description);
+      }
+
+      $options = $base_options + $field_options;
+
+      $default_mapping = '-1';
+      $default_value = '';
+      if (isset($field_mappings[$name])) {
+        $mapping = $field_mappings[$name];
+      }
+      else {
+        $mapping = NULL;
+      }
+
+      // If the DNM box has been clicked, make sure we clear the mapping and
+      // default value fields.
+      if (isset($form_state['values']) &&
+          $form_state['values']['field_mappings'][$name]['issue_group'] == 1) {
+        $dnm_value = 1;
+      }
+      else {
+        // Determine the default field mapping - if we have an existing one, use
+        // that, otherwise try to match on name.
+        if (isset($field_mappings[$name])) {
+          if ($mapping->getSourceField()) {
+            $default_mapping = $mapping->getSourceField();
+          }
+          $default_value = $mapping->getDefaultValue();
+          $dnm_value = ($mapping->getIssueGroup() == t('DNM'));
+        }
+        else {
+          $dnm_value = 0;
+        }
+      }
+
+      // Only show the machine name to advanced users.
+      if (user_access(MIGRATE_ACCESS_ADVANCED)) {
+        $label = '!description [!field_name]';
+      }
+      else {
+        $label = '!description';
+      }
+
+      // Indent subfields and options to show their relationship to the parent.
+      if (strpos($name, ':') > 0) {
+        $description = '&nbsp;&nbsp;' . $description;
+      }
+
+      $form['field_mappings'][$name]['issue_group'] = array(
+        '#type' => 'checkbox',
+        '#default_value' => $dnm_value,
+      );
+
+      $form['field_mappings'][$name]['mapping'] = array(
+        '#type' => 'select',
+        '#title' => t($label,
+                      array('!description' => $description, '!field_name' => $name)),
+        '#options' => $options,
+        '#default_value' => $default_mapping,
+      );
+
+      $form['field_mappings'][$name]['default_value'] = array(
+        '#type' => 'textfield',
+        '#default_value' => $default_value,
+        '#size' => 20,
+      );
+
+      $source_migration = NULL;
+      if ($mapping) {
+        $source_migration = $mapping->getSourceMigration();
+      }
+      if (!$source_migration) {
+        $source_migration = '-1';
+      }
+      $form['field_mappings'][$name]['source_migration'] = array(
+        '#type' => 'select',
+        '#options' => $source_migration_options,
+        '#default_value' => $source_migration,
+      );
+
+      if (is_a($mapping, 'MigrateXMLFieldMapping')) {
+        /** @var MigrateXMLFieldMapping $mapping */
+        $form['field_mappings'][$name]['xpath'] = array(
+          '#type' => 'textfield',
+          '#default_value' => $mapping->getXpath(),
+          '#size' => 20,
+        );
+      }
+
+    }
+  }
+
+  unset($source_migration_options[-1]);
+  unset($source_migration_options[$migration_name]);
+
+  $form['dependencies'] = array(
     '#type' => 'fieldset',
-    '#title' => t('Migration registration'),
-    '#description' => $description,
+    '#title' => t('Dependencies'),
+    '#collapsible' => TRUE,
+    '#collapsed' => is_a($migration, 'Migration'),
+    '#theme' => 'migrate_ui_field_mapping_dependencies',
+    '#description' => t('Set any dependencies on other migrations here. A <em>hard dependency</em> means that this migration is not allowed to run until the dependent migration has completed (without forcing it). A <em>soft dependency</em> places no such requirement - it simply affects the default order of migration. Note that any migrations that would lead to circular dependencies are not listed here.'),
   );
 
-  $build['registration']['auto_register'] = array(
-    '#type' => 'submit',
-    '#value' => $button_label,
-    '#submit' => array('migrate_ui_configure_register_auto_register'),
+  // Get the list of possible dependencies - it's the same as the list of
+  // possible source migrations, minus the empty choice and ourselves.
+
+  $dependency_options = array(
+    0 => t('None'),
+    1 => t('Hard'),
+    2 => t('Soft'),
   );
 
-  if (!variable_get('migrate_disable_autoregistration', FALSE)) {
-    $build['registration']['submit'] = array(
-      '#type' => 'submit',
-      '#value' => t('Register'),
-      '#submit' => array('migrate_ui_configure_register_submit'),
+  // Remove any migrations depending on us, directly or indirectly. First, get
+  // a list of such migrations.
+  $descendent_migrations = _migrate_ui_get_descendents($migration_name,
+                                                        $all_dependencies);
+  $source_migration_options = array_diff_key($source_migration_options,
+    $descendent_migrations);
+  foreach ($source_migration_options as $machine_name) {
+    if (in_array($machine_name, $migration->getHardDependencies())) {
+      $default_value = 1;
+    }
+    elseif (in_array($machine_name, $migration->getSoftDependencies())) {
+      $default_value = 2;
+    }
+    else {
+      $default_value = 0;
+    }
+    $form['dependencies'][$machine_name] = array(
+      '#type' => 'select',
+      '#title' => check_plain($machine_name),
+      '#default_value' => $default_value,
+      '#options' => $dependency_options,
     );
   }
 
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Apply changes'),
+  );
+
+  $form['revert'] = array(
+    '#type' => 'submit',
+    '#value' => t('Revert'),
+    '#submit' => array('migrate_ui_edit_mappings_revert'),
+  );
+
+  return $form;
+}
+
+/**
+ * Generate a list of all migrations dependent on a given migration.
+ *
+ * @param $migration_name
+ * @param array $all_dependencies
+ *
+ * @return array
+ */
+function _migrate_ui_get_descendents($migration_name, array $all_dependencies) {
+  $descendents = array();
+  foreach ($all_dependencies as $machine_name => $dependencies) {
+    if (in_array($migration_name, $dependencies)) {
+      $descendents[$machine_name] = $machine_name;
+      $descendents += _migrate_ui_get_descendents($machine_name,
+                                                  $all_dependencies);
+    }
+  }
+  return $descendents;
+}
+
+/**
+ * Submit callback for the edit mappings form. Save any choices made in the
+ * UI which override mappings made in code.
+ *
+ * @param $form
+ * @param $form_state
+ */
+function migrate_ui_edit_mappings_submit(&$form, &$form_state) {
+  $machine_name = $form_state['values']['machine_name'];
+  $row = db_select('migrate_status', 'ms')
+               ->fields('ms', array('arguments', 'class_name', 'group_name'))
+               ->condition('machine_name', $machine_name)
+               ->execute()
+               ->fetchObject();
+  $class_name = $row->class_name;
+  $group_name = $row->group_name;
+  $arguments = unserialize($row->arguments);
+  $arguments['field_mappings'] = array();
+  $arguments['group_name'] = $group_name;
+  $field_mappings = array();
+  $default_values = array();
+  $issue_group_values = array();
+  $xpaths = array();
+
+  $migration = Migration::getInstance($machine_name);
+  if (is_a($migration, 'Migration')) {
+    $xml = is_a($migration, 'XMLMigration') ? TRUE : FALSE;
+    $existing_mappings = $migration->getFieldMappings();
+    $coded_mappings = $migration->getCodedFieldMappings();
+    foreach ($form_state['values']['field_mappings'] as $destination_field => $info) {
+      // Treat empty strings as NULL.
+      if ($info['default_value'] === '') {
+        $info['default_value'] = NULL;
+      }
+      if ($xml && $info['xpath'] === '') {
+        $info['xpath'] = NULL;
+      }
+
+      // If this mapping matches a coded mapping but not a stored mapping, remove
+      // it entirely (don't store it in the database) so the coded mapping is not
+      // overwritten.
+      if (isset($coded_mappings[$destination_field])) {
+        $coded_source_field =
+          $coded_mappings[$destination_field]->getSourceField();
+        $coded_default_value =
+          $coded_mappings[$destination_field]->getDefaultValue();
+        $coded_source_migration =
+          $coded_mappings[$destination_field]->getSourceMigration();
+        if ($xml) {
+          $coded_xpath =
+            $coded_mappings[$destination_field]->getXpath();
+        }
+        if ($info['mapping'] == '-1') {
+          $info['mapping'] = NULL;
+        }
+        if ($info['source_migration'] == '-1') {
+          $info['source_migration'] = NULL;
+        }
+        if ($info['issue_group'] == 0 && $coded_mappings[$destination_field]->getIssueGroup() != t('DNM') ||
+            $info['issue_group'] == 1 && $coded_mappings[$destination_field]->getIssueGroup() == t('DNM')) {
+          $dnm_matches = TRUE;
+        }
+        else {
+          $dnm_matches = FALSE;
+        }
+        if ($info['mapping'] == $coded_source_field &&
+            $info['default_value'] == $coded_default_value &&
+            $info['source_migration'] == $coded_source_migration &&
+            (!$xml || ($xml && ($info['xpath'] == $coded_xpath))) &&
+            $dnm_matches) {
+          continue;
+        }
+      }
+      // This is not a match for a coded mapping, so we will want to save it.
+      $field_mappings[$destination_field] = $info['mapping'];
+      $default_values[$destination_field] = $info['default_value'];
+      $source_migrations[$destination_field] = $info['source_migration'];
+      $issue_group_values[$destination_field] = $info['issue_group'];
+      if ($xml) {
+        $xpaths[$destination_field] = $info['xpath'];
+      }
+    }
+
+    foreach ($field_mappings as $destination_field => $source_field) {
+      if ($source_field == -1) {
+        $source_field = NULL;
+      }
+
+      if ($issue_group_values[$destination_field]) {
+        $source_field = NULL;
+        $default = NULL;
+      }
+      else {
+        $default = $default_values[$destination_field];
+      }
+
+      // Until we can provide editing of all the options that go along with
+      // field mappings, we want to avoid overwriting pre-existing mappings and
+      // losing important bits.
+      $mapping = NULL;
+      if (isset($existing_mappings[$destination_field]) &&
+          $issue_group_values[$destination_field] != 0) {
+        /** @var MigrateFieldMapping $old_mapping */
+        $old_mapping = $existing_mappings[$destination_field];
+        if ($source_field == $old_mapping->getSourceField() &&
+            $default_values[$destination_field] == $old_mapping->getDefaultValue() &&
+            $source_migrations[$destination_field] == $old_mapping->getSourceMigration() &&
+            (!$xml || ($xml && ($xpaths[$destination_field] == $old_mapping->getXpath())))) {
+          // First, if this mapping matches a previously-stored mapping, we want to
+          // preserve it as it was originally stored.
+          if ($old_mapping->getMappingSource() ==
+              MigrateFieldMapping::MAPPING_SOURCE_DB) {
+            $mapping = $old_mapping;
+          }
+          // If it matches a coded mapping, then we don't want to save it at all.
+          else {
+            continue;
+          }
+        }
+      }
+
+      // We're not skipping this mapping, or preserving an old one, so create the
+      // new mapping.
+      if (!$mapping) {
+        $mapping = _migrate_ui_get_mapping_object($migration, $destination_field, $source_field);
+        $mapping->defaultValue($default);
+        if ($xml && $xpaths[$destination_field]) {
+          $mapping->xpath($xpaths[$destination_field]);
+        }
+      }
+
+      if ($issue_group_values[$destination_field]) {
+        $mapping->issueGroup(t('DNM'));
+      }
+      else {
+        $mapping->issueGroup(NULL);
+      }
+
+      if ($source_migrations[$destination_field] &&
+          $source_migrations[$destination_field] != '-1') {
+        $mapping->sourceMigration($source_migrations[$destination_field]);
+      }
+
+      $arguments['field_mappings'][] = $mapping;
+    }
+
+    // Handle any source fields marked DNM.
+    foreach ($form_state['values']['source_fields'] as $source_field => $value) {
+      // Is this field ignored in the code?
+      $code_ignored = FALSE;
+      foreach ($coded_mappings as $destination_field => $mapping) {
+        if (is_numeric($destination_field) &&
+            $mapping->getSourceField() == $source_field) {
+          $code_ignored = TRUE;
+        }
+      }
+      // If it is marked DNM in the UI, but is not ignored in the code,
+      // generate a DNM mapping.
+      if ($value && !$code_ignored) {
+        $mapping = _migrate_ui_get_mapping_object($migration, NULL, $source_field);
+        $mapping->issueGroup(t('DNM'));
+        $arguments['field_mappings'][] = $mapping;
+      }
+      // If it is marked DNM in the code, but is unchecked in the UI, see if
+      // it's mapped to a destination field through the UI. If not, generate
+      // an empty mapping without the DNM so it's available to be mapped.
+      elseif (!$value && $code_ignored) {
+        $mapping_found = FALSE;
+        foreach ($field_mappings as $destination_field => $mapped_source_field) {
+          if ($source_field == $mapped_source_field) {
+            $mapping_found = TRUE;
+            break;
+          }
+        }
+        if (!$mapping_found) {
+          $mapping = _migrate_ui_get_mapping_object($migration, NULL, $source_field);
+          $arguments['field_mappings'][] = $mapping;
+        }
+      }
+    }
+  }
+
+  $arguments['dependencies'] = $arguments['soft_dependencies'] = array();
+  if (isset($form_state['values']['dependencies'])) {
+    foreach ($form_state['values']['dependencies'] as $dependency => $value) {
+      if ($value == 1) {
+        $arguments['dependencies'][] = $dependency;
+      }
+      elseif ($value == 2) {
+        $arguments['soft_dependencies'][] = $dependency;
+      }
+    }
+  }
+
+  Migration::registerMigration($class_name, $machine_name, $arguments);
+
+  drupal_set_message(t('Migration changes applied.'));
+  $form_state['redirect'] =
+    "admin/content/migrate/groups/$group_name/$machine_name";
+}
+
+/**
+ * Create a field mapping object of the appropriate class.
+ *
+ * @param $migration
+ *
+ * @return MigrateFieldMapping
+ */
+function _migrate_ui_get_mapping_object($migration, $destination, $source) {
+  if (is_a($migration, 'XMLMigration')) {
+    return new MigrateXMLFieldMapping($destination, $source);
+  }
+  else {
+    return new MigrateFieldMapping($destination, $source);
+  }
+}
+
+/**
+ * Revert callback for the edit mappings form. Remove any field mappings that
+ * were defined through the UI.
+ *
+ * @param $form
+ * @param $form_state
+ */
+function migrate_ui_edit_mappings_revert(&$form, &$form_state) {
+  $machine_name = $form_state['values']['machine_name'];
+  db_delete('migrate_field_mapping')
+    ->condition('machine_name', $machine_name)
+    ->execute();
+  // Note that not all field mappings in the database came from the UI - they
+  // may also have been passed through a hook_migrate_api registration, so
+  // reregister the migration to restore those mappings.
+  migrate_static_registration(array($machine_name));
+}
+
+/**
+ * Theme function to layout field mappings in a table.
+ *
+ * @param array $variables
+ *
+ * @return string
+ *  Rendered markup.
+ */
+function theme_migrate_ui_field_mapping_form($variables) {
+  $output = '';
+  $form = $variables['field_mappings'];
+  $elements = element_children($form);
+  if (!empty($elements)) {
+    $header = array(t('DNM'), t('Destination field'), t('Source field'),
+                    t('Default value'), t('Source migration'));
+    if (!empty($form['#is_xml_migration'])) {
+      $header[] = t('Xpath');
+    }
+    $rows = array();
+    foreach ($elements as $mapping_key) {
+      $row = array();
+      $title = $form[$mapping_key]['mapping']['#title'];
+      unset($form[$mapping_key]['mapping']['#title']);
+      $row[] = drupal_render($form[$mapping_key]['issue_group']);
+      $row[] = $title;
+      $row[] = drupal_render($form[$mapping_key]['mapping']);
+      $row[] = drupal_render($form[$mapping_key]['default_value']);
+      $row[] = drupal_render($form[$mapping_key]['source_migration']);
+      if (!empty($form['#is_xml_migration'])) {
+        $row[] = drupal_render($form[$mapping_key]['xpath']);
+      }
+      $rows[] = $row;
+    }
+    $output .= theme('table', array('header' => $header, 'rows' => $rows));
+  }
+  $output .= drupal_render_children($form);
+  return $output;
+}
+
+/**
+ * Theme function to layout dependencies in a table.
+ *
+ * @param array $variables
+ *
+ * @return string
+ *  Rendered markup.
+ */
+function theme_migrate_ui_field_mapping_dependencies($variables) {
+  $output = '';
+  $form = $variables['dependencies'];
+  $header = array(t('Migration'), t('Dependency'));
+  $rows = array();
+  $elements = element_children($form);
+  foreach ($elements as $mapping_key) {
+    $row = array();
+    $title = $form[$mapping_key]['#title'];
+    unset($form[$mapping_key]['#title']);
+    $row[] = $title;
+    $row[] = drupal_render($form[$mapping_key]);
+    $rows[] = $row;
+  }
+  $output .= theme('table', array('rows' => $rows, 'header' => $header, 'empty' => t('No other migrations were found.')));
+
+  $output .= drupal_render_children($form);
+  return $output;
+}
+
+/**
+ * Menu callback for messages page
+ */
+function migrate_ui_messages($group_name, $migration_name) {
+  drupal_set_title(t('Import messages for !migration',
+                   array('!migration' => $migration_name)));
+
+  $build = $rows = array();
+
+  $migration = Migration::getInstance($migration_name);
+  if (!$migration) {
+    return $build;
+  }
+
+  $source_key = $migration->getMap()->getSourceKey();
+  $source_key_map = $migration->getMap()->getSourceKeyMap();
+  $source_key_map_flipped = array_flip($source_key_map);
+
+  $header = array();
+  // Add a table header for each source key in the migration's map.
+  foreach ($source_key as $key => $map_info) {
+    $header[] = array(
+      'data' => filter_xss_admin($map_info['description']),
+      'field' => $source_key_map[$key],
+      'sort' => 'asc',
+    );
+  }
+
+  $header[] = array('data' => t('Level'), 'field' => 'level');
+  $header[] = array('data' => t('Message'), 'field' => 'message');
+
+  // TODO: need a general MigrateMap API
+  $messages = $migration->getMap()->getConnection()
+              ->select($migration->getMap()->getMessageTable(), 'msg')
+              ->extend('PagerDefault')
+              ->extend('TableSort')
+              ->orderByHeader($header)
+              ->limit(500)
+              ->fields('msg')
+              ->execute();
+
+  foreach ($messages as $message) {
+    $classes[] = $message->level <= MigrationBase::MESSAGE_WARNING ? 'migrate-error' : '';
+    $row = array();
+    // Add a table column for each source key.
+    foreach ($source_key_map_flipped as $source_key => $source_field) {
+      $row[] = array(
+        'data' => filter_xss_admin($message->{$source_key}),
+        'class' => $classes,
+      );
+    }
+    $row[] = array(
+      'data' => filter_xss_admin($migration->getMessageLevelName($message->level)),
+      'class' => $classes,
+    );
+    $row[] = array(
+      'data' => filter_xss_admin($message->message),
+      'class' => $classes,
+    );
+
+    $rows[] = $row;
+
+    unset($classes);
+  }
+
+  $build['messages'] = array(
+    '#theme' => 'table',
+    '#header' => $header,
+    '#rows' => $rows,
+    '#empty' => t('No messages'),
+    '#attached' => array(
+      'css' => array(drupal_get_path('module', 'migrate_ui') . '/migrate_ui.css'),
+    ),
+  );
+  $build['migrate_ui_pager'] = array('#theme' => 'pager');
   return $build;
 }
 
 /**
- * Submit callback for the configuration form registration fieldset.
+ * Given a migration machine name, remove its tracking from the database.
+ *
+ * @param $machine_name
  */
-function migrate_ui_configure_register_submit($form, &$form_state) {
-  migrate_autoregister();
-  $form_state['redirect'] = 'admin/content/migrate';
-}
-
-/**
- * Submit callback for the configuration form auto-registration changes.
- */
-function migrate_ui_configure_register_auto_register($form, &$form_state) {
-  variable_set('migrate_disable_autoregistration',
-    !variable_get('migrate_disable_autoregistration', FALSE));
+function migrate_ui_deregister_migration($machine_name) {
+  // The class is gone, so we'll manually clear migrate_status, and make
+  // the default assumptions about the map/message tables.
+  db_drop_table('migrate_map_' . strtolower($machine_name));
+  db_drop_table('migrate_message_' . strtolower($machine_name));
+  db_delete('migrate_status')
+    ->condition('machine_name', $machine_name)
+    ->execute();
+  db_delete('migrate_field_mapping')
+    ->condition('machine_name', $machine_name)
+    ->execute();
+  drupal_set_message(t("Deregistered '!description' task",
+    array('!description' => $machine_name)));
 }
 
 /**
  * Menu callback
  */
-function migrate_ui_handlers() {
-  drupal_set_title(t('Migrate handler configuration'));
-  return drupal_get_form('migrate_ui_handlers_form');
+function migrate_ui_configure() {
+  drupal_set_title(t('Configure migration settings'));
+  return drupal_get_form('migrate_ui_configure_form');
 }
 
 /**
  * Form for reviewing migrations.
  */
-function migrate_ui_handlers_form($form, &$form_state) {
+function migrate_ui_configure_form($form, &$form_state) {
   $build = array();
+
+  $description = t('To register (or reregister with updated arguments) any
+    migrations defined in hook_migrate_api(), click the <strong>Register</strong>
+    button below.');
+
+  $build['registration'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Registration'),
+    '#description' => $description,
+  );
+
+  $build['registration']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Register statically defined classes'),
+    '#submit' => array('migrate_ui_configure_register_submit'),
+  );
+
+  $migrations = array();
+  $result = db_select('migrate_status', 'ms')
+                ->fields('ms', array('class_name', 'machine_name'))
+                ->execute();
+  $migration_list = '';
+  foreach ($result as $row) {
+    if (!class_exists($row->class_name)) {
+      $migrations[] = $row->machine_name;
+      $migration_list .= '<li>' . t('!migration (class !class)',
+        array(
+          '!migration' => filter_xss_admin($row->machine_name),
+          '!class' => filter_xss_admin($row->class_name),
+        )) . "</li>\n";
+    }
+  }
+
+  if (!empty($migrations)) {
+    $description = t('No class currently exists for the following migrations: <ul>!list</ul>',
+      array('!list' => $migration_list));
+    $build['deregistration'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Orphaned migration tasks'),
+      '#description' => $description,
+    );
+    $build['deregistration']['submit'] = array(
+      '#type' => 'submit',
+      '#value' => t('Deregister orphans'),
+      '#submit' => array('migrate_ui_configure_deregister_submit'),
+    );
+  }
+
+  $build['settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Settings'),
+  );
+  $build['settings']['deprecation_warnings'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Warn on usage of deprecated patterns'),
+    '#default_value' => variable_get('migrate_deprecation_warnings', 1),
+    '#description' => t('When checked, you will receive warnings when using methods and patterns that are deprecated as of Migrate 2.6.'),
+  );
+  $build['settings']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save settings'),
+    '#submit' => array('migrate_ui_configure_settings_submit'),
+  );
+
+  // Configure background imports if the drush command has been set.
+  $drush_path = trim(variable_get('migrate_drush_path', ''));
+  $drush_validated = FALSE;
+  if ($drush_path && is_executable($drush_path)) {
+    // Try running a drush status command to verify it's properly configured.
+    $uri = $GLOBALS['base_url'];
+    $uid = $GLOBALS['user']->uid;
+    $command = "$drush_path status --user=$uid --uri=$uri --root=" . DRUPAL_ROOT;
+    exec($command, $output, $status);
+    if ($status == 0) {
+      $version = '';
+      foreach ($output as $line) {
+        if (preg_match('|Drush version +: +(.*)|', $line, $matches)) {
+          $version = trim($matches[1]);
+        }
+        elseif (preg_match('|Drupal bootstrap +: +Successful *|', $line, $matches)) {
+          $drush_validated = TRUE;
+        }
+      }
+    }
+    if ($drush_validated) {
+      $description = t('Configure the use of <a href="@drush">drush</a> version @version to run import and rollback operations in the background.',
+        array(
+          '@drush' => 'http://drupal.org/project/drush',
+          '@version' => $version,
+        )
+      );
+    }
+    else {
+      $description = t('<a href="@drush">Drush</a> is misconfigured on the server. Please review the <a href="@config">documentation</a> on <a href="@dorg">drupal.org</a>, and make sure everything is set up correctly.',
+        array(
+          '@drush' => 'http://drupal.org/project/drush',
+          '@config' => 'http://drupal.org/node/1958170',
+        )
+      );
+    }
+  }
+  else {
+    $description = t('To enable running operations in the background with <a href="@drush">drush</a>, (which is <a href="@recommended">recommended</a>), some configuration must be done on the server. See the <a href="@config">documentation</a> on <a href="@dorg">drupal.org</a>.',
+      array(
+        '@drush' => 'http://drupal.org/project/drush',
+        '@recommended' => 'http://drupal.org/node/1806824',
+        '@config' => 'http://drupal.org/node/1958170',
+        '@dorg' => 'http://drupal.org/',
+      )
+    );
+  }
+
+  $build['drush'] = array(
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    '#title' => t('Background operations'),
+    '#description' => $description,
+  );
+
+  if ($drush_validated) {
+    $options = array(
+      0 => t('Immediate operation only'),
+      1 => t('Background operation only'),
+      2 => t('Allows both immediate and background operations'),
+    );
+    $build['drush']['migrate_import_method'] = array(
+      '#type' => 'select',
+      '#options' => $options,
+      '#default_value' => variable_get('migrate_import_method', 0),
+      '#title' => t('Import method'),
+      '#description' => t('Choose whether the dashboard will perform operations immediately, in the background via drush, or offer a choice.'),
+    );
+
+    $build['drush']['migrate_drush_mail'] = array(
+      '#type' => 'checkbox',
+      '#default_value' => variable_get('migrate_drush_mail', 0),
+      '#title' => t('Send email notification when a background operation completes.'),
+    );
+
+    $build['drush']['migrate_drush_mail_subject'] = array(
+      '#type' => 'textfield',
+      '#default_value' => variable_get('migrate_drush_mail_subject',
+        t('Migration operation completed')),
+      '#title' => t('Subject'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="migrate_drush_mail"]' => array('checked' => TRUE),
+        ),
+      ),
+    );
+
+    $build['drush']['migrate_drush_mail_body'] = array(
+      '#type' => 'textarea',
+      '#rows' => 10,
+      '#default_value' => variable_get('migrate_drush_mail_body',
+        t('The migration operation is complete. Please review the results on your dashboard')),
+      '#title' => t('Body'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="migrate_drush_mail"]' => array('checked' => TRUE),
+        ),
+      ),
+    );
+
+    $build['drush']['save_drush_config'] = array(
+      '#type' => 'submit',
+      '#value' => t('Save background configuration'),
+      '#submit' => array('migrate_ui_configure_drush_submit'),
+    );
+  }
 
   $build['handlers'] = array(
     '#type' => 'fieldset',
-    '#title' => t('Handler configuration'),
-    '#description' => t('In some cases, such as when a field handler for a contributed module is
-          implemented in both migrate_extras and the module itself, you may need to disable
-          a particular handler. In this case, you may uncheck the undesired handler below.'),
+    '#title' => t('Handlers'),
+    '#description' => t('In some cases, such as when a field handler for a contributed module is implemented in both migrate_extras and the module itself, you may need to disable a particular handler. In this case, you may uncheck the undesired handler below.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
   );
 
   $build['handlers']['destination'] = array(
@@ -825,7 +1905,8 @@ function migrate_ui_handlers_form($form, &$form_state) {
     'types' => array('data' => t('Destination types handled')),
   );
 
-  $disabled = unserialize(variable_get('migrate_disabled_handlers', serialize(array())));
+  $disabled = unserialize(variable_get('migrate_disabled_handlers',
+                                       serialize(array())));
   $class_list = _migrate_class_list('MigrateDestinationHandler');
   $rows = array();
   $default_values = array();
@@ -837,9 +1918,9 @@ function migrate_ui_handlers_form($form, &$form_state) {
               ->condition('type', 'class')
               ->execute()
               ->fetchField();
-    $row['module'] = $module;
-    $row['class'] = $class_name;
-    $row['types'] = implode(', ', $handler->getTypesHandled());
+    $row['module'] = check_plain($module);
+    $row['class'] = check_plain($class_name);
+    $row['types'] = filter_xss_admin(implode(', ', $handler->getTypesHandled()));
     $default_values[$class_name] = !in_array($class_name, $disabled);
     $rows[$class_name] = $row;
   }
@@ -874,9 +1955,9 @@ function migrate_ui_handlers_form($form, &$form_state) {
               ->condition('type', 'class')
               ->execute()
               ->fetchField();
-    $row['module'] = $module;
-    $row['class'] = $class_name;
-    $row['types'] = implode(', ', $handler->getTypesHandled());
+    $row['module'] = check_plain($module);
+    $row['class'] = check_plain($class_name);
+    $row['types'] = filter_xss_admin(implode(', ', $handler->getTypesHandled()));
     $default_values[$class_name] = !in_array($class_name, $disabled);
     $rows[$class_name] = $row;
   }
@@ -891,16 +1972,60 @@ function migrate_ui_handlers_form($form, &$form_state) {
   $build['handlers']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save handler statuses'),
-    '#submit' => array('migrate_ui_handlers_submit'),
+    '#submit' => array('migrate_ui_configure_submit'),
   );
 
   return $build;
 }
 
 /**
- * Submit callback for the configuration form handler fieldset.
+ * Submit callback for the configuration form registration fieldset.
  */
-function migrate_ui_handlers_submit($form, &$form_state) {
+function migrate_ui_configure_register_submit($form, &$form_state) {
+  migrate_static_registration();
+  drupal_set_message(t('All statically defined migrations have been (re)registered.'));
+  $form_state['redirect'] = 'admin/content/migrate';
+}
+
+/**
+ * Submit callback for the configuration form deregistration fieldset.
+ */
+function migrate_ui_configure_deregister_submit($form, &$form_state) {
+  $result = db_select('migrate_status', 'ms')
+                ->fields('ms', array('class_name', 'machine_name'))
+                ->execute();
+  foreach ($result as $row) {
+    if (!class_exists($row->class_name)) {
+      migrate_ui_deregister_migration($row->machine_name);
+    }
+  }
+  $form_state['redirect'] = 'admin/content/migrate';
+}
+
+/**
+ * Submit callback for the configuration form settings fieldset.
+ */
+function migrate_ui_configure_settings_submit($form, &$form_state) {
+  variable_set('migrate_deprecation_warnings',
+               $form_state['values']['deprecation_warnings']);
+  drupal_set_message(t('Migration settings saved.'));
+}
+
+/**
+ * Submit callback for the drush configuration form handler fieldset.
+ */
+function migrate_ui_configure_drush_submit($form, &$form_state) {
+  $values = $form_state['values'];
+  variable_set('migrate_import_method', $values['migrate_import_method']);
+  variable_set('migrate_drush_mail', $values['migrate_drush_mail']);
+  variable_set('migrate_drush_mail_subject', $values['migrate_drush_mail_subject']);
+  variable_set('migrate_drush_mail_body', $values['migrate_drush_mail_body']);
+}
+
+/**
+ * Submit callback for the handler configuration form handler fieldset.
+ */
+function migrate_ui_configure_submit($form, &$form_state) {
   $disabled = array();
   foreach ($form_state['values']['destination_handlers'] as $class => $value) {
     if (!$value) {

--- a/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.wizard.inc
+++ b/docroot/sites/all/modules/migration/migrate/migrate_ui/migrate_ui.wizard.inc
@@ -1,0 +1,663 @@
+<?php
+
+/**
+ * @file
+ * Migration wizard framework.
+ */
+
+/**
+ * The primary formbuilder function for the wizard form.
+ *
+ * This form has two defined submit handlers to process the different steps:
+ *  - Previous: handles the way to get back one step in the wizard.
+ *  - Next:     handles each step form submission,
+ *
+ * The third handler, the finish button handler, is the default form _submit
+ * handler used to process the information.
+ *
+ * @param string $class_name
+ *  Name of the MigrateUIWizard clsas for this wizard.
+ */
+function migrate_ui_wizard($form, &$form_state, $class_name = '') {
+  // Rather than track state in $form_state, we simply keep our wizard
+  // instance there, and it encapsulates all the state. We just need
+  // to create the instance the first time in, and it will be serialized
+  // between steps.
+  /** @var MigrateUIWizard $wizard */
+  if (empty($form_state['wizard'])) {
+    $wizard = new $class_name();
+
+    // Add any extenders.
+    $module_apis = migrate_get_module_apis();
+    // Need a second pass at this to add wizard extenders.
+    foreach ($module_apis as $module => $info) {
+      // Add any extenders.
+      // @todo: consider allowing extender classes to declare dependencies on
+      // other extender classes, to ensure they work in the correct order?
+      if (isset($info['wizard extenders'])) {
+        foreach ($info['wizard extenders'] as $wizard_class => $extender_classes) {
+          // Note that $class_name is in lower case, so we can't just use isset()
+          // to find our wizard.
+          if (strtolower($wizard_class) == $class_name) {
+            foreach ($extender_classes as $extender_class) {
+              $wizard->addExtender($extender_class);
+            }
+          }
+        }
+      }
+    }
+
+    $form_state['wizard'] = $wizard;
+  }
+  else {
+    $wizard = $form_state['wizard'];
+  }
+
+  // Fetch the form for the wizard's current step.
+  $form = $wizard->form($form_state);
+
+  return $form;
+}
+
+/**
+ * Submit handler for the "previous" button. Moves the wizard back to the
+ * previous step, and retrieves the values that were submitted on that step.
+ *
+ * @todo: Can we remove steps that were dynamically added?
+ */
+function migrate_ui_wizard_previous_submit($form, &$form_state) {
+  /** @var MigrateUIWizard $wizard */
+  $wizard = $form_state['wizard'];
+  $wizard->gotoPreviousStep($form_state);
+}
+
+/**
+ * Validate handler for the 'next' button. Dispatches to the wizard's current
+ * step for validation.
+ */
+function migrate_ui_wizard_next_validate($form, &$form_state) {
+  /** @var MigrateUIWizard $wizard */
+  $wizard = $form_state['wizard'];
+  $wizard->formValidate($form_state);
+}
+
+/**
+ * Submit handler for the 'next' button. Saves the form values for the step
+ * we're leaving, so Previous can pick them up, and moves the wizard to the
+ * next step.
+ */
+function migrate_ui_wizard_next_submit($form, &$form_state) {
+  /** @var MigrateUIWizard $wizard */
+  $wizard = $form_state['wizard'];
+  $wizard->gotoNextStep($form_state);
+}
+
+/**
+ * Submit handler for the Save settings button. Register the migrations that were
+ * (implicitly) defined along the way and redirect to the Migrate dashboard.
+ */
+function migrate_ui_wizard_submit($form, &$form_state) {
+  /** @var MigrateUIWizard $wizard */
+  $wizard = $form_state['wizard'];
+  $wizard->formSaveSettings();
+  $form_state['redirect'] = 'admin/content/migrate/groups/' .
+                            $wizard->getGroupName();
+}
+
+/**
+ * Submit handler for the "Save settings and import" button. Register the
+ * migrations that were (implicitly) defined along the way, run the import, and
+ * redirect to the Migrate dashboard.
+ */
+function migrate_ui_wizard_migrate_submit($form, &$form_state) {
+  /** @var MigrateUIWizard $wizard */
+  $wizard = $form_state['wizard'];
+  $wizard->formSaveSettings();
+  $wizard->formPerformImport();
+  $form_state['redirect'] = 'admin/content/migrate/groups/' .
+                            $wizard->getGroupName();
+}
+
+/**
+ * The base class for migration wizards. Extend this class to implement a
+ * wizard UI for importing into Drupal from a given source format (Drupal,
+ * WordPress, etc.).
+ */
+abstract class MigrateUIWizard {
+  /**
+   * We maintain a doubly-linked list of wizard steps, both to support
+   * previous/next, and to easily insert steps dynamically.
+   *
+   * The first step of the wizard, which has no predecessor. Will generally be
+   * an overview/introductory page.
+   *
+   * @var MigrateUIStep
+   */
+  protected $firstStep;
+
+  /**
+   * The last step of the wizard, which has no successor. Will generally be a
+   * review page.
+   *
+   * @var MigrateUIStep
+   */
+  protected $lastStep;
+
+  /**
+   * Get the list of steps currently defined.
+   *
+   * @return
+   *  An array of MigrateUIStep objects, in the order defined, keyed by the step
+   *  name.
+   */
+  protected function getSteps() {
+    $steps = array();
+
+    $steps[$this->firstStep->getName()] = $this->firstStep;
+    $next_step = $this->firstStep->nextStep;
+    while (!is_null($next_step)) {
+      $steps[$next_step->getName()] = $next_step;
+
+      $next_step = $next_step->nextStep;
+    }
+
+    return $steps;
+  }
+
+  /**
+   * The current step of the wizard (the one being shown in the UI, and the one
+   * whose button is being clicked on).
+   *
+   * @var MigrateUIStep
+   */
+  protected $currentStep;
+
+  /**
+   * The step number, used in the page title.
+   *
+   * @var int
+   */
+  protected $stepNumber = 1;
+
+  /**
+   * The group name to assign to any Migration instances created.
+   *
+   * @var string
+   */
+  protected $groupName = 'default';
+  public function getGroupName() {
+    return $this->groupName;
+  }
+
+  /**
+   * The user-visible title of the group.
+   *
+   * @var string
+   */
+  protected $groupTitle = 'default';
+
+  /**
+   * Any arguments that apply to all migrations in the group.
+   *
+   * @var array
+   */
+  protected $groupArguments = array();
+
+  /**
+   * Array of Migration argument arrays, keyed by machine name. On Finish, used
+   * to register Migrations.
+   *
+   * @var array
+   */
+  protected $migrations = array();
+
+  /**
+   * Array of MigrateUIWizardExtender objects that extend this wizard.
+   *
+   * @var array
+   */
+  protected $extenders = array();
+  public function getExtender($extender_class) {
+    if (isset($this->extenders[$extender_class])) {
+      return $this->extenders[$extender_class];
+    }
+    else {
+      return NULL;
+    }
+  }
+
+  /**
+   * Returns the translatable name representing the source of the data (e.g.,
+   * "Drupal", "WordPress", etc.).
+   *
+   * @return string
+   */
+  abstract public function getSourceName();
+
+  public function __construct() {}
+
+  /**
+   * Add a wizard extender.
+   *
+   * This initializes the new extender and adds it to our internal list.
+   *
+   * @param $extender_class
+   *  The name of an extender class.
+   */
+  public function addExtender($extender_class) {
+    $steps = $this->getSteps();
+
+    $extender = new $extender_class($this, $steps);
+    $this->extenders[$extender_class] = $extender;
+  }
+
+  /**
+   * Add a step to the wizard, using a step name and method.
+   *
+   * @param string $name
+   *  Translatable name for the step, to be used in the page title.
+   * @param callable $form_method
+   *  Callable returning the form array for the step. This can be either the
+   *  name of a MigrateUIWizard method, or a callable array specifying a method
+   *  on a wizard extender. The validation method is formed from the method's
+   *  name with the suffix 'Validate' added.
+   * @param MigrateUIStep $after
+   *  Optional step after which to insert the new step. If omitted, add it at
+   *  the end.
+   * @param mixed $context
+   *  Optional data to be used by this step's form.
+   *
+   * @return MigrateUIStep
+   */
+  public function addStep($name, $form_method, MigrateUIStep $after = NULL, $context = NULL) {
+    if (!is_array($form_method)) {
+      $form_method = array($this, $form_method);
+    }
+
+    $new_step = new MigrateUIStep($name, $form_method, $context);
+
+    // There were no steps, so this is the only one.
+    if (is_null($this->firstStep)) {
+      $this->firstStep = $this->lastStep = $this->currentStep = $new_step;
+    }
+    else {
+      // If no insertion point is specified, append to the end.
+      if (is_null($after)) {
+        $after = $this->lastStep;
+      }
+      // Do the insert, rewriting the links appropriately.
+      $new_step->nextStep = $after->nextStep;
+
+      if (is_null($new_step->nextStep)) {
+        $this->lastStep = $new_step;
+      }
+      else {
+        $new_step->nextStep->previousStep = $new_step;
+      }
+      $new_step->previousStep = $after;
+      $after->nextStep = $new_step;
+    }
+    return $new_step;
+  }
+
+  /**
+   * Remove the named step from the wizard.
+   *
+   * @param $name
+   */
+  protected function removeStep($name) {
+    for ($current_step = $this->firstStep; !is_null($current_step); $current_step = $current_step->nextStep) {
+      if ($current_step->getName() == $name) {
+        if (is_null($current_step->previousStep)) {
+          $this->firstStep = $current_step->nextStep;
+        }
+        else {
+          $current_step->previousStep->nextStep = $current_step->nextStep;
+        }
+        if (is_null($current_step->nextStep)) {
+          $this->lastStep = $current_step->previousStep;
+        }
+        else {
+          $current_step->nextStep->previousStep = $current_step->previousStep;
+        }
+        break;
+      }
+    }
+  }
+
+  /**
+   * Move the wizard to the next step in line (if any), first squirreling away
+   * the current step's form values.
+   */
+  public function gotoNextStep(&$form_state) {
+    if ($this->currentStep && $this->currentStep->nextStep) {
+      $this->currentStep->setFormValues($form_state['values']);
+      $form_state['rebuild'] = TRUE;
+      $this->currentStep = $this->currentStep->nextStep;
+      $this->stepNumber++;
+
+      // Ensure a page reload remains on the current step.
+      $current_step_form_values = $this->currentStep->getFormValues();
+      if (!empty($current_step_form_values)) {
+        $form_state['values'] = $current_step_form_values;
+      }
+      else {
+        $form_state['values'] = array();
+      }
+    }
+  }
+
+  /**
+   * Move the wizard to the previous step in line (if any), restoring its
+   * form values.
+   */
+  public function gotoPreviousStep(&$form_state) {
+    if ($this->currentStep && $this->currentStep->previousStep) {
+      $this->currentStep = $this->currentStep->previousStep;
+      $this->stepNumber--;
+      $form_state['values'] = $this->currentStep->getFormValues();
+      $form_state['rebuild'] = TRUE;
+    }
+  }
+
+  /**
+   * Build the form for the current step.
+   *
+   * @return array
+   */
+  public function form(&$form_state) {
+    drupal_set_title(t('Import from @source_title',
+      array('@source_title' => $this->getSourceName())));
+
+    $form_method = $this->currentStep->getFormMethod();
+    $form['title'] = array(
+      '#prefix' => '<h2>',
+      '#markup' => t('Step @step: @step_name',
+          array(
+                '@step' => $this->stepNumber,
+                '@step_name' => $this->currentStep->getName())),
+      '#suffix' => '</h2>',
+    );
+
+    $form += call_user_func($form_method, $form_state);
+
+    $form['actions'] = array('#type' => 'actions');
+
+    // Show the 'previous' button if appropriate. Note that #submit is set to
+    // a special submit handler, and that we use #limit_validation_errors to
+    // skip all complaints about validation when using the back button. The
+    // values entered will be discarded, but they will not be validated, which
+    // would be annoying in a "back" button.
+    if ($this->currentStep != $this->firstStep) {
+      $form['actions']['prev'] = array(
+        '#type' => 'submit',
+        '#value' => t('Previous'),
+        '#name' => 'prev',
+        '#submit' => array('migrate_ui_wizard_previous_submit'),
+        '#limit_validation_errors' => array(),
+      );
+    }
+
+    // Show the Next button only if there are more steps defined.
+    if ($this->currentStep == $this->lastStep) {
+      $form['actions']['finish'] = array(
+        '#type' => 'submit',
+        '#value' => t('Save import settings'),
+      );
+
+      $form['actions']['migrate'] = array(
+        '#type' => 'submit',
+        '#value' => t('Save import settings and run import'),
+        '#submit' => array('migrate_ui_wizard_migrate_submit'),
+      );
+    }
+    else {
+      $form['actions']['next'] = array(
+        '#type' => 'submit',
+        '#value' => t('Next'),
+        '#name' => 'next',
+        '#submit' => array('migrate_ui_wizard_next_submit'),
+        '#validate' => array('migrate_ui_wizard_next_validate'),
+      );
+    }
+    return $form;
+  }
+
+  /**
+   * Call the validation function for the current form (which has the same
+   * name of the form function with 'Validate' appended).
+   *
+   * @param array $form_state
+   */
+  public function formValidate(&$form_state) {
+    $validate_method = $this->currentStep->getFormMethod();
+
+    // This is an array for a method, or a function name.
+    if (is_array($validate_method)) {
+      $validate_method[1] .= 'Validate';
+    }
+    else {
+      $validate_method .= 'Validate';
+    }
+
+    if (is_callable($validate_method)) {
+      call_user_func($validate_method, $form_state);
+    }
+  }
+
+  /**
+   * Take the information we've accumulated throughout the wizard, and create
+   * the Migrations to perform the import.
+   */
+  public function formSaveSettings() {
+    MigrateGroup::register($this->groupName, $this->groupTitle, $this->groupArguments);
+    $info['arguments']['group_name'] = $this->groupName;
+    foreach ($this->migrations as $machine_name => $info) {
+      // Call the right registerMigration implementation. Note that this means
+      // that classes that override registerMigration() must handle registration
+      // themselves, they cannot leave it to us and expect their extension to be
+      // called.
+      if (is_subclass_of($info['class_name'], 'Migration')) {
+        Migration::registerMigration($info['class_name'], $machine_name,
+                $info['arguments']);
+      }
+      else {
+        MigrationBase::registerMigration($info['class_name'], $machine_name,
+                $info['arguments']);
+      }
+    };
+    menu_rebuild();
+  }
+
+  /**
+   * Run the import process for the migration group we've defined.
+   */
+  public function formPerformImport() {
+    $migrations = migrate_migrations();
+    $operations = array();
+    /** @var Migration $migration */
+    foreach ($migrations as $migration) {
+      $group_name = $migration->getGroup()->getName();
+      if ($group_name == $this->groupName) {
+        $operations[] = array('migrate_ui_batch', array('import', $migration->getMachineName(), NULL, 0));
+      }
+    }
+
+    if (count($operations) > 0) {
+      $batch = array(
+        'operations' => $operations,
+        'title' => t('Import processing'),
+        'file' => drupal_get_path('module', 'migrate_ui') . '/migrate_ui.pages.inc',
+        'init_message' => t('Starting import process'),
+        'progress_message' => t(''),
+        'error_message' => t('An error occurred. Some or all of the import processing has failed.'),
+        'finished' => 'migrate_ui_batch_finish',
+      );
+      batch_set($batch);
+    }
+  }
+
+  /**
+   * Record all the information necessary to register a migration when this is
+   * all over.
+   *
+   * @param string $machine_name
+   *  Machine name for the migration class.
+   * @param string $class_name
+   *  Name of the Migration class to instantiate.
+   * @param array $arguments
+   *  Further information configuring the migration.
+   */
+  public function addMigration($machine_name, $class_name, $arguments) {
+    // Give extenders an opportunity to modify or reject this migration.
+    foreach ($this->extenders as $extender) {
+      if (!$extender->addMigrationAlter($machine_name, $class_name, $arguments, $this)) {
+        return FALSE;
+      }
+    }
+
+    $machine_name = $this->groupName . $machine_name;
+    if (isset($arguments['dependencies'])) {
+      foreach ($arguments['dependencies'] as $index => $dependency) {
+        $arguments['dependencies'][$index] = $this->groupName . $dependency;
+      }
+    }
+    if (isset($arguments['soft_dependencies'])) {
+      foreach ($arguments['soft_dependencies'] as $index => $dependency) {
+        $arguments['soft_dependencies'][$index] = $this->groupName . $dependency;
+      }
+    }
+    $arguments += array(
+      'group_name' => $this->groupName,
+      'machine_name' => $machine_name,
+    );
+    $this->migrations[$machine_name] = array(
+      'class_name' => $class_name,
+      'arguments' => $arguments,
+    );
+
+    return TRUE;
+  }
+}
+
+/**
+ * Class representing one step of a wizard.
+ */
+class MigrateUIStep {
+  /**
+   * A translatable string briefly describing this step, to be used in the page
+   * title for the step form.
+   *
+   * @var string
+   */
+  protected $name;
+  public function getName() {
+    return $this->name;
+  }
+
+  /**
+   * Callable that returns the form array for this step.
+   *
+   * @var string
+   */
+  protected $formMethod;
+  public function getFormMethod() {
+    return $this->formMethod;
+  }
+
+  /**
+   * The form values ($form_state['values']) submitted for this step, saved in
+   * case we need to restore them on a Previous action.
+   *
+   * @var array
+   */
+  protected $formValues;
+  public function getFormValues() {
+    return $this->formValues;
+  }
+  public function setFormValues($form_values) {
+    $this->formValues = $form_values;
+  }
+
+  /**
+   * Any contextual data needed by the form for this step. For example, a
+   * field mapping form would need to know the source and destination content
+   * types so it can determine what fields to expose.
+   *
+   * @var mixed
+   */
+  protected $context;
+  public function getContext() {
+    return $this->context;
+  }
+
+  /**
+   * The step object is a node in a doubly-linked list - it links to its
+   * predecessor and successor steps.
+   *
+   * @var MigrateUIStep
+   */
+  public $nextStep;
+
+  /**
+   * @var MigrateUIStep
+   */
+  public $previousStep;
+
+  /**
+   * Class constructor.
+   *
+   * @param $name
+   *  The machine name of the wizard step.
+   * @param $form_method
+   *  A callable for the form array for this step. The validation method is
+   *  formed from the method name with the suffix 'Validate' added, regardless
+   *  of which object it is on.
+   * @param $context = NULL
+   *  Contextual data needed by the form for this step.
+   */
+  public function __construct($name, $form_method, $context = NULL) {
+    $this->name = $name;
+    $this->formMethod = $form_method;
+    $this->context = $context;
+  }
+}
+
+/**
+ *
+ */
+abstract class MigrateUIWizardExtender {
+  /**
+   * Reference to the wizard object that this extender applies to.
+   */
+  protected $wizard;
+
+  /**
+   * Class constructor.
+   *
+   * Wizard extenders should override this to add their steps to the wizard.
+   */
+  public function __construct(MigrateUIWizard $wizard, array $wizard_steps) {
+    $this->wizard = $wizard;
+  }
+
+  /**
+   * Alter the arguments to a migration before it is registered, or potentially
+   * reject it.
+   *
+   * @param string $machine_name
+   *  Machine name for the migration class.
+   * @param string $class_name
+   *  Name of the Migration class to instantiate.
+   * @param array $arguments
+   *  Further information configuring the migration.
+   * @param MigrateUIWizard $wizard
+   *  The wizard class performing the registration.
+   *
+   * @return bool
+   *  Return FALSE to prevent registration of this migration.
+   */
+  public function addMigrationAlter($machine_name, $class_name, &$arguments, $wizard) {
+    return TRUE;
+  }
+}

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/block_custom.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/block_custom.inc
@@ -1,0 +1,237 @@
+<?php
+
+/**
+ * @file
+ * Support for custom block destinations.
+ */
+
+/**
+ * Destination class implementing migration into {block_custom}.
+ */
+class MigrateDestinationCustomBlock extends MigrateDestination {
+  static public function getKeySchema() {
+    return array(
+      'bid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'ID of destination custom block',
+      ),
+    );
+  }
+  public function __construct() {
+    parent::__construct();
+  }
+
+  public function __toString() {
+    $output = t('Custom blocks');
+    return $output;
+  }
+
+  /**
+   * Returns a list of fields available to be mapped for custom blocks.
+   *
+   * @param Migration $migration
+   *  Optionally, the migration containing this destination.
+   * @return array
+   *  Keys: machine names of the fields (to be passed to addFieldMapping)
+   *  Values: Human-friendly descriptions of the fields.
+   */
+  public function fields($migration = NULL) {
+    $fields = array(
+      'bid' => t('The custom block ID (bid).'),
+      'body' => t('Block contents.'),
+      'info' => t('Block description.'),
+      'format' => t('The {filter_format}.format of the block body.'),
+    );
+    return $fields;
+  }
+
+  /**
+   * Import a single row.
+   *
+   * @param $block
+   *  Custom block object to build. Prefilled with any fields mapped in the Migration.
+   * @param $row
+   *  Raw source data object - passed through to prepare/complete handlers.
+   * @return array
+   *  Array of key fields of the object that was saved if
+   *  successful. FALSE on failure.
+   */
+  public function import(stdClass $block, stdClass $row) {
+    // Updating previously-migrated content
+    if (isset($row->migrate_map_destid1)) {
+      $block->bid = $row->migrate_map_destid1;
+    }
+
+    // Load old values if necessary.
+    $migration = Migration::currentMigration();
+    if ($migration->getSystemOfRecord() == Migration::DESTINATION) {
+      if (!isset($block->bid)) {
+        throw new MigrateException(t('System-of-record is DESTINATION, but no destination bid provided'));
+      }
+      if (!$old_block = $this->loadCustomBlock($block->bid)) {
+        throw new MigrateException(t('System-of-record is DESTINATION, and the provided bid could not be found'));
+      }
+      $block_to_update = (object) $old_block;
+      foreach ($old_block as $key => $value) {
+        if (!isset($block->$key)) {
+          $block->$key = $old_block[$key];
+        }
+      }
+    }
+
+    // Invoke migration prepare handlers
+    $this->prepare($block, $row);
+
+    // Custom blocks are handled as arrays, so clone the object to an array.
+    $item = clone $block;
+    $item = (array) $item;
+
+    migrate_instrument_start('block_custom_save');
+
+    // Check to see if this is a new custom block.
+    $update = FALSE;
+    if (isset($item['bid'])) {
+      $update = TRUE;
+      $bid = $this->saveCustomBlock($item);
+    }
+    else {
+      $bid = $this->saveCustomBlock($item);
+    }
+    migrate_instrument_stop('block_custom_save');
+
+    // Return the new id or FALSE on failure.
+    if (!empty($bid)) {
+      // Increment the count if the save succeeded.
+      if ($update) {
+        $this->numUpdated++;
+      }
+      else {
+        $this->numCreated++;
+      }
+      // Return the primary key to the mapping table.
+      $return = array($bid);
+    }
+    else {
+      $return = FALSE;
+    }
+
+    // Invoke migration complete handlers.
+    $block = (object) $this->loadCustomBlock($bid);
+    $this->complete($block, $row);
+
+    return $return;
+  }
+
+  /**
+   * Implementation of MigrateDestination::prepare().
+   */
+  public function prepare($block, stdClass $row) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+    $block->migrate = array(
+      'machineName' => $migration->getMachineName(),
+    );
+
+    // Call any general handlers.
+    migrate_handler_invoke_all('block_custom', 'prepare', $block, $row);
+    // Then call any prepare handler for this specific Migration.
+    if (method_exists($migration, 'prepare')) {
+      $migration->prepare($block, $row);
+    }
+  }
+
+  /**
+   * Implementation of MigrateDestination::complete().
+   */
+  public function complete($block, stdClass $row) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+    $block->migrate = array(
+      'machineName' => $migration->getMachineName(),
+    );
+    // Call any general handlers.
+    migrate_handler_invoke_all('block_custom', 'complete', $block, $row);
+    // Then call any complete handler for this specific Migration.
+    if (method_exists($migration, 'complete')) {
+      $migration->complete($block, $row);
+    }
+  }
+
+  /**
+   * Delete a batch of custom blocks at once.
+   *
+   * @param $bids
+   *  Array of custom block IDs to be deleted.
+   */
+  public function bulkRollback(array $bids) {
+    migrate_instrument_start('block_custom_delete_multiple');
+    $this->prepareRollback($bids);
+    $this->deleteMultipleCustomBlocks($bids);
+    $this->completeRollback($bids);
+    migrate_instrument_stop('block_custom_delete_multiple');
+  }
+
+  /**
+   * Give handlers a shot at cleaning up before a block has been rolled back.
+   *
+   * @param $bid
+   *  ID of the custom block about to be deleted.
+   */
+  public function prepareRollback($bid) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+    // Call any general handlers.
+    migrate_handler_invoke_all('block_custom', 'prepareRollback', $bid);
+    // Then call any complete handler for this specific Migration.
+    if (method_exists($migration, 'prepareRollback')) {
+      $migration->prepareRollback($bid);
+    }
+  }
+
+  /**
+   * Give handlers a shot at cleaning up after a block has been rolled back.
+   *
+   * @param $bid
+   *  ID of the custom block which has been deleted.
+   */
+  public function completeRollback($bid) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+    // Call any general handlers.
+    migrate_handler_invoke_all('block_custom', 'completeRollback', $bid);
+    // Then call any complete handler for this specific Migration.
+    if (method_exists($migration, 'completeRollback')) {
+      $migration->completeRollback($bid);
+    }
+  }
+
+  public function loadCustomBlock($bid) {
+    return block_custom_block_get($bid);
+  }
+
+  public function saveCustomBlock($block) {
+    drupal_alter('block_custom', $block);
+    if (!empty($block['bid'])) {
+      drupal_write_record('block_custom', $block, array('bid'));
+      module_invoke_all('block_custom_update', $block);
+    }
+    else {
+      drupal_write_record('block_custom', $block);
+      module_invoke_all('block_custom_insert', $block);
+    }
+    return $block['bid'];
+  }
+
+  public function deleteCustomBlock($bid) {
+    $this->deleteMultipleCustomBlocks(array($bid));
+  }
+
+  public function deleteMultipleCustomBlocks(array $bids) {
+    db_delete('block_custom')->condition('bid', $bids, 'IN')->execute();
+    db_delete('block')->condition('module', 'block')->condition('delta', $bids, 'IN')->execute();
+    db_delete('block_role')->condition('module', 'block')->condition('delta', $bids, 'IN')->execute();
+    db_delete('block_node_type')->condition('module', 'block')->condition('delta', $bids, 'IN')->execute();
+  }
+}

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/comment.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/comment.inc
@@ -65,33 +65,33 @@ class MigrateDestinationComment extends MigrateDestinationEntity {
   public function fields($migration = NULL) {
     $fields = array();
     // First the core (comment table) properties
-    $fields['cid'] = t('Comment: <a href="@doc">Existing comment ID</a>',
+    $fields['cid'] = t('<a href="@doc">Existing comment ID</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#cid'));
-    $fields['nid'] = t('Comment: <a href="@doc">Node (by Drupal ID)</a>',
+    $fields['nid'] = t('<a href="@doc">Node (by Drupal ID)</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#nid'));
-    $fields['uid'] = t('Comment: <a href="@doc">User (by Drupal ID)</a>',
+    $fields['uid'] = t('<a href="@doc">User (by Drupal ID)</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#uid'));
-    $fields['pid'] = t('Comment: <a href="@doc">Parent (by Drupal ID)</a>',
+    $fields['pid'] = t('<a href="@doc">Parent (by Drupal ID)</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#pid'));
-    $fields['subject'] = t('Comment: <a href="@doc">Subject</a>',
+    $fields['subject'] = t('<a href="@doc">Subject</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#subject'));
-    $fields['created'] = t('Comment: <a href="@doc">Created timestamp</a>',
+    $fields['created'] = t('<a href="@doc">Created timestamp</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#created'));
-    $fields['changed'] = t('Comment: <a href="@doc">Modified timestamp</a>',
+    $fields['changed'] = t('<a href="@doc">Modified timestamp</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#changed'));
-    $fields['status'] = t('Comment: <a href="@doc">Status</a>',
+    $fields['status'] = t('<a href="@doc">Status</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#status'));
-    $fields['hostname'] = t('Comment: <a href="@doc">Hostname/IP address</a>',
+    $fields['hostname'] = t('<a href="@doc">Hostname/IP address</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#hostname'));
-    $fields['name'] = t('Comment: <a href="@doc">User name (not username)</a>',
+    $fields['name'] = t('<a href="@doc">User name (not username)</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#name'));
-    $fields['mail'] = t('Comment: <a href="@doc">Email address</a>',
+    $fields['mail'] = t('<a href="@doc">Email address</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#mail'));
-    $fields['homepage'] = t('Comment: <a href="@doc">Homepage</a>',
+    $fields['homepage'] = t('<a href="@doc">Homepage</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#homepage'));
-    $fields['language'] = t('Comment: <a href="@doc">Language</a>',
+    $fields['language'] = t('<a href="@doc">Language</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#language'));
-    $fields['thread'] = t('Comment: <a href="@doc">Thread</a>',
+    $fields['thread'] = t('<a href="@doc">Thread</a>',
                 array('@doc' => 'http://drupal.org/node/1349714#thread'));
 
     // Then add in anything provided by handlers
@@ -147,6 +147,10 @@ class MigrateDestinationComment extends MigrateDestinationEntity {
     }
     if (isset($comment->changed)) {
       $comment->changed = MigrationBase::timestamp($comment->changed);
+    }
+
+    if (!isset($comment->node_type)) {
+      $comment->node_type = $this->bundle;
     }
 
     if ($migration->getSystemOfRecord() == Migration::DESTINATION) {
@@ -210,6 +214,10 @@ class MigrateDestinationComment extends MigrateDestinationEntity {
     else {
       $updating = FALSE;
     }
+
+    // Validate field data prior to saving.
+    MigrateDestinationEntity::fieldAttachValidate('comment', $comment);
+
     migrate_instrument_start('comment_save');
     comment_save($comment);
     migrate_instrument_stop('comment_save');
@@ -291,16 +299,48 @@ class MigrateDestinationComment extends MigrateDestinationEntity {
       // Empty table
       db_truncate('node_comment_statistics')->execute();
 
-      // TODO: DBTNG. Ignore keyword is Mysql only? Is only used in the rare case when
-      // two comments on the same node share same timestamp.
-      $sql = "
-        INSERT IGNORE INTO {node_comment_statistics} (nid, cid, last_comment_timestamp, last_comment_name, last_comment_uid, comment_count) (
-          SELECT c.nid, c.cid, c.created, c.name, c.uid, c2.comment_count FROM {comment} c
-          JOIN (
-            SELECT c.nid, MAX(c.created) AS created, COUNT(*) AS comment_count FROM {comment} c WHERE status=:published GROUP BY c.nid
-          ) AS c2 ON c.nid = c2.nid AND c.created=c2.created
-        )";
-      db_query($sql, array(':published' => COMMENT_PUBLISHED));
+      // DBTNG. IGNORE keyword is not compatible with Postgres. SQLite?
+      switch (db_driver()) {
+        case 'pgsql':
+          // We still want to run this under Postgres. On the very rare occasion
+          // when we have 2 comments on the same node with the same timestamp
+          // we will lose data.
+          $sql = "
+            INSERT INTO {node_comment_statistics} (nid, cid, last_comment_timestamp, last_comment_name, last_comment_uid, comment_count) (
+              SELECT c.nid, c.cid, c.created, c.name, c.uid, c2.comment_count
+              FROM {comment} c
+              JOIN (
+                SELECT c.nid, MAX(c.created) AS created, COUNT(*) AS comment_count
+                FROM {comment} c
+                WHERE status=:published
+                GROUP BY c.nid
+              ) AS c2 ON c.nid = c2.nid AND c.created=c2.created
+            )";
+        break;
+
+        default:
+          $sql = "
+            INSERT IGNORE INTO {node_comment_statistics} (nid, cid, last_comment_timestamp, last_comment_name, last_comment_uid, comment_count) (
+              SELECT c.nid, c.cid, c.created, c.name, c.uid, c2.comment_count
+              FROM {comment} c
+              JOIN (
+                SELECT c.nid, MAX(c.created) AS created, COUNT(*) AS comment_count
+                FROM {comment} c
+                WHERE status=:published
+                GROUP BY c.nid
+              ) AS c2 ON c.nid = c2.nid AND c.created=c2.created
+            )";
+      }
+      try {
+        db_query($sql, array(':published' => COMMENT_PUBLISHED));
+      }
+      catch (Exception $e) {
+        // Our edge case has been hit. A Postgres migration has likely just
+        // lost data. Let the user know.
+        Migration::displayMessage(t('Failed to update node comment statistics: !message',
+          array('!message' => $e->getMessage())
+        ));
+      }
 
       // Insert records into the node_comment_statistics for nodes that are missing.
       $query = db_select('node', 'n');
@@ -324,7 +364,10 @@ class MigrateCommentNodeHandler extends MigrateDestinationHandler {
     $this->registerTypes(array('node'));
   }
 
-  public function fields($entity_type, $bundle) {
+  /**
+   * Implementation of MigrateDestinationHandler::fields().
+   */
+  public function fields($entity_type, $bundle, $migration = NULL) {
     $fields = array();
     $fields['comment'] = t('Whether comments may be posted to the node');
     return $fields;

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/entity.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/entity.inc
@@ -138,6 +138,11 @@ abstract class MigrateDestinationEntity extends MigrateDestination {
     migrate_handler_invoke_all('Entity', 'prepare', $entity, $source_row);
     // Then call any entity-specific handlers
     migrate_handler_invoke_all($this->entityType, 'prepare', $entity, $source_row);
+
+    // Apply defaults, removing empty fields from the entity object.
+    $form = $form_state = array();
+    _field_invoke_default('submit', $this->entityType, $entity, $form, $form_state);
+
     // Then call any prepare handler for this specific Migration.
     if (method_exists($migration, 'prepare')) {
       $migration->prepare($entity, $source_row);
@@ -168,6 +173,36 @@ abstract class MigrateDestinationEntity extends MigrateDestination {
         // If we catch any errors here, save the messages without letting
         // the exception prevent the saving of the entity being recorded.
         $migration->saveMessage($e->getMessage());
+      }
+    }
+  }
+
+  /**
+   * Perform field validation against the field data in an entity. Wraps
+   * field_attach_validate to handle exceptions cleanly and provide maximum
+   * information for identifying the cause of validation errors.
+   *
+   * @param $entity_type
+   *   The type of $entity; e.g. 'node' or 'user'.
+   * @param $entity
+   *   The entity with fields to validate.
+   */
+  static public function fieldAttachValidate($entity_type, $entity) {
+    try {
+      field_attach_validate($entity_type, $entity);
+    }
+    catch (FieldValidationException $e) {
+      $migration = Migration::currentMigration();
+      foreach ($e->errors as $field_name => $field_errors) {
+        foreach ($field_errors as $langcode => $errors) {
+          foreach ($errors as $delta => $error_list) {
+            foreach ($error_list as $index => $error) {
+              $message = $error['message'];
+              $migration->saveMessage(t('Field validation error for !field_name: !message',
+                array('!field_name' => $field_name, '!message' => $message)));
+            }
+          }
+        }
       }
     }
   }

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/fields.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/fields.inc
@@ -12,15 +12,6 @@ class MigrateFieldsEntityHandler extends MigrateDestinationHandler {
 
   /**
    * Implementation of MigrateDestinationHandler::fields().
-   *
-   * @param $entity_type
-   *  The entity type (node, user, etc.) for which to list fields.
-   * @param $bundle
-   *  The bundle (article, blog, etc.), if any, for which to list fields.
-   * @param Migration $migration
-   *  Optionally, the migration providing the context.
-   * @return array
-   *  An array keyed by field name, with field descriptions as values.
    */
   public function fields($entity_type, $bundle, $migration = NULL) {
     $fields = array();
@@ -29,12 +20,17 @@ class MigrateFieldsEntityHandler extends MigrateDestinationHandler {
       $field_info = field_info_field($machine_name);
       $type = $field_info['type'];
 
-      $fields[$machine_name] = t('Field:') . ' ' . $instance['label'] .
-        ' (' . $field_info['type'] . ')';
+      if (user_access(MIGRATE_ACCESS_ADVANCED)) {
+        $fields[$machine_name] = $instance['label'] . ' (' . $field_info['type'] . ')';
+      }
+      else {
+        $fields[$machine_name] = $instance['label'];
+      }
 
       // Look for subfields
       $class_list = _migrate_class_list('MigrateFieldHandler');
       $disabled = unserialize(variable_get('migrate_disabled_handlers', serialize(array())));
+      $fields_found = FALSE;
       foreach ($class_list as $class_name => $handler) {
         if (!in_array($class_name, $disabled) && $handler->handlesType($type)
             && method_exists($handler, 'fields')) {
@@ -45,6 +41,18 @@ class MigrateFieldsEntityHandler extends MigrateDestinationHandler {
           foreach ($subfields as $subfield_name => $subfield_label) {
             $fields[$machine_name . ':' . $subfield_name] = $subfield_label;
           }
+          $fields_found = TRUE;
+        }
+      }
+      if (!$fields_found) {
+        // Check the default field handler last.
+        migrate_instrument_start('MigrateDefaultFieldHandler->fields');
+        $subfields = call_user_func(
+          array(new MigrateDefaultFieldHandler, 'fields'), $type, $instance,
+            $migration);
+        migrate_instrument_stop('MigrateDefaultFieldHandler->fields');
+        foreach ($subfields as $subfield_name => $subfield_label) {
+          $fields[$machine_name . ':' . $subfield_name] = $subfield_label;
         }
       }
     }
@@ -125,6 +133,95 @@ abstract class MigrateFieldHandler extends MigrateHandler {
       default:
         return $migration->getDestination()->getLanguage();
     }
+  }
+}
+
+/**
+ * A fallback field handler to do basic copying of field data.
+ */
+class MigrateDefaultFieldHandler extends MigrateFieldHandler {
+  public function __construct() {}
+
+  /**
+   * Implements MigrateFieldHandler::fields().
+   *
+   * @param $field_type
+   * @param $field_instance
+   *
+   * @return array
+   */
+  public function fields($field_type, $field_instance) {
+    $field_info = field_info_field($field_instance['field_name']);
+    $fields = array();
+    $first = TRUE;
+    foreach ($field_info['columns'] as $column_name => $column_info) {
+      // The first column is the primary value, which is mapped directly to
+      // the field name - so, don't include it here among the subfields.
+      if ($first) {
+        $first = FALSE;
+      }
+      else {
+        $fields[$column_name] = empty($column_info['description']) ?
+          $column_name : $column_info['description'];
+      }
+    }
+    return $fields;
+  }
+
+  /**
+   * Implements MigrateFieldHandler::prepare().
+   *
+   * @param $entity
+   * @param array $field_info
+   * @param array $instance
+   * @param array $values
+   *
+   * @return null
+   */
+  public function prepare($entity, array $field_info, array $instance,
+                          array $values) {
+    $arguments = array();
+    if (isset($values['arguments'])) {
+      $arguments = array_filter($values['arguments']);
+      unset($values['arguments']);
+    }
+    $language = $this->getFieldLanguage($entity, $field_info, $arguments);
+
+    // Get the name of the primary (first) column, which is mapped separately.
+    reset($field_info['columns']);
+    $primary_column = key($field_info['columns']);
+
+    // Setup the standard Field API array for saving.
+    $delta = 0;
+    foreach ($values as $value) {
+      // Handle multivalue arguments (especially for subfields).
+      $delta_arguments = array();
+      foreach ($arguments as $name => $argument) {
+        if (is_array($argument) && array_key_exists($delta, $argument)) {
+          $delta_arguments[$name] = $argument[$delta];
+        }
+        else {
+          $delta_arguments[$name] = $argument;
+        }
+      }
+      $return[$language][$delta] = array($primary_column => $value) +
+        array_intersect_key($delta_arguments, $field_info['columns']);
+      $delta++;
+    }
+
+    return isset($return) ? $return : NULL;
+  }
+
+  /**
+   * Overrides MigrateHandler::handlesType().
+   *
+   * @param string $type
+   *
+   * @return bool
+   */
+  public function handlesType($type) {
+    // We claim to handle any type.
+    return TRUE;
   }
 }
 
@@ -238,14 +335,21 @@ class MigrateTextFieldHandler extends MigrateFieldHandler {
   public function fields($type, $instance, $migration = NULL) {
     $fields = array();
     if ($type == 'text_with_summary') {
-      $fields['summary'] = t('Subfield: Summary of field contents');
+      $fields['summary'] = t('Subfield: <a href="@doc">Summary of field contents</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#summary'));
     }
     if ($instance['settings']['text_processing']) {
-      $fields['format'] = t('Subfield: Text format for the field');
+      $fields['format'] = t('Subfield: <a href="@doc">Text format for the field</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#format'));
     }
-    $fields['language'] = t('Subfield: Language for the field');
+    $field = field_info_field($instance['field_name']);
+    if (field_is_translatable($instance['entity_type'], $field)) {
+      $fields['language'] = t('Subfield: <a href="@doc">Language for the field</a>',
+          array('@doc' => 'http://drupal.org/node/1224042#language'));
+    }
     return $fields;
   }
+
 
   public function prepare($entity, array $field_info, array $instance, array $values) {
     if (isset($values['arguments'])) {
@@ -351,9 +455,12 @@ class MigrateTaxonomyTermReferenceFieldHandler extends MigrateFieldHandler {
    */
   public function fields($type, $instance, $migration = NULL) {
     return array(
-      'source_type' => t('Option: Set to \'tid\' when the value is a source ID'),
-      'create_term' => t('Option: Set to TRUE to create referenced terms when necessary'),
-      'ignore_case' => t('Option: Set to TRUE to ignore case differences between source data and existing term names'),
+      'source_type' => t('Option: <a href="@doc">Set to \'tid\' when the value is a source ID</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#source_type')),
+      'create_term' => t('Option: <a href="@doc">Set to TRUE to create referenced terms when necessary</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#create_term')),
+      'ignore_case' => t('Option: <a href="@doc">Set to TRUE to ignore case differences between source data and existing term names</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#ignore_case')),
     );
   }
 
@@ -365,7 +472,7 @@ class MigrateTaxonomyTermReferenceFieldHandler extends MigrateFieldHandler {
     else {
       $arguments = array();
     }
-    if (empty($values[0])) {
+    if (count($values) == 1 && empty($values[0])) {
       $values = array();
     }
 
@@ -375,6 +482,7 @@ class MigrateTaxonomyTermReferenceFieldHandler extends MigrateFieldHandler {
       $tids = $values;
     }
     elseif ($values) {
+      $vocab_name = $field_info['settings']['allowed_values'][0]['vocabulary'];
       $names = taxonomy_vocabulary_get_names();
 
       // Get the vocabulary for this term
@@ -382,9 +490,11 @@ class MigrateTaxonomyTermReferenceFieldHandler extends MigrateFieldHandler {
         $vid = $field_info['settings']['allowed_values'][0]['vid'];
       }
       else {
-        $vocab_name = $field_info['settings']['allowed_values'][0]['vocabulary'];
         $vid = $names[$vocab_name]->vid;
       }
+
+      // Remove leading and trailing spaces in term names
+      $values = array_map('trim', $values);
 
       // Cannot use taxonomy_term_load_multiple() since we have an array of names.
       // It wants a singular value. This query may return case-insensitive
@@ -398,17 +508,33 @@ class MigrateTaxonomyTermReferenceFieldHandler extends MigrateFieldHandler {
       // If we're ignoring case, change both the matched term name keys and the
       // source values to lowercase.
       if (isset($arguments['ignore_case']) && $arguments['ignore_case']) {
+        $ignore_case = TRUE;
         $existing_terms = array_change_key_case($existing_terms);
-        $values = array_map('strtolower', $values);
+        foreach ($values as $value) {
+          $lower_values[$value] = strtolower($value);
+        }
+      }
+      else {
+        $ignore_case = FALSE;
       }
       foreach ($values as $value) {
         if (isset($existing_terms[$value])) {
           $tids[] = $existing_terms[$value];
         }
+        elseif ($ignore_case && isset($existing_terms[$lower_values[$value]])) {
+          $tids[] = $existing_terms[$lower_values[$value]];
+        }
         elseif (!empty($arguments['create_term'])) {
           $new_term = new stdClass();
           $new_term->vid = $vid;
           $new_term->name = $value;
+          $new_term->vocabulary_machine_name = $vocab_name;
+
+          // This term is being created with no fields, but we should still call
+          // field_attach_validate() before saving, as that invokes
+          // hook_field_attach_validate().
+          MigrateDestinationEntity::fieldAttachValidate('taxonomy_term', $new_term);
+
           taxonomy_term_save($new_term);
           $tids[] = $new_term->tid;
           // Add newly created term to existing array.
@@ -465,8 +591,12 @@ abstract class MigrateFileFieldBaseHandler extends MigrateFieldHandler {
     $fields = array(
       'file_class' => t('Option: <a href="@doc">Implementation of MigrateFile to use</a>',
         array('@doc' => 'http://drupal.org/node/1540106#file_class')),
-      'language' => t('Subfield: Language for the field'),
     );
+
+    $field = field_info_field($instance['field_name']);
+    if (field_is_translatable($instance['entity_type'], $field)) {
+      $fields['language'] = t('Subfield: Language for the field');
+    }
 
     // If we can identify the file class mapped to this field, pick up the
     // subfields specific to that class.
@@ -478,7 +608,7 @@ abstract class MigrateFileFieldBaseHandler extends MigrateFieldHandler {
         $file_class = $mapping->getDefaultValue();
       }
     }
-    if (!isset($file_class)) {
+    if (empty($file_class)) {
       $file_class = 'MigrateFileUri';
     }
     $fields += call_user_func(array($file_class, 'fields'));
@@ -502,7 +632,7 @@ abstract class MigrateFileFieldBaseHandler extends MigrateFieldHandler {
       $arguments = array();
     }
 
-    $language = $this->getFieldLanguage($entity, $field_info, $arguments);
+    $default_language = $this->getFieldLanguage($entity, $field_info, $arguments);
     $migration = Migration::currentMigration();
 
     // One can override the source class via CLI or drushrc.php (the
@@ -561,6 +691,10 @@ abstract class MigrateFileFieldBaseHandler extends MigrateFieldHandler {
         // MigrateFile class has saved a message indicating why.
         if ($file) {
           $field_array = array('fid' => $file->fid);
+          $language = isset($instance_arguments['language']) ? $instance_arguments['language'] : $default_language;
+          if (is_array($language)) {
+            $language = $language[$delta];
+          }
           $return[$language][] = $this->buildFieldArray($field_array, $instance_arguments, $delta);
         }
       }
@@ -629,8 +763,10 @@ class MigrateFileFieldHandler extends MigrateFileFieldBaseHandler {
   public function fields($type, $instance, $migration = NULL) {
     $fields = parent::fields($type, $instance, $migration);
     $fields += array(
-      'description' => t('Subfield: String to be used as the description value'),
-      'display' => t('Subfield: String to be used as the display value'),
+      'description' => t('Subfield: <a href="@doc">String to be used as the description value</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#description')),
+      'display' => t('Subfield: <a href="@doc">String to be used as the display value</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#display')),
     );
     return $fields;
   }
@@ -690,8 +826,10 @@ class MigrateImageFieldHandler extends MigrateFileFieldBaseHandler {
   public function fields($type, $instance, $migration = NULL) {
     $fields = parent::fields($type, $instance, $migration);
     $fields += array(
-      'alt' => t('Subfield: String to be used as the alt value'),
-      'title' => t('Subfield: String to be used as the title value'),
+      'alt' => t('Subfield: <a href="@doc">String to be used as the alt value</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#alt')),
+      'title' => t('Subfield: <a href="@doc">String to be used as the title value</a>',
+        array('@doc' => 'http://drupal.org/node/1224042#title')),
     );
     return $fields;
   }

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/file.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/file.inc
@@ -36,12 +36,109 @@ interface MigrateFileInterface {
 
 abstract class MigrateFileBase implements MigrateFileInterface {
   /**
+   * Extension of the core FILE_EXISTS_* constants, offering an alternative to
+   * reuse the existing file if present as-is (core only offers the options of
+   * replacing it or renaming to avoid collision).
+   */
+  const FILE_EXISTS_REUSE = -1;
+
+  /**
+   * An optional file object to use as a default starting point for building the
+   * file entity.
+   *
+   * @var stdClass
+   */
+  protected $defaultFile;
+
+  /**
+   * How to handle destination filename collisions.
+   *
+   * @var int
+   */
+  protected $fileReplace = FILE_EXISTS_RENAME;
+
+  /**
+   * Set to TRUE to prevent file deletion on rollback.
+   *
+   * @var bool
+   */
+  protected $preserveFiles = FALSE;
+
+  public function __construct($arguments = array(), $default_file = NULL) {
+    if (isset($arguments['preserve_files'])) {
+      $this->preserveFiles = $arguments['preserve_files'];
+    }
+    if (isset($arguments['file_replace'])) {
+      $this->fileReplace = $arguments['file_replace'];
+    }
+    if ($default_file) {
+      $this->defaultFile = $default_file;
+    }
+    else {
+      $this->defaultFile = new stdClass;
+    }
+  }
+
+  /**
    * Default implementation of MigrateFileInterface::fields().
    *
    * @return array
    */
   static public function fields() {
-    return array();
+    return array(
+      'preserve_files' => t('Option: <a href="@doc">Boolean indicating whether files should be preserved or deleted on rollback</a>',
+        array('@doc' => 'http://drupal.org/node/1540106#preserve_files')),
+
+    );
+  }
+
+  /**
+   * Setup a file entity object suitable for saving.
+   *
+   * @param $destination
+   *  Path to the Drupal copy of the file.
+   * @param $owner
+   *  Uid of the file owner.
+   * @return stdClass
+   *  A file object ready to be saved.
+   */
+  protected function createFileEntity($destination, $owner) {
+    $file = clone $this->defaultFile;
+    $file->uri = $destination;
+    $file->uid = $owner;
+    if (!isset($file->filename)) {
+      $file->filename = drupal_basename($destination);
+    }
+    if (!isset($file->filemime)) {
+      $file->filemime = file_get_mimetype(urldecode($destination));
+    }
+    if (!isset($file->status)) {
+      $file->status = FILE_STATUS_PERMANENT;
+    }
+
+    if (empty($file->type) || $file->type == 'file') {
+      // Try to determine the file type.
+      if (module_exists('file_entity')) {
+        $type = file_get_type($file);
+      }
+      elseif ($slash_pos = strpos($file->filemime, '/')) {
+        $type = substr($file->filemime, 0, $slash_pos);
+      }
+      $file->type = isset($type) ? $type : 'file';
+    }
+
+    // If we are replacing or reusing an existing filesystem entry,
+    // also re-use its database record.
+    if ($this->fileReplace == FILE_EXISTS_REPLACE ||
+        $this->fileReplace == self::FILE_EXISTS_REUSE) {
+      $existing_files = file_load_multiple(array(), array('uri' => $destination));
+      if (count($existing_files)) {
+        $existing = reset($existing_files);
+        $file->fid = $existing->fid;
+        $file->filename = $existing->filename;
+      }
+    }
+    return $file;
   }
 
   /**
@@ -65,6 +162,18 @@ abstract class MigrateFileBase implements MigrateFileInterface {
         ->fields(array('count' => 1))
         ->execute();
     }
+  }
+}
+
+/**
+ * The simplest possible file class - where the value is a remote URI which
+ * simply needs to be saved as the URI on the destination side, with no attempt
+ * to copy or otherwise use it.
+ */
+class MigrateFileUriAsIs extends MigrateFileBase {
+  public function processFile($value, $owner) {
+    $file = file_save($this->createFileEntity($value, $owner));
+    return $file;
   }
 }
 
@@ -93,13 +202,6 @@ class MigrateFileFid extends MigrateFileBase {
  */
 abstract class MigrateFile extends MigrateFileBase {
   /**
-   * Extension of the core FILE_EXISTS_* constants, offering an alternative to
-   * reuse the existing file if present as-is (core only offers the options of
-   * replacing it or renaming to avoid collision).
-   */
-  const FILE_EXISTS_REUSE = -1;
-
-  /**
    * The destination directory within Drupal.
    *
    * @var string
@@ -113,46 +215,13 @@ abstract class MigrateFile extends MigrateFileBase {
    */
   protected $destinationFile = '';
 
-  /**
-   * How to handle destination filename collisions.
-   *
-   * @var int
-   */
-  protected $fileReplace = FILE_EXISTS_RENAME;
-
-  /**
-   * Set to TRUE to prevent file deletion on rollback.
-   *
-   * @var bool
-   */
-  protected $preserveFiles = FALSE;
-
-  /**
-   * An optional file object to use as a default starting point for building the
-   * file entity.
-   *
-   * @var stdClass
-   */
-  protected $defaultFile;
-
   public function __construct($arguments = array(), $default_file = NULL) {
+    parent::__construct($arguments, $default_file);
     if (isset($arguments['destination_dir'])) {
       $this->destinationDir = $arguments['destination_dir'];
     }
     if (isset($arguments['destination_file'])) {
       $this->destinationFile = $arguments['destination_file'];
-    }
-    if (isset($arguments['file_replace'])) {
-      $this->fileReplace = $arguments['file_replace'];
-    }
-    if (isset($arguments['preserve_files'])) {
-      $this->preserveFiles = $arguments['preserve_files'];
-    }
-    if ($default_file) {
-      $this->defaultFile = $default_file;
-    }
-    else {
-      $this->defaultFile = new stdClass;
     }
   }
 
@@ -162,53 +231,14 @@ abstract class MigrateFile extends MigrateFileBase {
    * @return array
    */
   static public function fields() {
-    return array(
+    return parent::fields() + array(
       'destination_dir' => t('Subfield: <a href="@doc">Path within Drupal files directory to store file</a>',
         array('@doc' => 'http://drupal.org/node/1540106#destination_dir')),
       'destination_file' => t('Subfield: <a href="@doc">Path within destination_dir to store the file.</a>',
         array('@doc' => 'http://drupal.org/node/1540106#destination_file')),
-      'file_replace' => t('Option: <a href="@doc">Value of $replace in that file function. Does not apply to file_fast(). Defaults to FILE_EXISTS_RENAME.</a>',
+      'file_replace' => t('Option: <a href="@doc">Value of $replace in that file function. Defaults to FILE_EXISTS_RENAME.</a>',
         array('@doc' => 'http://drupal.org/node/1540106#file_replace')),
-      'preserve_files' => t('Option: <a href="@doc">Boolean indicating whether files should be preserved or deleted on rollback</a>',
-        array('@doc' => 'http://drupal.org/node/1540106#preserve_files')),
     );
-  }
-
-  /**
-   * Setup a file entity object suitable for saving.
-   *
-   * @param $destination
-   *  Path to the Drupal copy of the file.
-   * @param $owner
-   *  Uid of the file owner.
-   * @return stdClass
-   *  A file object ready to be saved.
-   */
-  protected function createFileEntity($destination, $owner) {
-    $file = clone $this->defaultFile;
-    $file->uri = $destination;
-    $file->uid = $owner;
-    if (!isset($file->filename)) {
-      $file->filename = drupal_basename($destination);
-    }
-    if (!isset($file->filemime)) {
-      $file->filemime = file_get_mimetype($destination);
-    }
-    if (!isset($file->status)) {
-      $file->status = FILE_STATUS_PERMANENT;
-    }
-    // If we are replacing or reusing an existing filesystem entry,
-    // also re-use its database record.
-    if ($this->fileReplace == FILE_EXISTS_REPLACE ||
-        $this->fileReplace == self::FILE_EXISTS_REUSE) {
-      $existing_files = file_load_multiple(array(), array('uri' => $destination));
-      if (count($existing_files)) {
-        $existing = reset($existing_files);
-        $file->fid = $existing->fid;
-        $file->filename = $existing->filename;
-      }
-    }
-    return $file;
   }
 
   /**
@@ -242,13 +272,10 @@ abstract class MigrateFile extends MigrateFileBase {
     // Our own file_replace behavior - if the file exists, use it without
     // replacing it
     if ($this->fileReplace == self::FILE_EXISTS_REUSE) {
-      // See if we this file already (we'll reuse a file entity if it exists).
+      // See if we this file already (we'll reuse and resave a file entity if it exists).
       if (file_exists($destination)) {
         $file = $this->createFileEntity($destination, $owner);
-        // File entity didn't already exist, create it
-        if (empty($file->fid)) {
-          $file = file_save($file);
-        }
+        $file = file_save($file);
         $this->markForPreservation($file->fid);
         return $file;
       }
@@ -257,7 +284,8 @@ abstract class MigrateFile extends MigrateFileBase {
     }
 
     // Prepare the destination directory.
-    if (!file_prepare_directory(drupal_dirname($destination),
+    $destdir = drupal_dirname($destination);
+    if (!file_prepare_directory($destdir,
                                 FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS)) {
       $migration->saveMessage(t('Could not create destination directory for !dest',
                               array('!dest' => $destination)));
@@ -267,8 +295,7 @@ abstract class MigrateFile extends MigrateFileBase {
     // Determine whether we can perform this operation based on overwrite rules.
     $destination = file_destination($destination, $this->fileReplace);
     if ($destination === FALSE) {
-      $migration->saveMessage(t('The file could not be copied because ' .
-        'file %dest already exists in the destination directory.',
+      $migration->saveMessage(t('The file could not be copied because file %dest already exists in the destination directory.',
         array('%dest' => $destination)));
       return FALSE;
     }
@@ -318,10 +345,18 @@ class MigrateFileUri extends MigrateFile {
    */
   protected $sourcePath = '';
 
+  /**
+   * Whether to apply rawurlencode to the components of an incoming file path.
+   */
+  protected $urlEncode = TRUE;
+
   public function __construct($arguments = array(), $default_file = NULL) {
     parent::__construct($arguments, $default_file);
     if (isset($arguments['source_dir'])) {
       $this->sourceDir = rtrim($arguments['source_dir'], "/\\");
+    }
+    if (isset($arguments['urlencode'])) {
+      $this->urlEncode = $arguments['urlencode'];
     }
   }
 
@@ -335,6 +370,8 @@ class MigrateFileUri extends MigrateFile {
       array(
         'source_dir' => t('Subfield: <a href="@doc">Path to source file.</a>',
           array('@doc' => 'http://drupal.org/node/1540106#source_dir')),
+        'urlencode' => t('Option: <a href="@doc">Encode all segments of the incoming path (defaults to TRUE).</a>',
+          array('@doc' => 'http://drupal.org/node/1540106#urlencode')),
       );
   }
 
@@ -348,17 +385,19 @@ class MigrateFileUri extends MigrateFile {
    *  TRUE if the copy succeeded, FALSE otherwise.
    */
   protected function copyFile($destination) {
-    // Perform the copy operation, with a cleaned-up path.
-    $this->sourcePath = self::urlencode($this->sourcePath);
-    if (!@copy($this->sourcePath, $destination)) {
-      $migration = Migration::currentMigration();
-      $migration->saveMessage(t('The specified file %file could not be copied to ' .
-              '%destination.',
-              array('%file' => $this->sourcePath, '%destination' => $destination)));
-      return FALSE;
+    if ($this->urlEncode) {
+      // Perform the copy operation, with a cleaned-up path.
+      $this->sourcePath = self::urlencode($this->sourcePath);
     }
-    else {
+    try {
+      copy($this->sourcePath, $destination);
       return TRUE;
+    }
+    catch (Exception $e) {
+      $migration = Migration::currentMigration();
+      $migration->saveMessage(t('The specified file %file could not be copied to %destination: "%exception_msg"',
+              array('%file' => $this->sourcePath, '%destination' => $destination, '%exception_msg' => $e->getMessage())));
+      return FALSE;
     }
   }
 
@@ -377,8 +416,10 @@ class MigrateFileUri extends MigrateFile {
         $components[$key] = rawurlencode($component);
       }
       $filename = implode('/', $components);
-      // Actually, we don't want colons encoded
+      // Actually, we don't want certain characters encoded
       $filename = str_replace('%3A', ':', $filename);
+      $filename = str_replace('%3F', '?', $filename);
+      $filename = str_replace('%26', '&', $filename);
     }
     return $filename;
   }
@@ -473,6 +514,9 @@ class MigrateDestinationFile extends MigrateDestinationEntity {
    * @var string
    */
   protected $fileClass;
+  public function setFileClass($file_class) {
+    $this->fileClass = $file_class;
+  }
 
   /**
    * Boolean indicating whether we should avoid deleting the actual file on
@@ -521,10 +565,10 @@ class MigrateDestinationFile extends MigrateDestinationEntity {
   public function fields($migration = NULL) {
     $fields = array();
     // First the core properties
-    $fields['fid'] = t('File: Existing file ID');
-    $fields['uid'] = t('File: Uid of user associated with file');
-    $fields['value'] = t('File: Representation of the source file (usually a URI)');
-    $fields['timestamp'] = t('File: UNIX timestamp for the date the file was added');
+    $fields['fid'] = t('Existing file ID');
+    $fields['uid'] = t('Uid of user associated with file');
+    $fields['value'] = t('Representation of the source file (usually a URI)');
+    $fields['timestamp'] = t('UNIX timestamp for the date the file was added');
 
     // Then add in anything provided by handlers
     $fields += migrate_handler_invoke_all('Entity', 'fields', $this->entityType, $this->bundle, $migration);
@@ -559,12 +603,14 @@ class MigrateDestinationFile extends MigrateDestinationEntity {
       else {
         $preserve_files = FALSE;
       }
+      $this->prepareRollback($fid);
       if ($preserve_files) {
         $this->fileDelete($file);
       }
       else {
         file_delete($file, TRUE);
       }
+      $this->completeRollback($fid);
       migrate_instrument_stop('file_delete');
     }
   }
@@ -614,6 +660,19 @@ class MigrateDestinationFile extends MigrateDestinationEntity {
       }
       // @todo: Support DESTINATION case
       $old_file = file_load($file->fid);
+    }
+
+    // 'type' is the bundle property on file entities. It must be set here for
+    // the sake of the prepare handlers, although it may be overridden later
+    // based on the detected mime type.
+    if (empty($file->type)) {
+      // If a bundle was specified in the constructor we use it for filetype.
+      if ($this->bundle != 'file') {
+        $file->type = $this->bundle;
+      }
+      else {
+        $file->type = 'file';
+      }
     }
 
     // Invoke migration prepare handlers

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/node.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/node.inc
@@ -12,6 +12,8 @@
  * Destination class implementing migration into nodes.
  */
 class MigrateDestinationNode extends MigrateDestinationEntity {
+  protected $bypassDestIdCheck = FALSE;
+
   static public function getKeySchema() {
     return array(
       'nid' => array(
@@ -66,29 +68,29 @@ class MigrateDestinationNode extends MigrateDestinationEntity {
                            array('@doc' => 'http://drupal.org/node/1349696#title'))
                          . $node_type->title_label . '</a>';
     }
-    $fields['uid'] = t('Node: <a href="@doc">Authored by (uid)</a>',
+    $fields['uid'] = t('<a href="@doc">Authored by (uid)</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#uid'));
-    $fields['created'] = t('Node: <a href="@doc">Created timestamp</a>',
+    $fields['created'] = t('<a href="@doc">Created timestamp</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#created'));
-    $fields['changed'] = t('Node: <a href="@doc">Modified timestamp</a>',
+    $fields['changed'] = t('<a href="@doc">Modified timestamp</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#changed'));
-    $fields['status'] = t('Node: <a href="@doc">Published</a>',
+    $fields['status'] = t('<a href="@doc">Published</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#status'));
-    $fields['promote'] = t('Node: <a href="@doc">Promoted to front page</a>',
+    $fields['promote'] = t('<a href="@doc">Promoted to front page</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#promote'));
-    $fields['sticky'] = t('Node: <a href="@doc">Sticky at top of lists</a>',
+    $fields['sticky'] = t('<a href="@doc">Sticky at top of lists</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#sticky'));
-    $fields['revision'] = t('Node: <a href="@doc">Create new revision</a>',
+    $fields['revision'] = t('<a href="@doc">Create new revision</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#revision'));
-    $fields['log'] = t('Node: <a href="@doc">Revision Log message</a>',
+    $fields['log'] = t('<a href="@doc">Revision Log message</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#log'));
-    $fields['language'] = t('Node: <a href="@doc">Language (fr, en, ...)</a>',
+    $fields['language'] = t('<a href="@doc">Language (fr, en, ...)</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#language'));
-    $fields['tnid'] = t('Node: <a href="@doc">The translation set id for this node</a>',
+    $fields['tnid'] = t('<a href="@doc">The translation set id for this node</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#tnid'));
-    $fields['translate'] = t('Node: <a href="@doc">A boolean indicating whether this translation page needs to be updated</a>',
+    $fields['translate'] = t('<a href="@doc">A boolean indicating whether this translation page needs to be updated</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#translate'));
-    $fields['revision_uid'] = t('Node: <a href="@doc">Modified (uid)</a>',
+    $fields['revision_uid'] = t('<a href="@doc">Modified (uid)</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#revision_uid'));
     $fields['is_new'] = t('Option: <a href="@doc">Indicates a new node with the specified nid should be created</a>',
                     array('@doc' => 'http://drupal.org/node/1349696#is_new'));
@@ -128,7 +130,7 @@ class MigrateDestinationNode extends MigrateDestinationEntity {
   public function import(stdClass $node, stdClass $row) {
     // Updating previously-migrated content?
     $migration = Migration::currentMigration();
-    if (isset($row->migrate_map_destid1)) {
+    if (isset($row->migrate_map_destid1) && !$this->bypassDestIdCheck) {
       // Make sure is_new is off
       $node->is_new = FALSE;
       if (isset($node->nid)) {
@@ -177,7 +179,8 @@ class MigrateDestinationNode extends MigrateDestinationEntity {
         $node->uid = $old_node->uid;
       }
     }
-    elseif (!isset($node->type)) {
+
+    if (!isset($node->type)) {
       // Default the type to our designated destination bundle (by doing this
       // conditionally, we permit some flexibility in terms of implementing
       // migrations which can affect more than one type).
@@ -207,13 +210,21 @@ class MigrateDestinationNode extends MigrateDestinationEntity {
       if (isset($node->uid)) {
         $uid = $node->uid;
       }
+      if (isset($node->revision)) {
+        $revision = $node->revision;
+      }
+
       node_object_prepare($node);
+
       if (isset($created)) {
         $node->created = $created;
       }
       // No point to resetting $node->changed here, node_save() will overwrite it
       if (isset($uid)) {
         $node->uid = $uid;
+      }
+      if (isset($revision)) {
+        $node->revision = $revision;
       }
     }
 
@@ -245,6 +256,14 @@ class MigrateDestinationNode extends MigrateDestinationEntity {
     else {
       $updating = FALSE;
     }
+
+    // Make sure that if is_new is not TRUE, it is not present.
+    if (isset($node->is_new) && empty($node->is_new)) {
+      unset($node->is_new);
+    }
+
+    // Validate field data prior to saving.
+    MigrateDestinationEntity::fieldAttachValidate('node', $node);
 
     migrate_instrument_start('node_save');
     node_save($node);
@@ -294,5 +313,138 @@ class MigrateDestinationNode extends MigrateDestinationEntity {
 
     $this->complete($node, $row);
     return $return;
+  }
+}
+
+/**
+ * Allows you to import revisions.
+ *
+ * Adapted from http://www.darrenmothersele.com/blog/2012/07/16/migrating-node-revisions-drupal-7/
+ *
+ * Class MigrateDestinationNodeRevision
+ *
+ * @author darrenmothersele
+ * @author cthos
+ */
+class MigrateDestinationNodeRevision extends MigrateDestinationNode {
+  /**
+   * Basic initialization.
+   *
+   * @see parent::__construct
+   *
+   * @param string $bundle
+   *   A.k.a. the content type (page, article, etc.) of the node.
+   * @param array $options
+   *   Options applied to nodes.
+   */
+  public function __construct($bundle, array $options = array()) {
+    parent::__construct($bundle, $options);
+
+    $this->bypassDestIdCheck = TRUE;
+  }
+
+  /**
+   * Get key schema for the node revision destination.
+   *
+   * @see MigrateDestination::getKeySchema
+   *
+   * @return array
+   *   Returns the key schema.
+   */
+  static public function getKeySchema() {
+    return array(
+      'vid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'description' => 'ID of destination node revision',
+      ),
+    );
+  }
+
+  /**
+   * Returns additional fields on top of node destinations.
+   *
+   * @param string $migration
+   *   Active migration
+   *
+   * @return array
+   *   Fields.
+   */
+  public function fields($migration = NULL) {
+    $fields = parent::fields($migration);
+    $fields['vid'] = t('Node: <a href="@doc">Revision (vid)</a>', array('@doc' => 'http://drupal.org/node/1298724'));
+    return $fields;
+  }
+
+  /**
+   * Rolls back any versions that have been created.
+   *
+   * @param array $vids
+   *   Version ids to roll back.
+   */
+  public function bulkRollback(array $vids) {
+    migrate_instrument_start('revision_delete_multiple');
+    $this->prepareRollback($vids);
+    $nids = array();
+    foreach ($vids as $vid) {
+      if ($revision = node_load(NULL, $vid)) {
+        db_delete('node_revision')
+          ->condition('vid', $revision->vid)
+          ->execute();
+        module_invoke_all('node_revision_delete', $revision);
+        field_attach_delete_revision('node', $revision);
+        $nids[$revision->nid] = $revision->nid;
+      }
+    }
+    $this->completeRollback($vids);
+    foreach ($nids as $nid) {
+      $vid = db_select('node_revision', 'nr')->fields('nr', array('vid'))->condition('nid', $nid, '=')->execute()->fetchField();
+      if (!empty($vid)) {
+        db_update('node')->fields(array('vid' => $vid))->condition('nid', $nid, '=')->execute();
+      }
+    }
+    migrate_instrument_stop('revision_delete_multiple');
+  }
+
+  /**
+   * Overridden import method.
+   *
+   * This is done because parent::import will return the nid of the newly
+   * created nodes. This is bad since the migrate_map_* table will have
+   * nids instead of vids, which could cause a nightmare explosion on
+   * rollback.
+   *
+   * @param stdClass $node
+   *   Populated entity.
+   *
+   * @param stdClass $row
+   *   Source information in object format.
+   *
+   * @return array|bool
+   *   Array with newly created vid, or FALSE on error.
+   *
+   * @throws MigrateException
+   */
+  public function import(stdClass $node, stdClass $row) {
+    // We're importing revisions, this should be set.
+    $node->revision = 1;
+
+    if (empty($node->nid)) {
+      throw new MigrateException(t('Missing incoming nid.'));
+    }
+
+    $original_updated = $this->numUpdated;
+
+    parent::import($node, $row);
+
+    // Reset num updated and increment created since new revision is always an update.
+    $this->numUpdated = $original_updated;
+    $this->numCreated++;
+
+    if (empty($node->vid)) {
+      return FALSE;
+    }
+
+    return array($node->vid);
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/path.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/path.inc
@@ -10,25 +10,32 @@ class MigratePathEntityHandler extends MigrateDestinationHandler {
     $this->registerTypes(array('entity'));
   }
 
-  public function fields($entity_type, $bundle) {
+  /**
+   * Implementation of MigrateDestinationHandler::fields().
+   */
+  public function fields($entity_type, $bundle, $migration = NULL) {
     if (module_exists('path')) {
-      switch ($entity_type) {
-        case 'node':
-          return array('path' => t('Node: Path alias'));
-        case 'user':
-          return array('path' => t('User: Path alias'));
-        case 'taxonomy_term':
-          return array('path' => t('Term: Path alias'));
-      }
+      return array('path' => t('Path alias'));
     }
     return array();
   }
 
   public function prepare($entity, stdClass $row) {
     if (module_exists('path') && isset($entity->path)) {
-      $path = $entity->path;
-      $entity->path = array();
-      $entity->path['alias'] = $path;
+      // Make sure the alias doesn't already exist
+      $query = db_select('url_alias')
+        ->condition('alias', $entity->path)
+        ->condition('language', $entity->language);
+      $query->addExpression('1');
+      $query->range(0, 1);
+      if (!$query->execute()->fetchField()) {
+        $path = $entity->path;
+        $entity->path = array();
+        $entity->path['alias'] = $path;
+      }
+      else {
+        unset($entity->path);
+      }
     }
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/poll.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/poll.inc
@@ -60,13 +60,16 @@ class MigratePollEntityHandler extends MigrateDestinationHandler {
     $this->registerTypes(array('node'));
   }
 
-  public function fields($entity_type, $bundle) {
+  /**
+   * Implementation of MigrateDestinationHandler::fields().
+   */
+  public function fields($entity_type, $bundle, $migration = NULL) {
     if ($bundle == 'poll') {
       $fields = array(
-        'active' => t('Poll: Active status'),
-        'runtime' => t('Poll: How long the poll runs for in seconds'),
-        'choice' => t('Poll: Choices. Each choice is an array with chtext, chvotes, and weight keys.'),
-        'votes' => t('Poll: Votes. Each vote is an array with chid (or chtext), uid, hostname, and timestamp keys'),
+        'active' => t('Active status'),
+        'runtime' => t('How long the poll runs for in seconds'),
+        'choice' => t('Choices. Each choice is an array with chtext, chvotes, and weight keys.'),
+        'votes' => t('Votes. Each vote is an array with chid (or chtext), uid, hostname, and timestamp keys'),
       );
     }
     else {
@@ -97,14 +100,16 @@ class MigratePollEntityHandler extends MigrateDestinationHandler {
 
       // Insert actual votes.
       foreach ($row->votes as $vote) {
-        $chid = $vote['chid'];
-        if (!isset($chid)) {
+        if (!isset($vote['chid'])) {
           $result = db_select('poll_choice', 'pc')
                   ->fields('pc', array('chid'))
                   ->condition('pc.nid', $entity->nid)
                   ->condition('pc.chtext', $vote['chtext'])
                   ->execute();
           $chid = $result->fetchField();
+        }
+        else {
+          $chid = $vote['chid'];
         }
         db_insert('poll_vote')
           ->fields(array(

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/statistics.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/statistics.inc
@@ -10,12 +10,15 @@ class MigrateStatisticsEntityHandler extends MigrateDestinationHandler {
     $this->registerTypes(array('node'));
   }
 
-  public function fields() {
+  /**
+   * Implementation of MigrateDestinationHandler::fields().
+   */
+  public function fields($entity_type, $bundle, $migration = NULL) {
     if (module_exists('statistics')) {
       $fields = array(
-        'totalcount' => t('Node: The total number of times the node has been viewed.'),
-        'daycount' => t('Node: The total number of times the node has been viewed today.'),
-        'timestamp' => t('Node: The most recent time the node has been viewed.'),
+        'totalcount' => t('The total number of times the node has been viewed.'),
+        'daycount' => t('The total number of times the node has been viewed today.'),
+        'timestamp' => t('The most recent time the node has been viewed.'),
       );
     }
     else {
@@ -26,9 +29,12 @@ class MigrateStatisticsEntityHandler extends MigrateDestinationHandler {
 
   public function complete($node, stdClass $row) {
     if (module_exists('statistics') && isset($node->nid)) {
-      $totalcount = isset($node->totalcount) ? $node->totalcount : 0;
-      $daycount = isset($node->daycount) ? $node->daycount : 0;
-      $timestamp = isset($node->timestamp) ? $node->timestamp : 0;
+      $totalcount = isset($node->totalcount) && is_numeric($node->totalcount) ?
+        $node->totalcount : 0;
+      $daycount = isset($node->daycount) && is_numeric($node->daycount) ?
+        $node->daycount : 0;
+      $timestamp = isset($node->timestamp) && is_numeric($node->timestamp) ?
+        $node->timestamp : 0;
       db_merge('node_counter')
         ->key(array('nid' => $node->nid))
         ->fields(array(

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/table.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/table.inc
@@ -57,19 +57,20 @@ class MigrateDestinationTable extends MigrateDestination {
   /**
    * Delete a single row.
    *
-   * @param $id
-   *  Primary key values.
+   * @param array $ids
+   *   The primary key values of the row to be deleted.
    */
-  public function rollback(array $id) {
+  public function rollback(array $ids) {
     migrate_instrument_start('table rollback');
-    $delete = db_delete($this->tableName);
     $keys = array_keys(self::getKeySchema($this->tableName));
-    $i = 0;
-    foreach ($id as $value) {
-      $key = $keys[$i++];
+    $values = array_combine($keys, $ids);
+    $this->prepareRollback($values);
+    $delete = db_delete($this->tableName);
+    foreach ($values as $key => $value) {
       $delete->condition($key, $value);
     }
     $delete->execute();
+    $this->completeRollback($values);
     migrate_instrument_stop('table rollback');
   }
 
@@ -165,7 +166,7 @@ class MigrateDestinationTable extends MigrateDestination {
   public function fields($migration = NULL) {
     $fields = array();
     foreach ($this->schema['fields'] as $column => $schema) {
-      $fields[$column] = t('Type: !type', array('!type' => $schema['type']));
+      $fields[$column] = t('!type', array('!type' => $schema['type']));
     }
     return $fields;
   }
@@ -205,6 +206,46 @@ class MigrateDestinationTable extends MigrateDestination {
     // Call any complete handler for this specific Migration.
     if (method_exists($migration, 'complete')) {
       $migration->complete($entity, $source_row);
+    }
+  }
+
+  /**
+   * Give handlers a shot at cleaning up before the row has been rolled back.
+   *
+   * @param array $ids
+   *   The primary key values of the row about to be deleted, keyed by field
+   *    name.
+   */
+  public function prepareRollback(array $ids) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+
+    // Call any general handlers.
+    migrate_handler_invoke_all('table', 'prepareRollback', $ids);
+
+    // Then call any complete handler for this specific Migration.
+    if (method_exists($migration, 'prepareRollback')) {
+      $migration->prepareRollback($ids);
+    }
+  }
+
+  /**
+   * Give handlers a shot at cleaning up after a row has been rolled back.
+   *
+   * @param array $ids
+   *   The primary key values of the row which has been deleted, keyed by field
+   *   name.
+   */
+  public function completeRollback(array $ids) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+
+    // Call any general handlers.
+    migrate_handler_invoke_all('table', 'completeRollback', $ids);
+
+    // Then call any complete handler for this specific Migration.
+    if (method_exists($migration, 'completeRollback')) {
+      $migration->completeRollback($ids);
     }
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/table_copy.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/table_copy.inc
@@ -49,13 +49,18 @@ class MigrateDestinationTableCopy extends MigrateDestination {
     $migration = MigrationBase::currentMigration();
 
     $fields = clone $row;
+    // Remove all map data, otherwise we'll try to write it to the destination
+    // table.
+    foreach ($fields as $field => $data) {
+      if (strpos($field, 'migrate_map_') === 0) {
+        unset($fields->$field);
+      }
+    }
     $keys = array_keys($this->keySchema);
     $values  = array();
     foreach ($keys as $key) {
       $values[] = $row->$key;
     }
-    unset($fields->migrate_map_destid1);
-    unset($fields->needs_update);
     $query = db_merge($this->tableName)->key($keys, $values)->fields((array)$fields);
     try {
       $status = $query->execute();
@@ -72,7 +77,7 @@ class MigrateDestinationTableCopy extends MigrateDestination {
       Migration::displayMessage($e->getMessage());
     }
     catch (Exception $e) {
-      $this->handleException($e);
+      $migration->handleException($e);
     }
   }
 

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/term.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/term.inc
@@ -70,20 +70,20 @@ class MigrateDestinationTerm extends MigrateDestinationEntity {
   public function fields($migration = NULL) {
     $fields = array();
     // First the core (taxonomy_term_data table) properties
-    $fields['tid'] = t('Term: <a href="@doc">Existing term ID</a>',
+    $fields['tid'] = t('<a href="@doc">Existing term ID</a>',
                 array('@doc' => 'http://drupal.org/node/1349702#tid'));
-    $fields['name'] = t('Term: <a href="@doc">Name</a>',
+    $fields['name'] = t('<a href="@doc">Name</a>',
                     array('@doc' => 'http://drupal.org/node/1349702#name'));
-    $fields['description'] = t('Term: <a href="@doc">Description</a>',
+    $fields['description'] = t('<a href="@doc">Description</a>',
                     array('@doc' => 'http://drupal.org/node/1349702#description'));
-    $fields['parent'] = t('Term: <a href="@doc">Parent (by Drupal term ID)</a>',
+    $fields['parent'] = t('<a href="@doc">Parent (by Drupal term ID)</a>',
                     array('@doc' => 'http://drupal.org/node/1349702#parent'));
     // TODO: Remove parent_name, implement via arguments
-    $fields['parent_name'] = t('Term: <a href="@doc">Parent (by name)</a>',
+    $fields['parent_name'] = t('<a href="@doc">Parent (by name)</a>',
                     array('@doc' => 'http://drupal.org/node/1349702#parent_name'));
-    $fields['format'] = t('Term: <a href="@doc">Format</a>',
+    $fields['format'] = t('<a href="@doc">Format</a>',
                     array('@doc' => 'http://drupal.org/node/1349702#format'));
-    $fields['weight'] = t('Term: <a href="@doc">Weight</a>',
+    $fields['weight'] = t('<a href="@doc">Weight</a>',
                     array('@doc' => 'http://drupal.org/node/1349702#weight'));
 
     // Then add in anything provided by handlers
@@ -149,6 +149,12 @@ class MigrateDestinationTerm extends MigrateDestinationEntity {
         $term->tid = $row->migrate_map_destid1;
       }
     }
+
+    // Default to bundle if no vocabulary machine name provided
+    if (!isset($term->vocabulary_machine_name)) {
+      $term->vocabulary_machine_name = $this->bundle;
+    }
+
     if ($migration->getSystemOfRecord() == Migration::DESTINATION) {
       if (!isset($term->tid)) {
         throw new MigrateException(t('System-of-record is DESTINATION, but no destination tid provided'));
@@ -166,10 +172,6 @@ class MigrateDestinationTerm extends MigrateDestinationEntity {
       $term = $old_term;
     }
     else {
-      // Default to bundle if no vocabulary machine name provided
-      if (!isset($term->vocabulary_machine_name)) {
-        $term->vocabulary_machine_name = $this->bundle;
-      }
       // vid is required
       if (empty($term->vid)) {
         static $vocab_map = array();
@@ -203,7 +205,13 @@ class MigrateDestinationTerm extends MigrateDestinationEntity {
       if (empty($term->parent)) {
         $term->parent = array(0);
       }
-      if (is_array($term->parent) && isset($term->parent['arguments'])) {
+      elseif (!is_array($term->parent)) {
+        // Convert to an array for comparison in findMatchingTerm().
+        // Note: taxonomy_term_save() also normalizes to an array.
+        $term->parent = array($term->parent);
+      }
+
+      if (isset($term->parent['arguments'])) {
         // Unset arguments here to avoid duplicate entries in the
         // term_hierarchy table.
         unset($term->parent['arguments']);
@@ -211,7 +219,14 @@ class MigrateDestinationTerm extends MigrateDestinationEntity {
       if (!isset($term->format)) {
         $term->format = $this->textFormat;
       }
+      if (!isset($term->language)) {
+        $term->language = $this->language;
+      }
       $this->prepare($term, $row);
+
+      if (empty($term->name)) {
+        throw new MigrateException(t('Taxonomy term name is required.'));
+      }
 
       if (!$this->allowDuplicateTerms && $existing_term = $this->findMatchingTerm($term)) {
         foreach ($existing_term as $field => $value) {
@@ -241,6 +256,9 @@ class MigrateDestinationTerm extends MigrateDestinationEntity {
     else {
       $updating = FALSE;
     }
+
+    // Validate field data prior to saving.
+    MigrateDestinationEntity::fieldAttachValidate('taxonomy_term', $term);
 
     migrate_instrument_start('taxonomy_term_save');
     $status = taxonomy_term_save($term);

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/user.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/user.inc
@@ -75,41 +75,41 @@ class MigrateDestinationUser extends MigrateDestinationEntity {
   public function fields($migration = NULL) {
     $fields = array();
     // First the core (users table) properties
-    $fields['uid'] = t('User: <a href="@doc">Existing user ID</a>',
+    $fields['uid'] = t('<a href="@doc">Existing user ID</a>',
             array('@doc' => 'http://drupal.org/node/1349632#uid'));
-    $fields['mail'] = t('User: <a href="@doc">Email address</a>',
+    $fields['mail'] = t('<a href="@doc">Email address</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#mail'));
-    $fields['name'] = t('User: <a href="@doc">Username</a>',
+    $fields['name'] = t('<a href="@doc">Username</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#name'));
-    $fields['pass'] = t('User: <a href="@doc">Password (plain text)</a>',
+    $fields['pass'] = t('<a href="@doc">Password</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#pass'));
-    $fields['status'] = t('User: <a href="@doc">Status</a>',
+    $fields['status'] = t('<a href="@doc">Status</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#status'));
-    $fields['created'] = t('User: <a href="@doc">Registered timestamp</a>',
+    $fields['created'] = t('<a href="@doc">Registered timestamp</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#created'));
-    $fields['access'] = t('User: <a href="@doc">Last access timestamp</a>',
+    $fields['access'] = t('<a href="@doc">Last access timestamp</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#access'));
-    $fields['login'] = t('User: <a href="@doc">Last login timestamp</a>',
+    $fields['login'] = t('<a href="@doc">Last login timestamp</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#login'));
-    $fields['roles'] = t('User: <a href="@doc">Role IDs</a>',
+    $fields['roles'] = t('<a href="@doc">Role IDs</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#roles'));
-    $fields['role_names'] = t('User: <a href="@doc">Role Names</a>',
+    $fields['role_names'] = t('<a href="@doc">Role Names</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#role_names'));
-    $fields['picture'] = t('User: <a href="@doc">Picture</a>',
+    $fields['picture'] = t('<a href="@doc">Picture</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#picture'));
-    $fields['signature'] = t('User: <a href="@doc">Signature</a>',
+    $fields['signature'] = t('<a href="@doc">Signature</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#signature'));
-    $fields['signature_format'] = t('User: <a href="@doc">Signature format</a>',
+    $fields['signature_format'] = t('<a href="@doc">Signature format</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#signature_format'));
-    $fields['timezone'] = t('User: <a href="@doc">Timezone</a>',
+    $fields['timezone'] = t('<a href="@doc">Timezone</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#timezone'));
-    $fields['language'] = t('User: <a href="@doc">Language</a>',
+    $fields['language'] = t('<a href="@doc">Language</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#language'));
-    $fields['theme'] = t('User: <a href="@doc">Default theme</a>',
+    $fields['theme'] = t('<a href="@doc">Default theme</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#theme'));
-    $fields['init'] = t('User: <a href="@doc">Init</a>',
+    $fields['init'] = t('<a href="@doc">Init</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#init'));
-    $fields['data'] = t('User: <a href="@doc">Data</a>',
+    $fields['data'] = t('<a href="@doc">Data</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#init'));
     $fields['is_new'] = t('Option: <a href="@doc">Indicates a new user with the specified uid should be created</a>',
                 array('@doc' => 'http://drupal.org/node/1349632#is_new'));
@@ -230,6 +230,9 @@ class MigrateDestinationUser extends MigrateDestinationEntity {
       $account->login = MigrationBase::timestamp($account->login);
     }
 
+    // Validate field data prior to saving.
+    MigrateDestinationEntity::fieldAttachValidate('user', $account);
+
     migrate_instrument_start('user_save');
     $newaccount = user_save($old_account, (array)$account);
     migrate_instrument_stop('user_save');
@@ -262,6 +265,14 @@ class MigrateDestinationUser extends MigrateDestinationEntity {
       }
       else {
         $this->numCreated++;
+        // user_save() doesn't update file_usage on account creation, we have
+        // to do it ourselves.
+        if (!empty($newaccount->picture)) {
+          $file = file_load($newaccount->picture);
+          if (is_object($file)) {
+            file_usage_add($file, 'user', 'user', $newaccount->uid);
+          }
+        }
       }
       $this->complete($newaccount, $row);
       $return = array($newaccount->uid);
@@ -324,9 +335,9 @@ class MigrateDestinationRole extends MigrateDestinationTable {
           throw new MigrateException(t("Incoming id !id and map destination id !destid don't match",
             array('!id' => $entity->rid, '!destid' => $row->migrate_map_destid1)));
         }
-        else {
-          $entity->rid = $row->migrate_map_destid1;
-        }
+      }
+      else {
+        $entity->rid = $row->migrate_map_destid1;
       }
     }
 

--- a/docroot/sites/all/modules/migration/migrate/plugins/destinations/variable.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/destinations/variable.inc
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * @file
+ * Support for variable destinations.
+ */
+
+/**
+ * Destination class implementing migration into {variable}.
+ */
+class MigrateDestinationVariable extends MigrateDestination {
+
+  static public function getKeySchema() {
+    return array(
+      'name' => array(
+        'description' => 'The name of the variable.',
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+    );
+  }
+
+  public function __construct() {
+    parent::__construct();
+  }
+
+  public function __toString() {
+    $output = t('Variable');
+    return $output;
+  }
+
+  /**
+   * Returns a list of fields available to be mapped for variables.
+   *
+   * @param Migration $migration
+   *   Optionally, the migration containing this destination.
+   * @return array
+   *   Keys: machine names of the fields (to be passed to addFieldMapping)
+   *   Values: Human-friendly descriptions of the fields.
+   */
+  public function fields($migration = NULL) {
+    $fields = array(
+      'name' => t('The name of the variable.'),
+      'value' => t('The value of the variable.'),
+    );
+    return $fields;
+  }
+
+  /**
+   * Import a single row.
+   *
+   * @param $variable
+   *   Variable object to build. Prefilled with any fields mapped in the Migration.
+   * @param $row
+   *   Raw source data object - passed through to prepare/complete handlers.
+   * @return array
+   *   Array of key fields of the object that was saved if
+   *   successful. FALSE on failure.
+   */
+  public function import(stdClass $variable, stdClass $row) {
+    // Invoke migration prepare handlers
+    $this->prepare($variable, $row);
+
+    // Check to see if this is a new variable.
+    $update = FALSE;
+    // We cannot just check against NULL because a variable might actually be
+    // set to NULL. Attempt to use a unique variable default value that nothing
+    // else would use.
+    $default = 'migrate:' . REQUEST_TIME . ':' . drupal_random_key();
+    if (variable_get($variable->name, $default) !== $default) {
+      $update = TRUE;
+    }
+
+    // variable_set() provides no return callback, so we can't really test this
+    // without running a variable_get() check.
+    migrate_instrument_start('variable_set');
+    variable_set($variable->name, $variable->value);
+    migrate_instrument_stop('variable_set');
+
+    // Return the new id or FALSE on failure.
+    if (variable_get($variable->name, $default) === $variable->value) {
+      // Increment the count if the save succeeded.
+      if ($update) {
+        $this->numUpdated++;
+      }
+      else {
+        $this->numCreated++;
+      }
+      // Return the primary key to the mapping table.
+      $return = array($variable->name);
+    }
+    else {
+      $return = FALSE;
+    }
+
+    // Invoke migration complete handlers.
+    $this->complete($variable, $row);
+
+    return $return;
+  }
+
+  /**
+   * Implementation of MigrateDestination::prepare().
+   */
+  public function prepare($variable, stdClass $row) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+    $variable->migrate = array(
+      'machineName' => $migration->getMachineName(),
+    );
+
+    // Call any general handlers.
+    migrate_handler_invoke_all('variable', 'prepare', $variable, $row);
+    // Then call any prepare handler for this specific Migration.
+    if (method_exists($migration, 'prepare')) {
+      $migration->prepare($variable, $row);
+    }
+  }
+
+  /**
+   * Implementation of MigrateDestination::complete().
+   */
+  public function complete($variable, stdClass $row) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+    $variable->migrate = array(
+      'machineName' => $migration->getMachineName(),
+    );
+    // Call any general handlers.
+    migrate_handler_invoke_all('variable', 'complete', $variable, $row);
+    // Then call any complete handler for this specific Migration.
+    if (method_exists($migration, 'complete')) {
+      $migration->complete($variable, $row);
+    }
+  }
+
+  /**
+   * Delete a single variable.
+   *
+   * @param $id
+   *   Array of fields representing the key (in this case, just variable name).
+   */
+  public function rollback(array $id) {
+    $name = reset($id);
+    migrate_instrument_start('variable_delete');
+    $this->prepareRollback($name);
+    variable_del($name);
+    $this->completeRollback($name);
+    migrate_instrument_stop('variable_delete');
+  }
+
+  /**
+   * Give handlers a shot at cleaning up before a variable has been rolled back.
+   *
+   * @param $name
+   *   The name of the variable about to be deleted.
+   */
+  public function prepareRollback($name) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+    // Call any general handlers.
+    migrate_handler_invoke_all('variable', 'prepareRollback', $name);
+    // Then call any complete handler for this specific Migration.
+    if (method_exists($migration, 'prepareRollback')) {
+      $migration->prepareRollback($name);
+    }
+  }
+
+  /**
+   * Give handlers a shot at cleaning up after a variable has been rolled back.
+   *
+   * @param $name
+   *   The name of the variable which has been deleted.
+   */
+  public function completeRollback($name) {
+    // We do nothing here but allow child classes to act.
+    $migration = Migration::currentMigration();
+    // Call any general handlers.
+    migrate_handler_invoke_all('variable', 'completeRollback', $name);
+    // Then call any complete handler for this specific Migration.
+    if (method_exists($migration, 'completeRollback')) {
+      $migration->completeRollback($name);
+    }
+  }
+}

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/csv.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/csv.inc
@@ -186,6 +186,8 @@ class MigrateSourceCSV extends MigrateSource {
   public function getNextRow() {
     $row = $this->getNextLine();
     if ($row) {
+      // only use rows specified in $this->csvcolumns().
+      $row = array_intersect_key($row, $this->csvcolumns);
       // Set meaningful keys for the columns mentioned in $this->csvcolumns().
       foreach ($this->csvcolumns as $int => $values) {
         list($key, $description) = $values;

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/db2.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/db2.inc
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * @file
+ * Define a MigrateSource class for importing from IBM DB2 databases.
+ */
+
+/**
+ * Implementation of MigrateSource, to handle imports from remote DB2 servers.
+ */
+class MigrateSourceDB2 extends MigrateSource {
+  /**
+   * Array containing information for connecting to DB2:
+   *  database - Database to connect to
+   *  username - Username to connect as
+   *  password - Password for authentication
+   *
+   * @var array
+   */
+  protected $configuration;
+
+  /**
+   * The active DB2 connection for this source.
+   *
+   * @var resource
+   */
+  protected $connection;
+  public function getConnection() {
+    return $this->connection;
+  }
+
+  /**
+   * The SQL query from which to obtain data. Is a string.
+   */
+  protected $query;
+
+  /**
+   * The statement resource from executing the query - traversed to process the
+   * incoming data.
+   */
+  protected $stmt;
+
+  /**
+   * Return an options array for DB2 sources.
+   *
+   * @param boolean $cache_counts
+   *  Indicates whether to cache counts of source records.
+   */
+  static public function options($cache_counts = FALSE) {
+    return compact('cache_counts');
+  }
+
+  /**
+   * Simple initialization.
+   */
+  public function __construct(array $configuration, $query, $count_query,
+      array $fields, array $options = array()) {
+    parent::__construct($options);
+    $this->query = $query;
+    $this->countQuery = $count_query;
+    $this->configuration = $configuration;
+    $this->fields = $fields;
+  }
+
+  /**
+   * Return a string representing the source query.
+   *
+   * @return string
+   */
+  public function __toString() {
+    return $this->query;
+  }
+
+  /**
+   * Connect lazily to the DB server.
+   */
+  protected function connect() {
+    if (!isset($this->connection)) {
+      // Check for the ibm_db2 extension before attempting to connect with it.
+      if (!extension_loaded('ibm_db2')) {
+        throw new Exception(t('You must configure the ibm_db2 extension in PHP.'));
+      }
+      // Connect to db2.
+      $this->connection = db2_connect($this->configuration['database'],
+        $this->configuration['username'], $this->configuration['password']);
+    }
+    if ($this->connection) {
+      return TRUE;
+    }
+    // If we failed to connect, throw an exception with the connection error
+    // message.
+    else {
+      $e = db2_conn_errormsg();
+      throw new Exception($e);
+      return FALSE;
+    }
+  }
+
+  /**
+   * Returns a list of fields available to be mapped from the source query.
+   *
+   * @return array
+   *  Keys: machine names of the fields (to be passed to addFieldMapping)
+   *  Values: Human-friendly descriptions of the fields.
+   */
+  public function fields() {
+    // The fields are passed to the constructor for this plugin.
+    return $this->fields;
+  }
+
+  /**
+   * Return a count of all available source records.
+   */
+  public function computeCount() {
+    migrate_instrument_start('MigrateSourceDB2 count');
+    // Make sure we're connected.
+    if ($this->connect()) {
+      // Execute the count query.
+      $stmt = db2_exec($this->connection, $this->countQuery);
+      // If something went wrong, throw an exception with the error message.
+      if (!$stmt) {
+        $e = db2_stmt_errormsg($stmt);
+        throw new Exception($e);
+      }
+      // Grab the first row as an array.
+      $count_array = db2_fetch_array($stmt);
+      // The first item in this array will be our count.
+      $count = reset($count_array);
+    }
+    else {
+      // Connection failed.
+      $count = FALSE;
+    }
+    migrate_instrument_stop('MigrateSourceDB2 count');
+    return $count;
+  }
+
+  /**
+   * Implementation of MigrateSource::performRewind().
+   */
+  public function performRewind() {
+    migrate_instrument_start('db2_query');
+    // Ensure we're connected to the database.
+    $this->connect();
+    // Execute the query.
+    $this->stmt = db2_exec($this->connection, $this->query);
+    // Throw an exception with the error message if something went wrong.
+    if (!$this->stmt) {
+      $e = db2_stmt_errormsg($this->stmt);
+      throw new Exception($e);
+    }
+    migrate_instrument_stop('db2_query');
+  }
+
+  /**
+   * Implementation of MigrateSource::getNextRow().
+   *
+   * @return object
+   */
+  public function getNextRow() {
+    return db2_fetch_object($this->stmt);
+  }
+}

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/files.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/files.inc
@@ -62,6 +62,7 @@ class MigrateListFiles extends MigrateList {
   protected $fileMask;
   protected $directoryOptions;
   protected $parser;
+  protected $getContents;
 
   /**
    * Constructor.
@@ -86,8 +87,12 @@ class MigrateListFiles extends MigrateList {
    * @param $options
    *   Options that will be passed on to file_scan_directory(). See docs of that
    *   core Drupal function for more information.
+   * @param MigrateContentParser $parser
+   *   Content parser class to use.
+   * @param $get_contents
+   *   Whether to load the contents of files.
    */
-  public function __construct($list_dirs, $base_dir, $file_mask = NULL, $options = array(), MigrateContentParser $parser = NULL) {
+  public function __construct($list_dirs, $base_dir, $file_mask = NULL, $options = array(), MigrateContentParser $parser = NULL, $get_contents = TRUE) {
     if (!$parser) {
       $parser = new MigrateSimpleContentParser();
     }
@@ -97,6 +102,7 @@ class MigrateListFiles extends MigrateList {
     $this->fileMask = $file_mask;
     $this->directoryOptions = $options;
     $this->parser = $parser;
+    $this->getContents = $get_contents;
   }
 
   /**
@@ -136,11 +142,16 @@ class MigrateListFiles extends MigrateList {
   protected function getIDsFromFiles(array $files) {
     $ids = array();
     foreach ($files as $file) {
-      $contents = file_get_contents($file->uri);
-      $this->parser->setContent($contents);
-      if ($this->parser->getChunkCount() > 1) {
-        foreach ($this->parser->getChunkIDs() as $chunk_id) {
-          $ids[] = str_replace($this->baseDir, '', (string) $file->uri) . MIGRATE_CHUNK_SEPARATOR . $chunk_id;
+      if ($this->getContents) {
+        $contents = file_get_contents($file->uri);
+        $this->parser->setContent($contents);
+        if ($this->parser->getChunkCount() > 1) {
+          foreach ($this->parser->getChunkIDs() as $chunk_id) {
+            $ids[] = str_replace($this->baseDir, '', (string) $file->uri) . MIGRATE_CHUNK_SEPARATOR . $chunk_id;
+          }
+        }
+        else {
+          $ids[] = str_replace($this->baseDir, '', (string) $file->uri);
         }
       }
       else {
@@ -206,7 +217,7 @@ class MigrateItemFile extends MigrateItem {
   public function getItem($id) {
     $pieces = explode(MIGRATE_CHUNK_SEPARATOR ,$id);
     $item_uri = $this->baseDir . $pieces[0];
-    $chunk = $pieces[1];
+    $chunk = !empty($pieces[1]) ? $pieces[1] : '';
 
     // Get the file data at the specified URI
     $data = $this->loadFile($item_uri);

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/json.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/json.inc
@@ -92,7 +92,7 @@ class MigrateListJSON extends MigrateList {
     if ($json) {
       $data = drupal_json_decode($json);
       if ($data) {
-        $count = count($data);
+        $count = count($this->getIDsFromJSON($data));
       }
     }
     return $count;
@@ -503,7 +503,7 @@ class MigrateSourceJSON extends MigrateSource {
    * @return string
    */
   public function activeUrl() {
-    if ($this->activeUrl) {
+    if (isset($this->activeUrl)) {
       return $this->sourceUrls[$this->activeUrl];
     }
   }

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/list.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/list.inc
@@ -56,6 +56,17 @@ abstract class MigrateItem {
    * @return stdClass
    */
   abstract public function getItem($id);
+
+  /**
+   * Implementors may optionally implement a hash function, applied to the
+   * entire source row, if this particular item type makes it difficult to
+   * do on the raw row.
+   *
+   * @param $row
+   *
+   * @return mixed
+   */
+  //abstract public function hash($row);
 }
 
 /**
@@ -187,9 +198,23 @@ class MigrateSourceList extends MigrateSource {
           list(, $id) = each($ids);
           $row->$key_name = $id;
         }
+        break;
       }
-      break;
     }
     return $row;
+  }
+
+  /**
+   * Overrides MigrateSource::hash().
+   */
+  protected function hash($row) {
+    // Let the item class override the default hash function.
+    if (method_exists($this->itemClass, 'hash')) {
+      $hash = $this->itemClass->hash($row);
+    }
+    else {
+      $hash = parent::hash($row);
+    }
+    return $hash;
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/mongodb.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/mongodb.inc
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * @file
+ * Define a MigrateSource for importing from MongoDB connections
+ */
+
+/**
+ * Implementation of MigrateSource, to handle imports from MongoDB connections.
+ */
+class MigrateSourceMongoDB extends MigrateSource {
+  /**
+   * The mongodb collection object.
+   *
+   * @var MongoCollection
+   */
+  protected $collection;
+
+  /**
+   * The mongodb cursor object.
+   *
+   * @var MongoCursor
+   */
+  protected $cursor;
+
+  /**
+   * The mongodb query.
+   *
+   * @var array
+   */
+  protected $query;
+
+  /**
+   * List of available source fields.
+   *
+   * @var array
+   */
+  protected $fields = array();
+
+  /**
+   * Simple initialization.
+   */
+  public function __construct(MongoCollection $collection, array $query,
+      array $fields = array(), array $sort = array('_id' => 1),
+      array $options = array()) {
+    parent::__construct($options);
+
+    $this->collection = $collection;
+    $this->query = $query;
+    $this->sort = $sort;
+    $this->fields = $fields;
+  }
+
+  /**
+   * Returns a list of fields available to be mapped from the source query.
+   *
+   * @return array
+   *  Keys: machine names of the fields (to be passed to addFieldMapping)
+   *  Values: Human-friendly descriptions of the fields.
+   */
+  public function fields() {
+    // The fields are passed to the constructor for this plugin.
+    return $this->fields;
+  }
+
+  /**
+   * Return a count of all available source records.
+   */
+  public function computeCount() {
+    return $this->cursor->count(TRUE);
+  }
+
+  /**
+   * Implementation of MigrateSource::getNextRow().
+   *
+   * @return object
+   */
+  public function getNextRow() {
+    $row = $this->cursor->getNext();
+
+    if ($row) {
+      return (object) $row;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Implementation of MigrateSource::performRewind().
+   *
+   * @return void
+   */
+  public function performRewind() {
+    $keys = $this->getSourceKeyNameAndType();
+
+    // If we have an existing idlist we use it.
+    if ($this->idList) {
+      foreach ($this->idList as $key => $id) {
+        // Try make new ObjectID.
+        $this->idList[$key] = $this->getMongoId($id, $keys);
+      }
+
+      $this->query[$keys[0]['name']]['$in'] = $this->idList;
+    }
+
+    migrate_instrument_start('MigrateSourceMongoDB execute');
+    try {
+      $this->cursor = $this->collection
+                           ->find($this->query)
+                           ->sort($this->sort);
+      $this->cursor->timeout(-1);
+    } catch (MongoCursorException $e) {
+      Migration::displayMessage($e->getMessage(), 'error');
+    }
+    migrate_instrument_stop('MigrateSourceMongoDB execute');
+  }
+
+  /**
+   * Return a string representing the source query.
+   *
+   * @return string
+   */
+  public function __toString() {
+    if (is_null($this->cursor)) {
+      $this->cursor = $this->collection
+                           ->find($this->query)
+                           ->sort($this->sort);
+      $this->cursor->timeout(-1);
+    }
+
+    $query_info = $this->cursor->info();
+
+    $query  = 'query:    ' . drupal_json_encode($query_info['query']['$query']);
+    $sort   = 'order by: ' . drupal_json_encode($query_info['query']['$orderby']);
+    $fields = 'fields:   ' . drupal_json_encode($query_info['fields']);
+
+    return $query . PHP_EOL .
+           $sort . PHP_EOL .
+           $fields . PHP_EOL;
+  }
+
+  /**
+   * Check if given document id is a mongo ObjectId and return mongo ObjectId
+   * or simple value.
+   *
+   * @param mixed $document_id
+   *   Document key value.
+   * @param array $keys
+   *   List of keys.
+   * @return type
+   */
+  public function getMongoId($document_id, $keys) {
+    if ($keys[0]['name'] != '_id') {
+      switch ($keys[0]['type']) {
+        case 'int':
+          return (int)$document_id;
+          break;
+        default:
+          return $document_id;
+      }
+    }
+
+    // Trying create Mongo ObjectId
+    $mongoid = new MongoId($document_id);
+
+    // If (string) $mongoid == $document_id we return $mongoid object
+    if ((string) $mongoid == $document_id) {
+      return $mongoid;
+    }
+
+    return $document_id;
+  }
+
+  /**
+   * Get source keys array.
+   */
+  public function getSourceKeyNameAndType() {
+    // Get the key name, and type.
+    $keys = array();
+    foreach ($this->activeMap->getSourceKey() as $field_name => $field_schema) {
+      $keys[] = array(
+        'name' => $field_name,
+        'type' => $field_schema['type'],
+      );
+    }
+
+    return $keys;
+  }
+}

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/mssql.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/mssql.inc
@@ -125,7 +125,8 @@ class MigrateSourceMSSQL extends MigrateSource {
     migrate_instrument_start('MigrateSourceMSSQL count');
     if ($this->connect()) {
       $result = mssql_query($this->countQuery);
-      $count = reset(mssql_fetch_object($result));
+      $result_array = mssql_fetch_array($result);
+      $count = reset($result_array);
     }
     else {
       // Do something else?

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/multiitems.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/multiitems.inc
@@ -47,8 +47,18 @@ abstract class MigrateItems {
    * @return stdClass
    */
   abstract public function getItem($id);
-}
 
+  /**
+   * Implementors may optionally implement a hash function, applied to the
+   * entire source row, if this particular item type makes it difficult to
+   * do on the raw row.
+   *
+   * @param $row
+   *
+   * @return mixed
+   */
+  //abstract public function hash($row);
+}
 
 /**
  * Implementation of MigrateItems, for providing a list of IDs and for
@@ -177,10 +187,23 @@ class MigrateSourceMultiItems extends MigrateSource {
         $sourceKey = $this->activeMap->getSourceKey();
         $key_name = key($sourceKey);
         $row->$key_name = $id;
+        break;
       }
-      break;
     }
     return $row;
   }
-}
 
+  /**
+   * Overrides MigrateSource::hash().
+   */
+  protected function hash($row) {
+    // Let the item class override the default hash function.
+    if (method_exists($this->itemsClass, 'hash')) {
+      $hash = $this->itemsClass->hash($row);
+    }
+    else {
+      $hash = parent::hash($row);
+    }
+    return $hash;
+  }
+}

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/spreadsheet.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/spreadsheet.inc
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * @file
+ * Define a MigrateSource for importing from spreadsheet files.
+ *
+ * Requires the PHPExcel library to be installed.
+ * - Download PHPExcel at http://phpexcel.codeplex.com/.
+ * - Extract the archive to a temporary folder.
+ * - Ensure the hosting environment fulfills the requirements found in
+ *   install.txt.
+ * - Copy the contents of the Classes folder to an appropriate location
+ *   (sites/all/libraries/PHPExcel).
+ */
+
+/**
+ * Implements MigrateSource, to handle imports from XLS files.
+ */
+class MigrateSourceSpreadsheet extends MigrateSource {
+  /**
+   * PHPExcel object for storing the workbook data.
+   *
+   * @var PHPExcel
+   */
+  protected $workbook;
+
+  /**
+   * PHPExcel object for storing the worksheet data.
+   *
+   * @var PHPExcel_Worksheet
+   */
+  protected $worksheet;
+
+  /**
+   * The name of the worksheet that will be processed.
+   *
+   * @var string
+   */
+  protected $sheetName;
+
+  /**
+   * Number of rows in the worksheet that is being processed.
+   *
+   * @var integer
+   */
+  protected $rows = 0;
+
+  /**
+   * Number of columns in the worksheet that is being processed.
+   *
+   * @var integer
+   */
+  protected $cols = 0;
+
+  /**
+   * List of available source fields.
+   *
+   * @var array
+   */
+  protected $fields = array();
+
+  /**
+   * The current row number in the XLS file.
+   *
+   * @var integer+   */
+  protected $rowNumber;
+
+  /**
+   * The columns to be read from Excel
+   */
+  protected $columns;
+
+  /**
+   * Simple initialization.
+   *
+   * @param string $path
+   *   The path to the source file.
+   * @param string $sheet_name
+   *   The name of the sheet to be processed.
+   * @param array $options
+   *   Options applied to this source.
+   */
+  public function __construct($path, $sheet_name, $columns = array(), array $options = array()) {
+    parent::__construct($options);
+    $this->file = $path;
+    $this->sheetName = $sheet_name;
+    $this->columns = $columns;
+
+    // Load the workbook.
+    if ($this->load()) {
+      // Get the dimensions of the worksheet.
+      $this->rows = $this->worksheet->getHighestDataRow();
+      $this->cols = PHPExcel_Cell::columnIndexFromString($this->worksheet->getHighestDataColumn());
+
+      // Map field names to their column index.
+      for ($col = 0; $col < $this->cols; ++$col) {
+        $this->fields[$col] = trim($this->worksheet->getCellByColumnAndRow($col, 1)->getValue());
+      }
+
+      $this->unload();
+    }
+  }
+
+  /**
+   * Loads the workbook.
+   *
+   * @return bool
+   *   Returns true if the workbook was successfully loaded, otherwise false.
+   */
+  public function load() {
+    // Check that the file exists.
+    if (!file_exists($this->file)) {
+      Migration::displayMessage(t('The file !filename does not exist.', array('!filename' => $this->file)));
+      return FALSE;
+    }
+
+    // Check that required modules are enabled.
+    if (!module_exists('libraries')) {
+      Migration::displayMessage(t('The Libraries API module is not enabled.'));
+      return FALSE;
+    }
+    if (!module_exists('phpexcel')) {
+      Migration::displayMessage(t('The PHPExcel module is not enabled.'));
+      return FALSE;
+    }
+
+    $library = libraries_load('PHPExcel');
+    if (empty($library['loaded'])) {
+      Migration::displayMessage(t('The PHPExcel library could not be found.'));
+      return FALSE;
+    }
+
+    // Load the workbook.
+    try {
+      // Identify the type of the input file.
+      $type = PHPExcel_IOFactory::identify($this->file);
+      // Create a new Reader of the file type.
+      $reader = PHPExcel_IOFactory::createReader($type);
+      // Advise the Reader that we only want to load cell data.
+      $reader->setReadDataOnly(TRUE);
+      // Advise the Reader of which worksheet we want to load.
+      $reader->setLoadSheetsOnly($this->sheetName);
+      // Load the source file.
+      $this->workbook = $reader->load($this->file);
+      $this->worksheet = $this->workbook->getSheet();
+    }
+    catch (Exception $e) {
+      Migration::displayMessage(t('Error loading file: %message', array('%message' => $e->getMessage())));
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Unloads the workbook.
+   */
+  public function unload() {
+    $this->workbook->disconnectWorksheets();
+    unset($this->workbook);
+  }
+
+  /**
+   * Returns a string representing the source query.
+   *
+   * @return string
+   */
+  public function __toString() {
+    return $this->file;
+  }
+
+  /**
+   * Returns a list of fields available to be mapped from the source query.
+   *
+   * @return array
+   *   Keys: machine names of the fields (to be passed to addFieldMapping).
+   *   Values: Human-friendly descriptions of the fields.
+   */
+  public function fields() {
+    $fields = array();
+
+    foreach ($this->fields as $name) {
+      $fields[$name] = $name;
+    }
+
+    return $fields;
+  }
+
+  /**
+   * Returns a count of all available source records.
+   */
+  public function computeCount() {
+    // Subtract 1 for the header.
+    return $this->rows - 1;
+  }
+
+  /**
+   * Implements MigrateSource::performRewind().
+   *
+   * @return void
+   */
+  public function performRewind() {
+    // Initialize the workbook if it isn't already.
+    if (!isset($this->workbook)) {
+      $this->load();
+    }
+
+    $this->rowNumber = 1;
+  }
+
+  /**
+   * Implements MigrateSource::getNextRow().
+   *
+   * @return null|object
+   */
+  public function getNextRow() {
+    migrate_instrument_start('MigrateSourceSpreadsheet::next');
+    ++$this->rowNumber;
+
+    if ($this->rowNumber <= $this->rows) {
+      $row_values = array();
+      for ($col = 0; $col < $this->cols; ++$col) {
+        if (in_array($this->fields[$col], $this->columns) || empty($this->columns)) {
+          $row_values[$this->fields[$col]] = trim($this->worksheet->getCellByColumnAndRow($col, $this->rowNumber)->getValue());
+         }
+      }
+
+      return (object) $row_values;
+    }
+    else {
+      // EOF, close the workbook.
+      $this->unload();
+
+      migrate_instrument_stop('MigrateSourceSpreadsheet::next');
+      return NULL;
+    }
+  }
+}

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/sql.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/sql.inc
@@ -14,7 +14,7 @@ class MigrateSourceSQL extends MigrateSource {
    *
    * @var SelectQueryInterface
    */
-  protected $originalQuery, $query, $countQuery;
+  protected $originalQuery, $query, $countQuery, $alteredQuery;
 
   /**
    * Return a reference to the base query, in particular so Migration classes
@@ -24,7 +24,7 @@ class MigrateSourceSQL extends MigrateSource {
    * @return SelectQueryInterface
    */
   public function &query() {
-    return $this->originalQuery();
+    return $this->originalQuery;
   }
 
   /**
@@ -41,6 +41,21 @@ class MigrateSourceSQL extends MigrateSource {
    * @var int
    */
   protected $numProcessed = 0;
+
+  /**
+   * Current data batch.
+   *
+   * @var int
+   */
+  protected $batch = 0;
+
+  /**
+   * Number of records to fetch from the database during each batch. A value
+   * of zero indicates no batching is to be done.
+   *
+   * @var int
+   */
+  protected $batchSize = 0;
 
   /**
    * List of available source fields.
@@ -118,6 +133,18 @@ class MigrateSourceSQL extends MigrateSource {
       $this->countQuery = $count_query;
     }
 
+    if (isset($options['batch_size'])) {
+      $this->batchSize = $options['batch_size'];
+      // Joining to the map table is incompatible with batching, disable it.
+      $options['map_joinable'] = FALSE;
+    }
+
+    // If we're tracking changes, then we need to fetch all rows to see if
+    // they've changed, we can't make that determination through a direct join.
+    if (!empty($options['track_changes'])) {
+      $options['map_joinable'] = FALSE;
+    }
+
     if (isset($options['map_joinable'])) {
       $this->mapJoinable = $options['map_joinable'];
     }
@@ -153,14 +180,15 @@ class MigrateSourceSQL extends MigrateSource {
     }
   }
 
-
   /**
    * Return a string representing the source query.
    *
    * @return string
    */
   public function __toString() {
-    return (string) $this->query;
+    $query = clone $this->query;
+    $query = $query->extend('MigrateConnectionQuery');
+    return $query->getString();
   }
 
   /**
@@ -243,6 +271,7 @@ class MigrateSourceSQL extends MigrateSource {
   public function performRewind() {
     $this->result = NULL;
     $this->query = clone $this->originalQuery;
+    $this->batch = 0;
 
     // Get the key values, for potential use in joining to the map table, or
     // enforcing idlist.
@@ -259,7 +288,41 @@ class MigrateSourceSQL extends MigrateSource {
     // 1. If idlist is provided, then only process items in that list (AND key
     //    IN (idlist)). Only applicable with single-value keys.
     if ($this->idList) {
-      $this->query->condition($keys[0], $this->idList, 'IN');
+      $simple_ids = array();
+      $compound_ids = array();
+      $key_count = count($keys);
+
+      foreach ($this->idList as $id) {
+        // Look for multi-key separator. If there is only 1 key, ignore.
+        if (strpos($id, $this->multikeySeparator) === FALSE || $key_count == 1) {
+          $simple_ids[] = $id;
+          continue;
+        }
+
+        $compound_ids[] = explode($this->multikeySeparator, $id);
+      }
+
+      // Check for compunded ids. If present add them with subsequent OR statements.
+      if (!empty($compound_ids)) {
+        $condition = db_or();
+        if (!empty($simple_ids)) {
+          $condition->condition($keys[0], $simple_ids, 'IN');
+        }
+
+        foreach ($compound_ids as $values) {
+          $temp_and = db_and();
+          foreach ($values as $pos => $value) {
+            $temp_and->condition($keys[$pos], $value);
+          }
+
+          $condition->condition($temp_and);
+        }
+
+        $this->query->condition($condition);
+      }
+      else {
+        $this->query->condition($keys[0], $simple_ids, 'IN');
+      }
     }
     else {
       // 2. If the map is joinable, join it. We will want to accept all rows
@@ -313,19 +376,42 @@ class MigrateSourceSQL extends MigrateSource {
       // 3. If we are using highwater marks, also include rows above the mark.
       //    But, include all rows if the highwater mark is not set.
       if (isset($this->highwaterField['name']) && $this->activeMigration->getHighwater() !== '') {
-        if (isset($this->highwaterField['alias'])) {
-          $highwater = $this->highwaterField['alias'] . '.' . $this->highwaterField['name'];
+        // But, if there are any existing items marked as needing update which
+        // fall below the highwater mark, and map_joinable is FALSE, those
+        // items will be skipped. Thus, in that case do not add the highwater
+        // optimization to the query.
+        $add_highwater_condition = TRUE;
+        if (!$this->mapJoinable) {
+          $count_needs_update = db_query('SELECT COUNT(*) FROM {' .
+            $this->activeMap->getQualifiedMapTable() . '} WHERE needs_update = 1')
+            ->fetchField();
+          if ($count_needs_update > 0) {
+            $add_highwater_condition = FALSE;
+          }
         }
-        else {
-          $highwater = $this->highwaterField['name'];
+        if ($add_highwater_condition) {
+          if (isset($this->highwaterField['alias'])) {
+            $highwater = $this->highwaterField['alias'] . '.' . $this->highwaterField['name'];
+          }
+          else {
+            $highwater = $this->highwaterField['name'];
+          }
+          $conditions->condition($highwater, $this->activeMigration->getHighwater(), '>');
+          $condition_added = TRUE;
         }
-        $conditions->condition($highwater, $this->activeMigration->getHighwater(), '>');
-        $condition_added = TRUE;
       }
       if ($condition_added) {
         $this->query->condition($conditions);
       }
+
+      // 4. Download data in batches for performance.
+      if ($this->batchSize > 0) {
+        $this->query->range($this->batch * $this->batchSize, $this->batchSize);
+      }
     }
+
+    // Save our fixed-up query so getNextBatch() matches it.
+    $this->alteredQuery = clone $this->query;
 
     migrate_instrument_start('MigrateSourceSQL execute');
     $this->result = $this->query->execute();
@@ -338,6 +424,71 @@ class MigrateSourceSQL extends MigrateSource {
    * @return object
    */
   public function getNextRow() {
-    return $this->result->fetchObject();
+    $row = $this->result->fetchObject();
+
+    // We might be out of data entirely, or just out of data in the current batch.
+    // Attempt to fetch the next batch and see.
+    if (!is_object($row) && $this->batchSize > 0) {
+      $this->getNextBatch();
+      $row = $this->result->fetchObject();
+    }
+    if (is_object($row)) {
+      return $row;
+    }
+    else {
+      return NULL;
+    }
+  }
+
+  /**
+   * Downloads the next set of data from the source database.
+   */
+  protected function getNextBatch() {
+    $this->batch++;
+    $query = clone $this->alteredQuery;
+    $query->range($this->batch * $this->batchSize, $this->batchSize);
+    $this->result = $query->execute();
+  }
+
+}
+
+/**
+ * Query extender for retrieving the connection used on the query.
+ */
+class MigrateConnectionQuery extends SelectQueryExtender {
+
+  public function __construct(SelectQueryInterface $query, DatabaseConnection $connection) {
+    parent::__construct($query, $connection);
+    // Add the connection as metadata if anything else wants to access it.
+    $query->addMetaData('connection', $connection);
+  }
+
+  /**
+   * Return a string representing the source query.
+   *
+   * This is copied from devel module's dpq() function.
+   *
+   * @param bool $prefix
+   *   If the tables should be prefixed. If FALSE will return tables names in
+   *   the query like {tablename}.
+   *
+   * @return string
+   *   The SQL query.
+   */
+  public function getString($prefix = TRUE) {
+    $query = $this;
+    if (method_exists($this, 'preExecute')) {
+      $query->preExecute();
+    }
+    $sql = (string) $this;
+    $quoted = array();
+    foreach ((array) $this->arguments() as $key => $val) {
+      $quoted[$key] = $this->connection->quote($val);
+    }
+    $sql = strtr($sql, $quoted);
+    if ($prefix) {
+      $sql = $this->connection->prefixTables($sql);
+    }
+    return $sql;
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/sqlmap.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/sqlmap.inc
@@ -69,19 +69,52 @@ class MigrateSQLMap extends MigrateMap {
    */
   protected $ensured;
 
+  /**
+   * Provide caching for Source or Desination Map Lookups.
+   */
+  protected $cacheMapLookups;
+
+  /**
+   * Constructor.
+   *
+   * @param string $machine_name
+   *   The unique reference to the migration that we are mapping.
+   * @param array $source_key
+   *   The database schema for the source key.
+   * @param array $destination_key
+   *   The database schema for the destination key.
+   * @param string $connection_key
+   *   Optional - The connection used to create the mapping tables. By default 
+   *   this is the destination (Drupal). If it's not possible to make joins
+   *   between the destination database and your source database you can specify
+   *   a different connection to create the mapping tables on.
+   * @param array $options
+   *   Optional - Options applied to this source.
+   */
   public function __construct($machine_name, array $source_key,
       array $destination_key, $connection_key = 'default', $options = array()) {
     if (isset($options['track_last_imported'])) {
       $this->trackLastImported = TRUE;
     }
+
+    if (isset($options['cache_map_lookups'])) {
+      $this->cacheMapLookups = $options['cache_map_lookups'];
+    }
+    else {
+      $this->cacheMapLookups = FALSE;
+    }
+
+    $this->connection = Database::getConnection('default', $connection_key);
+
     // Default generated table names, limited to 63 characters
+    $prefixLength = strlen($this->connection->tablePrefix()) ;
     $this->mapTable = 'migrate_map_' . drupal_strtolower($machine_name);
-    $this->mapTable = drupal_substr($this->mapTable, 0, 63);
+    $this->mapTable = drupal_substr($this->mapTable, 0, 63 - $prefixLength);
     $this->messageTable = 'migrate_message_' . drupal_strtolower($machine_name);
-    $this->messageTable = drupal_substr($this->messageTable, 0, 63);
+    $this->messageTable = drupal_substr($this->messageTable, 0, 63 - $prefixLength);
     $this->sourceKey = $source_key;
     $this->destinationKey = $destination_key;
-    $this->connection = Database::getConnection('default', $connection_key);
+
     // Build the source and destination key maps
     $this->sourceKeyMap = array();
     $count = 1;
@@ -147,6 +180,12 @@ class MigrateSQLMap extends MigrateMap {
           'default' => 0,
           'description' => 'UNIX timestamp of the last time this row was imported',
         );
+        $fields['hash'] = array(
+          'type' => 'varchar',
+          'length' => '32',
+          'not null' => FALSE,
+          'description' => 'Hash of source row data, for detecting changes',
+        );
         $schema = array(
           'description' => t('Mappings from source key to destination key'),
           'fields' => $fields,
@@ -181,6 +220,29 @@ class MigrateSQLMap extends MigrateMap {
           'indexes' => array('sourcekey' => $pks),
         );
         $this->connection->schema()->createTable($this->messageTable, $schema);
+      }
+      else {
+        // Add any missing columns to the map table
+        if (!$this->connection->schema()->fieldExists($this->mapTable,
+                                                      'rollback_action')) {
+          $this->connection->schema()->addField($this->mapTable,
+                                                'rollback_action', array(
+            'type' => 'int',
+            'size' => 'tiny',
+            'unsigned' => TRUE,
+            'not null' => TRUE,
+            'default' => 0,
+            'description' => 'Flag indicating what to do for this item on rollback',
+          ));
+        }
+        if (!$this->connection->schema()->fieldExists($this->mapTable, 'hash')) {
+          $this->connection->schema()->addField($this->mapTable, 'hash', array(
+            'type' => 'varchar',
+            'length' => '32',
+            'not null' => FALSE,
+            'description' => 'Hash of source row data, for detecting changes',
+          ));
+        }
       }
       $this->ensured = TRUE;
     }
@@ -252,6 +314,16 @@ class MigrateSQLMap extends MigrateMap {
    */
   public function lookupSourceID(array $destination_id) {
     migrate_instrument_start('lookupSourceID');
+    // Try a cache lookup if enabled.
+    if ($this->cacheMapLookups) {
+      $cache = &drupal_static($this->mapTable . '_sourceIDCache');
+      $serialized = json_encode($destination_id);
+      if (isset($cache[$serialized])) {
+        migrate_instrument_stop('lookupSourceID');
+        return $cache[$serialized];
+      }
+    }
+
     $query = $this->connection->select($this->mapTable, 'map')
               ->fields('map', $this->sourceKeyMap);
     foreach ($this->destinationKeyMap as $key_name) {
@@ -259,6 +331,12 @@ class MigrateSQLMap extends MigrateMap {
     }
     $result = $query->execute();
     $source_id = $result->fetchAssoc();
+
+    // Store the id in a cache if enabled.
+    if ($this->cacheMapLookups) {
+      $cache[$serialized] = $destination_id;
+    }
+
     migrate_instrument_stop('lookupSourceID');
     return $source_id;
   }
@@ -274,6 +352,16 @@ class MigrateSQLMap extends MigrateMap {
    */
   public function lookupDestinationID(array $source_id) {
     migrate_instrument_start('lookupDestinationID');
+    // Try a cache lookup if enabled.
+    if ($this->cacheMapLookups) {
+      $cache = &drupal_static($this->mapTable . '_destinationIDCache');
+      $serialized = json_encode($source_id);
+      if (isset($cache[$serialized])) {
+        migrate_instrument_stop('lookupDestinationID');
+        return $cache[$serialized];
+      }
+    }
+
     $query = $this->connection->select($this->mapTable, 'map')
               ->fields('map', $this->destinationKeyMap);
     foreach ($this->sourceKeyMap as $key_name) {
@@ -281,10 +369,15 @@ class MigrateSQLMap extends MigrateMap {
     }
     $result = $query->execute();
     $destination_id = $result->fetchAssoc();
+
+    // Store the id in a cache if enabled.
+    if ($this->cacheMapLookups) {
+      $cache[$serialized] = $destination_id;
+    }
+
     migrate_instrument_stop('lookupDestinationID');
     return $destination_id;
   }
-
   /**
    * Called upon import of one record, we record a mapping from the source key
    * to the destination key. Also may be called, setting the third parameter to
@@ -300,9 +393,12 @@ class MigrateSQLMap extends MigrateMap {
    * @param int $rollback_action
    *  How to handle the destination object on rollback. Defaults to
    *  ROLLBACK_DELETE.
+   * $param string $hash
+   *  If hashing is enabled, the hash of the raw source row.
    */
   public function saveIDMapping(stdClass $source_row, array $dest_ids,
-      $needs_update = MigrateMap::STATUS_IMPORTED, $rollback_action = MigrateMap::ROLLBACK_DELETE) {
+      $needs_update = MigrateMap::STATUS_IMPORTED,
+      $rollback_action = MigrateMap::ROLLBACK_DELETE, $hash = NULL) {
     migrate_instrument_start('saveIDMapping');
     // Construct the source key
     $keys = array();
@@ -321,6 +417,7 @@ class MigrateSQLMap extends MigrateMap {
     $fields = array(
       'needs_update' => (int)$needs_update,
       'rollback_action' => (int)$rollback_action,
+      'hash' => $hash,
     );
     $count = 1;
     if (!empty($dest_ids)) {
@@ -354,8 +451,8 @@ class MigrateSQLMap extends MigrateMap {
     if (is_array($source_key)) {
       foreach ($source_key as $key_value) {
         $fields['sourceid' . $count++] = $key_value;
-        // If any key value is empty, we can't save - print out and abort
-        if (empty($key_value)) {
+        // If any key value is not set, we can't save - print out and abort
+        if (!isset($key_value)) {
           print($message);
           return;
         }

--- a/docroot/sites/all/modules/migration/migrate/plugins/sources/xml.inc
+++ b/docroot/sites/all/modules/migration/migrate/plugins/sources/xml.inc
@@ -17,9 +17,9 @@
  * example.
  */
 
-/* =========================================================================== */
-/*                              List Method                                    */
-/* =========================================================================== */
+/* ========================================================================== */
+/*                              List Method                                   */
+/* ========================================================================== */
 /**
  * Implementation of MigrateList, for retrieving a list of IDs to be migrated
  * from an XML document.
@@ -32,32 +32,45 @@ class MigrateListXML extends MigrateList {
    */
   protected $listUrl;
 
-  public function __construct($list_url) {
+  /**
+   * An array of namespaces to explicitly register before Xpath queries.
+   *
+   * @var array
+   */
+  protected $namespaces;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($list_url, array $namespaces = array()) {
     parent::__construct();
     $this->listUrl = $list_url;
-    // Suppress errors during parsing, so we can pick them up after
+    $this->namespaces = $namespaces;
+    // Suppress errors during parsing, so we can pick them up after.
     libxml_use_internal_errors(TRUE);
   }
 
   /**
-   * Our public face is the URL we're getting items from
+   * {@inheritdoc}
    *
-   * @return string
+   * Our public face is the URL we're getting items from
    */
   public function __toString() {
     return $this->listUrl;
   }
 
   /**
-   * Load the XML at the given URL, and return an array of the IDs found within it.
+   * {@inheritdoc}
    *
-   * @return array
+   * Load the XML at the given URL, and return an array of the IDs found
+   * within it.
    */
   public function getIdList() {
     migrate_instrument_start("Retrieve $this->listUrl");
     $xml = simplexml_load_file($this->listUrl);
     migrate_instrument_stop("Retrieve $this->listUrl");
     if ($xml !== FALSE) {
+      $this->registerNamespaces($xml);
       return $this->getIDsFromXML($xml);
     }
     else {
@@ -73,34 +86,69 @@ class MigrateListXML extends MigrateList {
   }
 
   /**
+   * Gets an array of the IDs found in a XML.
+   *
    * Given an XML object, parse out the IDs for processing and return them as an
    * array. The default implementation assumes the IDs are simply the values of
    * the top-level elements - in most cases, you will need to override this to
    * reflect your particular XML structure.
    *
    * @param SimpleXMLElement $xml
+   *   Object from we get the ID's
    *
    * @return array
+   *   Extracted ID's
    */
   protected function getIDsFromXML(SimpleXMLElement $xml) {
     $ids = array();
     foreach ($xml as $element) {
-      $ids[] = (string)$element;
+      $ids[] = (string) $element;
+    }
+    // Additionally, if there are any namespaces registered, try to parse
+    // elements with namespaces as well.
+    if ($namespaces = $xml->getNamespaces()) {
+      foreach ($namespaces as $prefix => $url) {
+        foreach ($xml->children($url) as $element) {
+          $ids[] = (string) $element;
+        }
+      }
     }
     return array_unique($ids);
   }
 
   /**
-   * Return a count of all available IDs from the source listing. The default
-   * implementation assumes the count of top-level elements reflects the number
-   * of IDs available - in many cases, you will need to override this to reflect
-   * your particular XML structure.
+   * {@inheritdoc}
+   *
+   * Return a count of all available IDs from the source listing.
+   * The default implementation assumes the count of top-level elements
+   * reflects the number of IDs available - in many cases, you will need
+   * to override this to reflect your particular XML structure.
    */
   public function computeCount() {
     $xml = simplexml_load_file($this->listUrl);
-    // Number of sourceid elements beneath the top-level element
+    $this->registerNamespaces($xml);
+    // Number of sourceid elements beneath the top-level element.
     $count = count($xml);
+    // Additionally, if there are any namespaces registered, try to count
+    // elements with namespaces as well.
+    if ($namespaces = $xml->getNamespaces()) {
+      foreach ($namespaces as $prefix => $url) {
+        $count += count($xml->children($url));
+      }
+    }
     return $count;
+  }
+
+  /**
+   * Explicitly register namespaces on an XML element.
+   *
+   * @param SimpleXMLElement $xml
+   *   A SimpleXMLElement to register the namespaces on.
+   */
+  protected function registerNamespaces(SimpleXMLElement &$xml) {
+    foreach ($this->namespaces as $prefix => $namespace) {
+      $xml->registerXPathNamespace($prefix, $namespace);
+    }
   }
 }
 
@@ -117,40 +165,62 @@ class MigrateItemXML extends MigrateItem {
    */
   protected $itemUrl;
 
-  public function __construct($item_url) {
+  /**
+   * An array of namespaces to explicitly register before Xpath queries.
+   *
+   * @var array
+   */
+  protected $namespaces;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($item_url, array $namespaces = array()) {
     parent::__construct();
     $this->itemUrl = $item_url;
-    // Suppress errors during parsing, so we can pick them up after
+    $this->namespaces = $namespaces;
+    // Suppress errors during parsing, so we can pick them up after.
     libxml_use_internal_errors(TRUE);
   }
 
   /**
+   * Explicitly register namespaces on an XML element.
+   *
+   * @param SimpleXMLElement $xml
+   *   A SimpleXMLElement to register the namespaces on.
+   */
+  protected function registerNamespaces(SimpleXMLElement &$xml) {
+    foreach ($this->namespaces as $prefix => $namespace) {
+      $xml->registerXPathNamespace($prefix, $namespace);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   *
    * Implementors are expected to return an object representing a source item.
-   *
-   * @param mixed $id
-   *
-   * @return stdClass
    */
   public function getItem($id) {
-    // Make sure we actually have an ID
+    // Make sure we actually have an ID.
     if (empty($id)) {
       return NULL;
     }
     $item_url = $this->constructItemUrl($id);
-    // And make sure we actually got a URL to fetch
+    // And make sure we actually got a URL to fetch.
     if (empty($item_url)) {
       return NULL;
     }
-    // Get the XML object at the specified URL;
+    // Get the XML object at the specified URL.
     $xml = $this->loadXmlUrl($item_url);
     if ($xml !== FALSE) {
-      $return = new stdclass;
+      $this->registerNamespaces($xml);
+      $return = new stdclass();
       $return->xml = $xml;
       return $return;
     }
     else {
       $migration = Migration::currentMigration();
-      $message =  t('Loading of !objecturl failed:', array('!objecturl' => $item_url));
+      $message = t('Loading of !objecturl failed:', array('!objecturl' => $item_url));
       foreach (libxml_get_errors() as $error) {
         $message .= "\n" . $error->message;
       }
@@ -162,23 +232,49 @@ class MigrateItemXML extends MigrateItem {
   }
 
   /**
+   * Creates a valid URL pointing to current item.
+   *
    * The default implementation simply replaces the :id token in the URL with
-   * the ID obtained from MigrateListXML. Override if the item URL is not
-   * so easily expressed from the ID.
+   * the ID obtained from MigrateListXML. Override if the item URL is not so
+   * easily expressed from the ID.
    *
    * @param mixed $id
+   *   XML item ID
+   *
+   * @return string
+   *   Formatted string with replaced tokens
    */
   protected function constructItemUrl($id) {
     return str_replace(':id', $id, $this->itemUrl);
   }
 
   /**
-   * Default XML loader - just use Simplexml directly. This can be overridden for
-   * preprocessing of XML (removal of unwanted elements, caching of XML if the
-   * source service is slow, etc.)
+   * Loads the XML.
+   *
+   * Default XML loader - just use Simplexml directly. This can be overridden
+   * for preprocessing of XML (removal of unwanted elements, caching of XML if
+   * the source service is slow, etc.)
+   *
+   * @param string $item_url
+   *   URL to the XML file
+   *
+   * @return SimpleXMLElement
+   *   Loaded XML
    */
   protected function loadXmlUrl($item_url) {
     return simplexml_load_file($item_url);
+  }
+
+  /**
+   * Implments MigrateItem::hash().
+   */
+  public function hash($row) {
+    // $row->xml is a SimpleXMLElement. Temporarily set it as an XML string
+    // to prevent parent::hash() failing when try to create the hash.
+    migrate_instrument_start('MigrateItemXML::hash');
+    $hash = md5(serialize($row->xml->asXML()));
+    migrate_instrument_stop('MigrateItemXML::hash');
+    return $hash;
   }
 }
 
@@ -192,14 +288,22 @@ class MigrateXMLFieldMapping extends MigrateFieldMapping {
    * @var string
    */
   protected $xpath;
+
+  /**
+   * Get xpath of current item.
+   */
   public function getXpath() {
     return $this->xpath;
   }
 
   /**
-   * Add an xpath to this field mapping
+   * Add an xpath to this field mapping.
    *
    * @param string $xpath
+   *   xpath
+   *
+   * @return MigrateFieldMapping
+   *   MigrateFieldMapping
    */
   public function xpath($xpath) {
     $this->xpath = $xpath;
@@ -212,22 +316,27 @@ class MigrateXMLFieldMapping extends MigrateFieldMapping {
  */
 abstract class XMLMigration extends Migration {
   /**
-   * Override the default addFieldMapping(), so we can create our special
-   * field mapping class.
-   * TODO: Find a cleaner way to just substitute a different mapping class
+   * {@inheritdoc}
    *
-   * @param string $destinationField
-   *  Name of the destination field.
-   * @param string $sourceField
-   *  Name of the source field (optional).
-   * @param boolean $warn_on_override
-   *  Set to FALSE to prevent warnings when there's an existing mapping
-   *  for this destination field.
+   * So we can create our special field mapping class.
+   *
+   * @todo Find a cleaner way to just substitute a different mapping class.
+   *
+   * @param string|null $destination_field
+   *   machine-name of destination field
+   * @param string|null $source_field
+   *   name of source field
+   * @param bool $warn_on_override
+   *   Set to FALSE to prevent warnings when there's an existing mapping
+   *   for this destination field.
+   *
+   * @return MigrateXMLFieldMapping
+   *   MigrateXMLFieldMapping
    */
   public function addFieldMapping($destination_field, $source_field = NULL,
                                   $warn_on_override = TRUE) {
-    // Warn of duplicate mappings
-    if ($warn_on_override && !is_null($destination_field) && isset($this->fieldMappings[$destination_field])) {
+    // Warn of duplicate mappings.
+    if ($warn_on_override && !is_null($destination_field) && isset($this->codedFieldMappings[$destination_field])) {
       self::displayMessage(
         t('!name addFieldMapping: !dest was previously mapped, overridden',
           array('!name' => $this->machineName, '!dest' => $destination_field)),
@@ -235,15 +344,17 @@ abstract class XMLMigration extends Migration {
     }
     $mapping = new MigrateXMLFieldMapping($destination_field, $source_field);
     if (is_null($destination_field)) {
-      $this->fieldMappings[] = $mapping;
+      $this->codedFieldMappings[] = $mapping;
     }
     else {
-      $this->fieldMappings[$destination_field] = $mapping;
+      $this->codedFieldMappings[$destination_field] = $mapping;
     }
     return $mapping;
   }
 
   /**
+   * {@inheritdoc}
+   *
    * A normal $data_row has all the input data as top-level fields - in this
    * case, however, the data is embedded within a SimpleXMLElement object in
    * $data_row->xml. Explode that out to the normal form, and pass on to the
@@ -251,13 +362,16 @@ abstract class XMLMigration extends Migration {
    */
   protected function applyMappings() {
     // We only know what data to pull from the xpaths in the mappings.
-    foreach ($this->fieldMappings as $mapping) {
+    foreach ($this->getFieldMappings() as $mapping) {
       $source = $mapping->getSourceField();
-      if ($source) {
+      if ($source && !isset($this->sourceValues->{$source})) {
         $xpath = $mapping->getXpath();
         if ($xpath) {
-          // Derived class may override applyXpath()
-          $this->sourceValues->$source = $this->applyXpath($this->sourceValues, $xpath);
+          // Derived class may override applyXpath().
+          $source_value = $this->applyXpath($this->sourceValues, $xpath);
+          if (!is_null($source_value)) {
+            $this->sourceValues->$source = $source_value;
+          }
         }
       }
     }
@@ -265,10 +379,17 @@ abstract class XMLMigration extends Migration {
   }
 
   /**
+   * Gets item from XML using the xpath.
+   *
    * Default implementation - straightforward xpath application
    *
-   * @param $data_row
-   * @param $xpath
+   * @param stdClass $data_row
+   *   row containing items.
+   * @param string $xpath
+   *   xpath used to find the item
+   *
+   * @return SimpleXMLElement
+   *   found element
    */
   public function applyXpath($data_row, $xpath) {
     $result = $data_row->xml->xpath($xpath);
@@ -276,12 +397,12 @@ abstract class XMLMigration extends Migration {
       if (count($result) > 1) {
         $return = array();
         foreach ($result as $record) {
-          $return[] = (string)$record;
+          $return[] = (string) $record;
         }
         return $return;
       }
       else {
-        return (string)$result[0];
+        return (string) $result[0];
       }
     }
     else {
@@ -290,32 +411,70 @@ abstract class XMLMigration extends Migration {
   }
 }
 
-/* =========================================================================== */
-/*                            MultiItems Method                                */
-/* =========================================================================== */
+/* ========================================================================== */
+/*                            MultiItems Method                               */
+/* ========================================================================== */
 /**
  * Implementation of MigrateItems, for providing a list of IDs and for
  * retrieving a parsed XML document given an ID from this list.
  */
 class MigrateItemsXML extends MigrateItems {
   /**
-   * A URL pointing to an XML document containing the ids and data.
+   * An array with all urls to available xml files.
+   *
+   * @var array
+   */
+  protected $urls;
+
+  /**
+   * Define the current cursor over the urls array.
    *
    * @var string
    */
-  protected $xmlUrl;
+  protected $currentUrl;
 
   /**
-   * Stores the loaded XML document.
+   * An array of namespaces to explicitly register before Xpath queries.
+   *
+   * @var array
+   */
+  protected $namespaces;
+
+  /**
+   * Stores the loaded XML document from currentUrl.
    *
    * @var SimpleXMLElement
    */
-  protected $xml = FALSE;
+  protected $currentXml = FALSE;
 
   /**
-   * xpath identifying the element used for each item
+   * To find the right url depending on the id, we'll build a map in the form of
+   * an array('url1' => $ids, 'url2' => $ids, ...).
+   *
+   * @var array
+   */
+  protected $idsMap = NULL;
+
+  /**
+   * Stores the id list from all urls.
+   *
+   * @var array
+   */
+  protected $cacheIDs = NULL;
+
+  /**
+   * xpath identifying the element used for each item.
+   *
+   * @var string
    */
   protected $itemXpath;
+
+  /**
+   * Gets xpath identifying the element used for each item.
+   *
+   * @return string
+   *   xpath
+   */
   public function getItemXpath() {
     return $this->itemXpath;
   }
@@ -323,56 +482,98 @@ class MigrateItemsXML extends MigrateItems {
   /**
    * xpath identifying the subelement under itemXpath that holds the id for
    * each item.
+   *
+   * @var string
    */
   protected $itemIDXpath;
+
+  /**
+   * Getter for itemIDXpath.
+   *
+   * @return string
+   */
   public function getIDXpath() {
     return $this->itemIDXpath;
   }
 
-  public function __construct($xml_url, $item_xpath='item', $itemID_xpath='id') {
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($urls, $item_xpath = 'item', $item_id_xpath = 'id',
+                              array $namespaces = array()) {
     parent::__construct();
-    $this->xmlUrl = $xml_url;
+    if (!is_array($urls)) {
+      $urls = array($urls);
+    }
+    $this->urls = $urls;
     $this->itemXpath = $item_xpath;
-    $this->itemIDXpath = $itemID_xpath;
+    $this->itemIDXpath = $item_id_xpath;
+    $this->namespaces = $namespaces;
 
-    // Suppress errors during parsing, so we can pick them up after
+    // Suppress errors during parsing, so we can pick them up after.
     libxml_use_internal_errors(TRUE);
   }
 
   /**
-   * Our public face is the URL we're getting items from
+   * Explicitly register namespaces on an XML element.
    *
-   * @return string
+   * @param SimpleXMLElement $xml
+   *   A SimpleXMLElement to register the namespaces on.
    */
-  public function __toString() {
-    return 'url = ' . $this->xmlUrl . ' | item xpath = ' . $this->itemXpath .
-                                      ' | item ID xpath = ' . $this->itemIDXpath;
+  protected function registerNamespaces(SimpleXMLElement &$xml) {
+    foreach ($this->namespaces as $prefix => $namespace) {
+      $xml->registerXPathNamespace($prefix, $namespace);
+    }
   }
 
   /**
-   * Load and return the xml from the defined xmlUrl.
+   * Our public face is the URL list we're getting items from.
+   */
+  public function __toString() {
+    $urls = implode('</li><li>', $this->urls);
+    // Prepare a list of urls.
+    $output = '<b>urls</b> = <ul><li>' . $urls . '</li></ul>';
+    $output .= '<br />';
+    // Add selection rules to the end.
+    $output .= '<b>item xpath</b> = ' . $this->itemXpath . ' | ';
+    $output .= '<b>item ID xpath</b> = ' . $this->itemIDXpath;
+
+    return $output;
+  }
+
+  /**
+   * Load and return the xml from currentUrl.
+   *
    * @return SimpleXMLElement
+   *   SimpleXMLElement
    */
   public function &xml() {
-    if (!$this->xml && !empty($this->xmlUrl)) {
-      $this->xml = simplexml_load_file($this->xmlUrl);
-      if (!$this->xml) {
+    if (!empty($this->currentUrl)) {
+      $this->currentXml = simplexml_load_file($this->currentUrl);
+      if ($this->currentXml === FALSE) {
         Migration::displayMessage(t(
-          'Loading of !xmlUrl failed:',
-          array('!xmlUrl' => $this->xmlUrl)
+          'Loading of !currentUrl failed:',
+          array('!currentUrl' => $this->currentUrl)
         ));
         foreach (libxml_get_errors() as $error) {
           Migration::displayMessage(self::parseLibXMLError($error));
         }
       }
+      else {
+        $this->registerNamespaces($this->currentXml);
+      }
     }
-    return $this->xml;
+    return $this->currentXml;
   }
 
   /**
    * Parses a LibXMLError to a error message string.
+   *
    * @param LibXMLError $error
+   *   Error thrown by the XML
+   *
    * @return string
+   *   Error message
    */
   public static function parseLibXMLError(LibXMLError $error) {
     $error_code_name = 'Unknown Error';
@@ -380,15 +581,18 @@ class MigrateItemsXML extends MigrateItems {
       case LIBXML_ERR_WARNING:
         $error_code_name = t('Warning');
         break;
+
       case LIBXML_ERR_ERROR:
         $error_code_name = t('Error');
         break;
+
       case LIBXML_ERR_FATAL:
         $error_code_name = t('Fatal Error');
         break;
     }
+
     return t(
-       "!libxmlerrorcodename !libxmlerrorcode: !libxmlerrormessage\n" .
+      "!libxmlerrorcodename !libxmlerrorcode: !libxmlerrormessage\n" .
       "Line: !libxmlerrorline\n" .
       "Column: !libxmlerrorcolumn\n" .
       "File: !libxmlerrorfile",
@@ -404,17 +608,33 @@ class MigrateItemsXML extends MigrateItems {
   }
 
   /**
-   * Load the XML at the given URL, and return an array of the IDs found
-   * within it.
+   * Load ID's from URLs.
+   *
+   * Load ids from all urls and map them in idsMap depending on the currentURL.
+   *
+   * After ids were fetched from all urls store them in cacheIDs and return the
+   * whole list.
    *
    * @return array
+   *   mapped ID's
    */
   public function getIdList() {
-    migrate_instrument_start("Retrieve $this->xmlUrl");
-    $xml = $this->xml();
-    migrate_instrument_stop("Retrieve $this->xmlUrl");
-    if ($xml !== FALSE) {
-      return $this->getIDsFromXML($xml);
+    $ids = array();
+    foreach ($this->urls as $url) {
+      migrate_instrument_start("Retrieve $url");
+      // Make sure, to load new xml.
+      $this->currentUrl = $url;
+      $xml = $this->xml();
+      if ($xml !== FALSE) {
+        $url_ids = $this->getIdsFromXML($xml);
+        $this->idsMap[$url] = $url_ids;
+        $ids = array_merge($ids, $url_ids);
+      }
+      migrate_instrument_stop("Retrieve $url");
+    }
+    if (!empty($ids)) {
+      $this->cacheIDs = array_unique($ids);
+      return $this->cacheIDs;
     }
     return NULL;
   }
@@ -429,93 +649,103 @@ class MigrateItemsXML extends MigrateItems {
    * TRUE.
    *
    * @param SimpleXMLElement $xml
-   * @param boolean $refresh
+   *   SimpleXMLElement
    *
    * @return array
    */
-  protected $cache_ids = NULL;
-  protected function getIDsFromXML(SimpleXMLElement $xml, $refresh = FALSE) {
-    if ($refresh !== TRUE && $this->cache_ids != NULL) {
-      return $this->cache_ids;
-    }
-
-    $this->cache_ids = NULL;
+  protected function getIDsFromXML(SimpleXMLElement $xml) {
     $result = $xml->xpath($this->itemXpath);
 
     $ids = array();
     if ($result) {
       foreach ($result as $element) {
+        if (!isset($element)) {
+          continue;
+        }
+        // Namespaces must be reapplied after xpath().
+        $this->registerNamespaces($element);
         $id = $this->getItemID($element);
         if (!is_null($id)) {
-          $ids[] = (string)$id;
+          $ids[] = (string) $id;
         }
       }
     }
-    $this->cache_ids = array_unique($ids);
-    return $this->cache_ids;
+    return array_unique($ids);
   }
+
 
   /**
    * Return a count of all available IDs from the source listing.
+   *
+   * @return int
+   *   count of available IDs
    */
   public function computeCount() {
-    $count = 0;
-    $xml = $this->xml();
-    if ($xml !== FALSE) {
-      $ids = $this->getIDsFromXML($xml, TRUE);
-      $count = count($ids);
+    if (!isset($this->cacheIDs)) {
+      $this->getIdList();
     }
-    return $count;
+    return count($this->cacheIDs);
   }
 
   /**
-   * Load the XML at the given URL, and return an array of the Items found
-   * within it.
+   * Load the XML at the given URL, and return an array.
    *
    * @return array
+   *   array of the Items found within it.
    */
   public function getAllItems() {
     $xml = $this->xml();
     if ($xml !== FALSE) {
-      return $this->getItemsFromXML($xml);
+      return $this->getItemsFromXML($xml, TRUE);
     }
     return NULL;
   }
 
+  protected $currentItems = NULL;
+
   /**
+   * Parses out the items from a given XML object, and parse it's items.
+   *
    * Given an XML object, parse out the items for processing and return them as
    * an array. The location of the items in the XML are based on the item xpath
-   * set in the constructor.  Items are cached.  The list of items are returned
-   * from the cache except when this is the first call (ie, cache is NULL) OR
-   * the refresh parameter is TRUE.
+   * set in the constructor. Items from currentUrl are cached. The list of items
+   * returned from the cache except when this is the first call
+   * (ie, cache is NULL) OR the refresh parameter is TRUE.
    *
-   * Items are cached as an array of key=ID and value=stdclass object with
+   * Items are cached as an array of key=ID and value=stdClass object with
    * attribute xml containing the xml SimpleXMLElement object of the item.
    *
    * @param SimpleXMLElement $xml
-   * @param boolean $refresh
+   *   XML to parse
+   * @param bool $refresh
+   *   Indicates if necessary parse again the items or get them from cache.
    *
    * @return array
+   *   Array of obtained items.
    */
-  protected $cache_items = NULL;
-  public function getItemsFromXML(SimpleXMLElement $xml, $refresh=FALSE) {
-    if ($refresh !== FALSE && $this->cache_items != NULL) {
-      return $this->cache_items;
+  public function getItemsFromXML(SimpleXMLElement $xml, $refresh = FALSE) {
+    if ($refresh !== FALSE && $this->currentItems != NULL) {
+      return $this->currentItems;
     }
 
-    $this->cache_items = NULL;
+    $this->currentItems = NULL;
     $items = array();
     $result = $xml->xpath($this->itemXpath);
 
     if ($result) {
       foreach ($result as $item_xml) {
+        if (!isset($item_xml)) {
+          continue;
+        }
+        // Namespaces must be reapplied after xpath().
+        $this->registerNamespaces($item_xml);
         $id = $this->getItemID($item_xml);
-        $item = new stdclass;
+        $item = new stdclass();
         $item->xml = $item_xml;
         $items[$id] = $item;
       }
-      $this->cache_items = $items;
-      return $items;
+      $this->currentItems = $items;
+      return $this->currentItems;
     }
     else {
       return NULL;
@@ -525,49 +755,78 @@ class MigrateItemsXML extends MigrateItems {
   /**
    * Get the item ID from the itemXML based on itemIDXpath.
    *
+   * @param SimpleXMLElement $item_xml
+   *   Element from we get the ID
+   *
    * @return string
+   *   The item ID
    */
-  protected function getItemID($itemXML) {
-    return $this->getElementValue($itemXML, $this->itemIDXpath);
+  protected function getItemID($item_xml) {
+    return $this->getElementValue($item_xml, $this->itemIDXpath);
   }
 
   /**
    * Get an element from the itemXML based on an xpath.
    *
+   * @param SimpleXMLElement $item_xml
+   *   Element from we get the required value
+   * @param string $xpath
+   *   xpath used to locate the value
+   *
    * @return string
+   *   Extracted value
    */
-  protected function getElementValue($itemXML, $xpath) {
+  protected function getElementValue($item_xml, $xpath) {
     $value = NULL;
-    if ($itemXML) {
-      $result = $itemXML->xpath($xpath);
-      if ($result)
-        $value = (string)$result[0];
+    if ($item_xml->asXML()) {
+      $result = $item_xml->xpath($xpath);
+      if ($result) {
+        $value = (string) $result[0];
+      }
     }
     return $value;
   }
 
   /**
-   * Implementors are expected to return an object representing a source item.
-   * Items are cached as an array of key=ID and value=stdclass object with
-   * attribute xml containing the xml SimpleXMLElement object of the item.
+   * Implementers are expected to return an object representing a source item.
+   * Items from currentUrl are cached as an array of key=ID and value=stdClass
+   * object with attribute xml containing the xml SimpleXMLElement object of the
+   * item.
    *
    * @param mixed $id
    *
    * @return stdClass
    */
   public function getItem($id) {
-    // Make sure we actually have an ID
+    // Make sure we actually have an ID.
     if (empty($id)) {
       return NULL;
     }
-    $items = $this->getAllItems();
-    $item = $items[$id];
-    if ($item) {
+    // If $id is in currentXml return the right item immediately.
+    if (isset($this->currentItems) && isset($this->currentItems[$id])) {
+      $item = $this->currentItems[$id];
+    }
+    else {
+      // Otherwise find the right url and get the items from.
+      if ($this->idsMap === NULL) {
+        // Populate the map.
+        $this->getIdList();
+      }
+      foreach ($this->idsMap as $url => $ids) {
+        if (in_array($id, $ids)) {
+          $this->currentItems = NULL;
+          $this->currentUrl = $url;
+          $items = $this->getAllItems();
+          $item = $items[$id];
+        }
+      }
+    }
+    if (!empty($item)) {
       return $item;
     }
     else {
       $migration = Migration::currentMigration();
-      $message =  t('Loading of item XML for ID !id failed:', array('!id' => $id));
+      $message = t('Loading of item XML for ID !id failed:', array('!id' => $id));
       foreach (libxml_get_errors() as $error) {
         $message .= "\n" . $error->message;
       }
@@ -576,6 +835,18 @@ class MigrateItemsXML extends MigrateItems {
       libxml_clear_errors();
       return NULL;
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hash($row) {
+    // $row->xml is a SimpleXMLElement. Temporarily set it as an XML string
+    // to prevent parent::hash() failing when try to create the hash.
+    migrate_instrument_start('MigrateItemXML::hash');
+    $hash = md5(serialize($row->xml->asXML()));
+    migrate_instrument_stop('MigrateItemXML::hash');
+    return $hash;
   }
 }
 
@@ -642,7 +913,8 @@ class MigrateXMLReader implements Iterator {
   public $elementQuery;
 
   /**
-   * Xpath query string used to retrieve the primary key value from each element.
+   * Xpath query string used to retrieve the primary key value from each
+   * element.
    *
    * @var string
    */
@@ -673,26 +945,22 @@ class MigrateXMLReader implements Iterator {
   /**
    * Prepares our extensions to the XMLReader object.
    *
-   * @param $xml_url
-   *  URL of the XML file to be parsed.
-   * @param $element_query
-   *  Query string in a restricted xpath format, for selecting elements to be
-   *  returned by the interator. Supported syntax:
-   *  - The full path to the element must be specified; i.e., /file/article
-   *    rather than //article.
-   *  - The elements may be filtered by attribute value by appending
-   *    [@attribute="value"].
-   * @param $id_query
-   *  Query string to the unique identifier for an element, relative to the root
-   *  of that element. This supports the full xpath syntax.
+   * @param string $xml_url
+   *   URL of the XML file to be parsed.
+   * @param string $element_query
+   *   Query string in a restricted xpath format, for selecting elements to be
+   * @param string $id_query
+   *   Query string to the unique identifier for an element,
+   *   relative to the root of that element. This supports the full
+   *   xpath syntax.
    */
   public function __construct($xml_url, $element_query, $id_query) {
-    $this->reader = new XMLReader;
+    $this->reader = new XMLReader();
     $this->url = $xml_url;
     $this->elementQuery = $element_query;
     $this->idQuery = $id_query;
 
-    // Suppress errors during parsing, so we can pick them up after
+    // Suppress errors during parsing, so we can pick them up after.
     libxml_use_internal_errors(TRUE);
 
     // Parse the element query. First capture group is the element path, second
@@ -703,13 +971,15 @@ class MigrateXMLReader implements Iterator {
     $attribute_query = $matches[2][0];
     if ($attribute_query) {
       // Matches [@attribute="value"] (with either single- or double-quotes).
-      preg_match_all('|^\[@([^=]+)=[\'"](.*)[\'"]\]$|', $attribute_query, $matches);
+      preg_match_all('|^\[@([^=]+)=[\'"](.*)[\'"]\]$|', $attribute_query,
+                     $matches);
       $this->attributeName = $matches[1][0];
       $this->attributeValue = $matches[2][0];
     }
 
-    // If the element path contains any colons, it must be specifying namespaces,
-    // so we need to compare using the prefixed element name in next().
+    // If the element path contains any colons, it must be specifying
+    // namespaces, so we need to compare using the prefixed element
+    // name in next().
     if (strpos($element_path, ':')) {
       $this->prefixedName = TRUE;
     }
@@ -717,29 +987,27 @@ class MigrateXMLReader implements Iterator {
 
   /**
    * Implementation of Iterator::rewind().
-   *
-   * @return void
    */
   public function rewind() {
     // (Re)open the provided URL.
     $this->reader->close();
-    $status = $this->reader->open($this->url);
-    if (!$status) {
+    $status = $this->reader->open($this->url, NULL, LIBXML_NOWARNING);
+
+    // Reset our path tracker.
+    $this->currentPath = array();
+
+    if ($status) {
+      // Load the first matching element and its ID.
+      $this->next();
+    }
+    else {
       Migration::displayMessage(t('Could not open XML file !url',
                                 array('!url' => $this->url)));
     }
-
-    // Reset our path tracker
-    $this->currentPath = array();
-
-    // Load the first matching element and its ID.
-    $this->next();
   }
 
   /**
    * Implementation of Iterator::next().
-   *
-   * @return void
    */
   public function next() {
     migrate_instrument_start('MigrateXMLReader::next');
@@ -759,9 +1027,12 @@ class MigrateXMLReader implements Iterator {
           // We're positioned to the right element path - if filtering on an
           // attribute, check that as well before accepting this element.
           if (empty($this->attributeName) ||
-              ($this->reader->getAttribute($this->attributeName) == $this->attributeValue)) {
-            // We've found a matching element - get a SimpleXML object representing it.
-            // We must associate the DOMNode with a DOMDocument to be able to import
+            ($this->reader->getAttribute($this->attributeName) ==
+             $this->attributeValue)
+          ) {
+            // We've found a matching element - get a SimpleXML object
+            // representing it.We must associate the DOMNode with a
+            // DOMDocument to be able to import
             // it into SimpleXML.
             // Despite appearances, this is almost twice as fast as
             // simplexml_load_string($this->readOuterXML());
@@ -773,7 +1044,7 @@ class MigrateXMLReader implements Iterator {
               $this->currentElement = simplexml_import_dom($node);
               $idnode = $this->currentElement->xpath($this->idQuery);
               if (is_array($idnode)) {
-                $this->currentId = (string)reset($idnode);
+                $this->currentId = (string) reset($idnode);
               }
               else {
                 throw new Exception(t('Failure retrieving ID, xpath: !xpath',
@@ -796,7 +1067,7 @@ class MigrateXMLReader implements Iterator {
         }
       }
       elseif ($this->reader->nodeType == XMLREADER::END_ELEMENT) {
-        // Remove this element and any deeper ones from the current path
+        // Remove this element and any deeper ones from the current path.
         foreach ($this->currentPath as $depth => $name) {
           if ($depth >= $this->reader->depth) {
             unset($this->currentPath[$depth]);
@@ -811,6 +1082,7 @@ class MigrateXMLReader implements Iterator {
    * Implementation of Iterator::current().
    *
    * @return null|SimpleXMLElement
+   *   Current item
    */
   public function current() {
     return $this->currentElement;
@@ -820,6 +1092,7 @@ class MigrateXMLReader implements Iterator {
    * Implementation of Iterator::key().
    *
    * @return null|string
+   *   Current key
    */
   public function key() {
     return $this->currentId;
@@ -829,9 +1102,10 @@ class MigrateXMLReader implements Iterator {
    * Implementation of Iterator::valid().
    *
    * @return bool
+   *   Indicates if current element is valid
    */
   public function valid() {
-    return !empty($this->currentElement);
+    return $this->currentElement instanceof SimpleXMLElement;
   }
 }
 
@@ -841,11 +1115,19 @@ class MigrateXMLReader implements Iterator {
 class MigrateSourceXML extends MigrateSource {
 
   /**
-   * The MigrateXMLReader object serving as a cursor over the XML source.
-   *
-   * @var MigrateXMLReader
+   * @var $reader MigrateXMLReader
    */
   protected $reader;
+
+  /**
+   * The MigrateXMLReader object serving as a cursor over the XML source.
+   *
+   * @return MigrateXMLReader
+   *   MigrateXMLReader
+   */
+  public function getReader() {
+    return $this->reader;
+  }
 
   /**
    * The source URLs to load XML from
@@ -860,6 +1142,13 @@ class MigrateSourceXML extends MigrateSource {
    * @var int
    */
   protected $activeUrl = NULL;
+
+  /**
+   * An array of namespaces to explicitly register before Xpath queries.
+   *
+   * @var array
+   */
+  protected $namespaces;
 
   /**
    * Store the query string used to recognize elements being iterated
@@ -895,25 +1184,26 @@ class MigrateSourceXML extends MigrateSource {
   /**
    * Source constructor.
    *
-   * @param string or array $url
-   *  URL(s) of the XML source data.
+   * @param string|array $urls
+   *   URL(s) of the XML source data.
    * @param string $element_query
-   *  Query string used to recognize elements being iterated.
+   *   Query string used to recognize elements being iterated.
    * @param string $id_query
-   *  Xpath query string used to retrieve the primary key value from each element.
+   *   Xpath query string used to retrieve the primary key value
+   *   from each element.
    * @param array $fields
-   *  Optional - keys are field names, values are descriptions. Use to override
-   *  the default descriptions, or to add additional source fields which the
-   *  migration will add via other means (e.g., prepareRow()).
-   * @param boolean $options
-   *  Options applied to this source. In addition to the standard MigrateSource
-   *  options, we support:
-   *  - reader_class: The reader class to instantiate for traversing the XML -
-   *    defaults to MigrateXMLReader (any substitutions must be derived from
-   *    MigrateXMLReader).
+   *   Optional - keys are field names, values are descriptions. Use to override
+   *   the default descriptions, or to add additional source fields which the
+   *   migration will add via other means (e.g., prepareRow()).
+   * @param array $options
+   *   Options applied to this source. In addition to the standard MigrateSource
+   *   options, we support:
+   *   - reader_class: The reader class to instantiate for traversing the XML -
+   *     defaults to MigrateXMLReader (any substitutions must be derived from
+   *     MigrateXMLReader).
    */
   public function __construct($urls, $element_query, $id_query, array $fields = array(),
-      array $options = array()) {
+                              array $options = array(), array $namespaces = array()) {
     parent::__construct($options);
     if (empty($options['reader_class'])) {
       $reader_class = 'MigrateXMLReader';
@@ -932,16 +1222,31 @@ class MigrateSourceXML extends MigrateSource {
     $this->idQuery = $id_query;
     $this->readerClass = $reader_class;
     $this->fields = $fields;
+    $this->namespaces = $namespaces;
+  }
+
+  /**
+   * Explicitly register namespaces on an XML element.
+   *
+   * @param SimpleXMLElement $xml
+   *   A SimpleXMLElement to register the namespaces on.
+   */
+  protected function registerNamespaces(SimpleXMLElement &$xml) {
+    foreach ($this->namespaces as $prefix => $namespace) {
+      $xml->registerXPathNamespace($prefix, $namespace);
+    }
   }
 
   /**
    * Return a string representing the source query.
    *
    * @return string
+   *   source query
    */
   public function __toString() {
     // Clump the urls into a string
-    // This could cause a problem when using a lot of urls, may need to hash
+    // This could cause a problem when using
+    // a lot of urls, may need to hash.
     $urls = implode(', ', $this->sourceUrls);
     return 'urls = ' . $urls .
            ' | item xpath = ' . $this->elementQuery .
@@ -952,8 +1257,8 @@ class MigrateSourceXML extends MigrateSource {
    * Returns a list of fields available to be mapped from the source query.
    *
    * @return array
-   *  Keys: machine names of the fields (to be passed to addFieldMapping)
-   *  Values: Human-friendly descriptions of the fields.
+   *   keys: machine names of the fields (to be passed to addFieldMapping)
+   *   values: Human-friendly descriptions of the fields.
    */
   public function fields() {
     return $this->fields;
@@ -963,9 +1268,10 @@ class MigrateSourceXML extends MigrateSource {
    * Returns the active Url.
    *
    * @return string
+   *   active Url
    */
   public function activeUrl() {
-    if ($this->activeUrl) {
+    if (!is_null($this->activeUrl)) {
       return $this->sourceUrls[$this->activeUrl];
     }
   }
@@ -976,7 +1282,8 @@ class MigrateSourceXML extends MigrateSource {
   public function computeCount() {
     $count = 0;
     foreach ($this->sourceUrls as $url) {
-      $reader = new $this->readerClass($url, $this->elementQuery, $this->idQuery);
+      $reader = new $this->readerClass($url, $this->elementQuery,
+                                       $this->idQuery);
       foreach ($reader as $element) {
         $count++;
       }
@@ -1000,7 +1307,7 @@ class MigrateSourceXML extends MigrateSource {
    * Implementation of MigrationSource::getNextRow().
    *
    * @return stdClass
-   *  data for the next row from the XML source files
+   *   data for the next row from the XML source files
    */
   public function getNextRow() {
     migrate_instrument_start('MigrateSourceXML::next');
@@ -1009,24 +1316,27 @@ class MigrateSourceXML extends MigrateSource {
     $key_name = key($source_key);
     $row = NULL;
 
-    // The reader is now lazy loaded, so it may not be defined yet, need to test if set
+    // The reader is now lazy loaded, so it may
+    // not be defined yet, need to test if set.
     if (isset($this->reader)) {
-      // attempt to load the next row
+      // Attempt to load the next row.
       $this->reader->next();
     }
 
-    // Test the reader for a valid row
+    // Test the reader for a valid row.
     if (isset($this->reader) && $this->reader->valid()) {
-      $row = new stdClass;
+      $row = new stdClass();
       $row->$key_name = $this->reader->key();
       $row->xml = $this->reader->current();
+      $this->registerNamespaces($row->xml);
     }
     else {
-      // The current source is at the end, try to load the next source
+      // The current source is at the end, try to load the next source.
       if ($this->getNextSource()) {
-        $row = new stdClass;
+        $row = new stdClass();
         $row->$key_name = $this->reader->key();
         $row->xml = $this->reader->current();
+        $this->registerNamespaces($row->xml);
       }
     }
 
@@ -1035,31 +1345,33 @@ class MigrateSourceXML extends MigrateSource {
   }
 
   /**
-   * Advances the reader to the next source from source_urls
+   * Advances the reader to the next source from source_urls.
    *
    * @return bool
-   *  TRUE if a valid source was loaded
+   *   TRUE if a valid source was loaded
    */
   public function getNextSource() {
     migrate_instrument_start('MigrateSourceXML::nextSource');
 
-    // Return value
+    // Return value.
     $status = FALSE;
 
-    while ($this->activeUrl === NULL || (count($this->sourceUrls)-1) > $this->activeUrl) {
+    while ($this->activeUrl === NULL || (count($this->sourceUrls) - 1) > $this->activeUrl) {
       if (is_null($this->activeUrl)) {
         $this->activeUrl = 0;
       }
       else {
-        // Increment the activeUrl so we try to load the next source
+        // Increment the activeUrl so we try to load the next source.
         $this->activeUrl = $this->activeUrl + 1;
       }
 
-      $this->reader = new $this->readerClass($this->sourceUrls[$this->activeUrl], $this->elementQuery, $this->idQuery);
+      $this->reader = new $this->readerClass(
+        $this->sourceUrls[$this->activeUrl], $this->elementQuery,
+        $this->idQuery);
       $this->reader->rewind();
 
       if ($this->reader->valid()) {
-        // We have a valid source
+        // We have a valid source.
         $status = TRUE;
         break;
       }
@@ -1067,5 +1379,14 @@ class MigrateSourceXML extends MigrateSource {
 
     migrate_instrument_stop('MigrateSourceXML::nextSource');
     return $status;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function hash($row) {
+    // $row->xml is a SimpleXMLElement. Temporarily set it as an XML string
+    // to prevent parent::hash() failing when try to create the hash.
+    return parent::hash($row->xml->asXML());
   }
 }

--- a/docroot/sites/all/modules/migration/migrate/tests/import/options.test
+++ b/docroot/sites/all/modules/migration/migrate/tests/import/options.test
@@ -21,7 +21,7 @@ class MigrateImportOptionsTest extends DrupalWebTestCase {
     parent::setUp('migrate_example');
 
     // Make sure the migrations are registered.
-    migrate_get_module_apis();
+    migrate_static_registration();
   }
 
   function testItemLimitOption() {
@@ -40,17 +40,13 @@ class MigrateImportOptionsTest extends DrupalWebTestCase {
 
     $result = $migration->processImport($options);
 
-    $this->verbose(print_r($timers, 1));
     $successes = $migration->importedCount();
-    $this->verbose("Total successes: {$successes}");
     $assertion = format_plural($limit, 'The migration successfully processed 1 item.',
       'The migration successfully processed @count items.');
     $this->assertEqual($limit, $successes, $assertion);
 
     $prepare_row_count = $timers['BeerTermMigration prepareRow']['count'];
-    $this->verbose("prepareRow() count: {$prepare_row_count}");
     $processed = $migration->processedCount();
-    $this->verbose("Total processed count: {$processed}");
     $assertion = format_plural($processed, 'The migration executed processRow() on 1 item.',
       'The migration executed processRow() on @count items.');
     $this->assertEqual($prepare_row_count, $processed, $assertion);

--- a/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/comment.test
+++ b/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/comment.test
@@ -21,7 +21,7 @@ class MigrateCommentUnitTest extends DrupalWebTestCase {
     parent::setUp('taxonomy', 'image', 'comment', 'migrate', 'migrate_example');
 
     // Make sure the migrations are registered.
-    migrate_get_module_apis();
+    migrate_static_registration();
   }
 
   function testCommentImport() {

--- a/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/node.test
+++ b/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/node.test
@@ -21,7 +21,7 @@ class MigrateNodeUnitTest extends DrupalWebTestCase {
     parent::setUp('list', 'number', 'taxonomy', 'image', 'migrate', 'migrate_example');
 
     // Make sure the migrations are registered.
-    migrate_get_module_apis();
+    migrate_static_registration();
   }
 
   function testNodeImport() {

--- a/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/table.test
+++ b/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/table.test
@@ -21,7 +21,7 @@ class MigrateTableUnitTest extends DrupalWebTestCase {
     parent::setUp('migrate', 'migrate_example');
 
     // Make sure the migrations are registered.
-    migrate_get_module_apis();
+    migrate_static_registration();
   }
 
   function testTableImport() {

--- a/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/term.test
+++ b/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/term.test
@@ -21,7 +21,7 @@ class MigrateTaxonomyUnitTest extends DrupalWebTestCase {
     parent::setUp('taxonomy', 'migrate', 'migrate_example');
 
     // Make sure the migrations are registered.
-    migrate_get_module_apis();
+    migrate_static_registration();
   }
 
   function testTermImport() {

--- a/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/user.test
+++ b/docroot/sites/all/modules/migration/migrate/tests/plugins/destinations/user.test
@@ -24,7 +24,7 @@ class MigrateUserUnitTest extends DrupalWebTestCase {
     date_default_timezone_set('US/Mountain');
 
     // Make sure the migrations are registered.
-    migrate_get_module_apis();
+    migrate_static_registration();
   }
 
   function testUserImport() {
@@ -46,6 +46,14 @@ class MigrateUserUnitTest extends DrupalWebTestCase {
       $roles[$row->name] = $row->rid;
     }
     $this->assertEqual(count($roles), 2, t('Both roles imported'));
+
+    // Make sure update does not fail (regression test of
+    // http://drupal.org/node/1872446)
+    $migration->prepareUpdate();
+    $migration->processImport();
+    $num_messages = $migration->getMap()->messageCount();
+    $this->assertEqual($num_messages, 0, t('No messages generated'));
+
     $migration = Migration::getInstance('WineUser');
     $result = $migration->processImport();
     $this->assertEqual($result, Migration::RESULT_COMPLETED,
@@ -106,9 +114,10 @@ class MigrateUserUnitTest extends DrupalWebTestCase {
       1, t('Female gender migrated'));
     $this->assert(!isset($users['fonzie']->field_migrate_example_gender[LANGUAGE_NONE][0]['value']),
       t('Missing gender left unmigrated'));
+/* For some reason, this fails on d.o but not in local environments
     $this->assert(is_object($users['fonzie']->picture) &&
-                  $users['fonzie']->picture->filename == 'association-individual.png',
-      t('Picture migrated'));
+                  $users['fonzie']->picture->filename == '200',
+      t('Picture migrated'));*/
     $this->assertNotNull($users['fonzie']->roles[$roles['Taster']], t('Taster role'));
     $this->assertNotNull($users['fonzie']->roles[$roles['Vintner']], t('Vintner role'));
 

--- a/docroot/sites/all/modules/migration/migrate/tests/plugins/sources/oracle.test
+++ b/docroot/sites/all/modules/migration/migrate/tests/plugins/sources/oracle.test
@@ -31,7 +31,7 @@ class MigrateOracleUnitTest extends DrupalWebTestCase {
     }
 
     // Make sure the migrations are registered.
-    migrate_get_module_apis();
+    migrate_static_registration();
   }
 
   function testOracleImport() {

--- a/docroot/sites/all/modules/migration/migrate/tests/plugins/sources/xml.test
+++ b/docroot/sites/all/modules/migration/migrate/tests/plugins/sources/xml.test
@@ -21,7 +21,7 @@ class MigrateXMLUnitTest extends DrupalWebTestCase {
     parent::setUp('taxonomy', 'migrate', 'migrate_example');
 
     // Make sure the migrations are registered.
-    migrate_get_module_apis();
+    migrate_static_registration();
   }
 
   function testNodeImport() {
@@ -29,22 +29,51 @@ class MigrateXMLUnitTest extends DrupalWebTestCase {
     $result = $migration->processImport();
     $this->assertEqual($result, Migration::RESULT_COMPLETED,
       t('Region term import returned RESULT_COMPLETED'));
+
     $migration = Migration::getInstance('WineFileCopy');
     $result = $migration->processImport();
     $this->assertEqual($result, Migration::RESULT_COMPLETED,
       t('File import returned RESULT_COMPLETED'));
+
     $migration = Migration::getInstance('WineRole');
     $result = $migration->processImport();
     $this->assertEqual($result, Migration::RESULT_COMPLETED,
       t('Role import returned RESULT_COMPLETED'));
+
     $migration = Migration::getInstance('WineUser');
     $result = $migration->processImport();
     $this->assertEqual($result, Migration::RESULT_COMPLETED,
       t('User import returned RESULT_COMPLETED'));
-    $migration = Migration::getInstance('WineProducerXML');
-    $result = $migration->processImport();
+
+    $migration1 = Migration::getInstance('WineProducerXML');
+    $result = $migration1->processImport();
     $this->assertEqual($result, Migration::RESULT_COMPLETED,
-      t('Producer node import returned RESULT_COMPLETED'));
+      t('Producer node import 1 returned RESULT_COMPLETED'));
+
+    $migration2 = Migration::getInstance('WineProducerNamespaceXML');
+    $result = $migration2->processImport();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node import 2 returned RESULT_COMPLETED'));
+
+    $migration3 = Migration::getInstance('WineProducerMultiXML');
+    $result = $migration3->processImport();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node import 3 returned RESULT_COMPLETED'));
+
+    $migration4 = Migration::getInstance('WineProducerMultiNamespaceXML');
+    $result = $migration4->processImport();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node import 4 returned RESULT_COMPLETED'));
+
+    $migration5 = Migration::getInstance('WineProducerXMLPull');
+    $result = $migration5->processImport();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node import 5 returned RESULT_COMPLETED'));
+
+    $migration6 = Migration::getInstance('WineProducerNamespaceXMLPull');
+    $result = $migration6->processImport();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node import 6 returned RESULT_COMPLETED'));
 
     // Gather producer nodes, and their corresponding input data
     $rawnodes = node_load_multiple(FALSE, array('type' => 'migrate_example_producer'), TRUE);
@@ -54,7 +83,7 @@ class MigrateXMLUnitTest extends DrupalWebTestCase {
       $producer_nodes[$node->title] = $node;
     }
 
-    $this->assertEqual(count($producer_nodes), 1,
+    $this->assertEqual(count($producer_nodes), 10,
       t('Counts of producer nodes and input rows match'));
 
     // Test each base node field
@@ -81,10 +110,32 @@ class MigrateXMLUnitTest extends DrupalWebTestCase {
     $this->assertEqual($region[0]['tid'], $term->tid,
       t('region properly migrated'));
 
-    // Test rollback
-    $result = $migration->processRollback();
+    // Rollback producer migrations
+    $result = $migration1->processRollback();
     $this->assertEqual($result, Migration::RESULT_COMPLETED,
-      t('Producer node rollback returned RESULT_COMPLETED'));
+      t('Producer node rollback 1 returned RESULT_COMPLETED'));
+
+    $result = $migration2->processRollback();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node rollback 2 returned RESULT_COMPLETED'));
+
+    $result = $migration3->processRollback();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node rollback 3 returned RESULT_COMPLETED'));
+
+    $result = $migration4->processRollback();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node rollback 4 returned RESULT_COMPLETED'));
+
+    $result = $migration5->processRollback();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node rollback 5 returned RESULT_COMPLETED'));
+
+    $result = $migration6->processRollback();
+    $this->assertEqual($result, Migration::RESULT_COMPLETED,
+      t('Producer node rollback 6 returned RESULT_COMPLETED'));
+
+    // Test rollback
     $rawnodes = node_load_multiple(FALSE, array('type' => 'migrate_example_producer'), TRUE);
     $this->assertEqual(count($rawnodes), 0, t('All nodes deleted'));
     $count = db_select('migrate_map_wineproducerxml', 'map')


### PR DESCRIPTION
Upgraded the Migrate module from **7.x-2.5** to **7.x-2.8**.

This is a security release.

As this module was used during migration and not during the operation of the site, there should be no real need for significant testing.

However, some things have changed in the module's API, so if there is ever a need to use it again, it is worth checking in CHANGELOG.txt for required changes.

[ Fixes [#10253](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=751) ]