### PR TITLE
Make National Archives dependent on specific version of redirect

### DIFF
--- a/docroot/sites/all/modules/custom/national_archives/national_archives.info
+++ b/docroot/sites/all/modules/custom/national_archives/national_archives.info
@@ -2,5 +2,5 @@ name = National Archives
 description = "Provides functionality for integrating with the National Archives"
 core = 7.x
 package = Archiving
-dependencies[] = redirect
+dependencies[] = redirect (>=7.x-1.0-rc3)
 configure = admin/config/search/nationalarchives/settings


### PR DESCRIPTION
The National Archives module is currently dependent on at least version **7.x-1.0-rc3** of the Redirect module due to a change in the API.

Previous versions of the module do not use the concept of a status for a redirect, which is used by the National Archives module.

@todo Make this module backwards compatible by deleting redirects if there is no ability to disable them.

[ Partial fix for #2014090110000295 ]