### PR TITLE
Check review date format before converting

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_review_date/fsa_review_date.module
+++ b/docroot/sites/all/modules/custom/fsa_review_date/fsa_review_date.module
@@ -289,7 +289,7 @@ function fsa_review_date_node_update($node) {
       ->fields(array(
           'nid' => $node->nid,
           'node_type' => $node->type,
-          'review_date' => strtotime($node->review_date),
+          'review_date' => !is_numeric($node->review_date) ? strtotime($node->review_date) : $node->review_date,
           'review_comment' => !empty($node->review_comment) ? $node->review_comment : NULL,
         ))
       ->execute();


### PR DESCRIPTION
When saving the review date, we were converting it to a timestamp, assuming that the input was a value from the form, which is a string.

However, in bulk operations where a node has a review date set, the review date value will already be a timestamp, so trying to convert it causes an error.

To fix it, we check first whether the value is numeric, and if so, we use it as is.

[ Fixes #10262 ]