### PR TITLE
Add google charts javascript code

### DIFF
--- a/docroot/sites/all/themes/site_frontend/includes/external_libraries.inc
+++ b/docroot/sites/all/themes/site_frontend/includes/external_libraries.inc
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @file
+ * External libraries to be used with the theme
+ */
+
+/**
+ * Implements hook_external_libraries().
+ *
+ * This is a hook defined within the site_frontend theme and called using
+ * `omega_invoke_all()`.
+ *
+ * @return array
+ *   Array of external libraries to be added to the page
+ *
+ * @see site_frontend_get_external_libraries()
+ * @see site_frontend_preprocess_page()
+ *
+ * @todo Modify this functionality so that the external libraries can be
+ *   managed by administrators via the UI, using an Omega extension.
+ */
+function site_frontend_external_libraries() {
+  $libraries = array();
+
+  // Include the Google Charts library
+  // @see https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=779
+  $libraries['google_charts'] = array(
+    'name' => 'Google Charts',
+    'url' => '//www.google.com/jsapi',
+    'type' => 'js',
+    'options' => array(
+      'group' => JS_THEME,
+      'weight' => 20
+    ),
+  );
+
+  return $libraries;
+}

--- a/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
+++ b/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
@@ -42,6 +42,12 @@ function site_frontend_preprocess_page(&$variables) {
     }
   }
 
+  // Add the Google Charts JavaScript code
+  // @see https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=779
+  // @todo Provide a better way of doing this. Started working on an Omega
+  //       extension to enable editors to add external libraries such as JS and
+  //       CSS, but this needs more work.
+  drupal_add_js('//www.google.com/jsapi', array('group' => JS_THEME, 'weight' => 20));
 }
 
 /**

--- a/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
+++ b/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
@@ -42,12 +42,9 @@ function site_frontend_preprocess_page(&$variables) {
     }
   }
 
-  // Add the Google Charts JavaScript code
-  // @see https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=779
-  // @todo Provide a better way of doing this. Started working on an Omega
-  //       extension to enable editors to add external libraries such as JS and
-  //       CSS, but this needs more work.
-  drupal_add_js('//www.google.com/jsapi', array('group' => JS_THEME, 'weight' => 20));
+  // Add any external libraries - not to be hosted locally within Drupal.
+  site_frontend_get_external_libraries();
+
 }
 
 /**

--- a/docroot/sites/all/themes/site_frontend/template.php
+++ b/docroot/sites/all/themes/site_frontend/template.php
@@ -228,3 +228,35 @@ function site_frontend_css_alter(&$css) {
   }
 
 }
+
+
+/**
+ * Includes external libraries
+ *
+ * @see site_frontend_preprocess_page().
+ */
+function site_frontend_get_external_libraries() {
+  // Get the path to the theme
+  $theme_path = drupal_get_path('theme', 'site_frontend');
+  // Include the file that contains this theme's external library declarations
+  require_once "$theme_path/includes/external_libraries.inc";
+  // Invoke hook_external_libraries().
+  $libraries = omega_invoke_all('external_libraries');
+  // Set some defaults
+  $library_defaults = array(
+    'type' => 'js',
+    'options' => array(),
+  );
+  // Add each library.
+  foreach ($libraries as $library) {
+    $library += $library_defaults;
+    switch ($library['type']) {
+      case 'js':
+        drupal_add_js($library['url'], $library['options']);
+        break;
+      case 'css':
+        // @todo Flesh this out for adding external CSS libraries.
+        break;
+    }
+  }
+}


### PR DESCRIPTION
Added the JavaScript file requested by Atif to enable Google Charts.

The external library is included via a new hook `hook_external_libraries()`, which is called via a new function in the site_frontend theme's template.php file.

Links to the JavaScript files are then added via an implementation of `drupal_add_js()` called in `site_frontend_preprocess_page()`

@todo Add ability to administer external libraries via the admin UI
@todo Add ability to determine the pages on which the libraries are included

[ Fixes [#10281](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=779) ]