### PR TITLE
Develop: Create SiteImprove module

### DIFF
--- a/docroot/sites/all/modules/custom/siteimprove/siteimprove.admin.inc
+++ b/docroot/sites/all/modules/custom/siteimprove/siteimprove.admin.inc
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @file
+ * Administrative functions for the SiteImprove Drupal module.
+ */
+
+/**
+ * Form builder: SiteImprove admin form
+ */
+function siteimprove_admin_form($form, &$form_state) {
+  
+  $form['siteimprove_account_code'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Account code'),
+    '#size' => 8,
+    '#description' => t('Your SiteImprove account code. You can obtain this by completing the <a href="@form_url">online form</a>.', array('@form_url' => 'http://go.siteimprove.com/analytics-tracking-code')),
+    '#default_value' => variable_get('siteimprove_account_code'),
+  );
+  
+  $form['siteimprove_track_admin'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Track admin pages'),
+    '#description' => t('Determines whether the analytics tracking code appears on admin pages.'),
+    '#default_value' => variable_get('siteimprove_track_admin', FALSE),
+  );
+  
+  $form['cms_deeplink'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('CMS deeplinking options'),
+    '#description' => t('CMS deeplinking creates a link from the Siteimprove tool to the corresponding editing page in Drupal. Drupal can add special meta elements to the page to make this easier.'),
+  );
+  
+  $form['cms_deeplink']['siteimprove_meta_pageid'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Add pageID meta tag'),
+    '#default_value' => variable_get('siteimprove_meta_pageid', FALSE),
+  );
+  
+  $form['cms_deeplink']['siteimprove_meta_editing_page'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Add editing link meta tag'),
+    '#default_value' => variable_get('siteimprove_meta_editing_page', FALSE),
+  );
+  
+  return system_settings_form($form);
+}

--- a/docroot/sites/all/modules/custom/siteimprove/siteimprove.api.php
+++ b/docroot/sites/all/modules/custom/siteimprove/siteimprove.api.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the SiteImprove module.
+ */
+
+/**
+ * Alter the editing page options.
+ *
+ * Using this hook, you can specify an alternative URL for the SiteImprove
+ * CMS edit URL.
+ *
+ * @param array $editing_page_options
+ *   An array of options suitable for passing to the $options parameter of the
+ *   url() function.
+ */
+function siteimprove_siteimprove_editing_page_options_alter(&$editing_page_options) {
+  // Use an alternative base URL for editing.
+  $editing_page_options['base_url'] = 'https://admin.test.com';
+}

--- a/docroot/sites/all/modules/custom/siteimprove/siteimprove.info
+++ b/docroot/sites/all/modules/custom/siteimprove/siteimprove.info
@@ -1,0 +1,5 @@
+name = SiteImprove
+description = "Provides integration with the SiteImprove web quality assurance service."
+core = 7.x
+package = Statistics
+configure = admin/config/services/siteimprove

--- a/docroot/sites/all/modules/custom/siteimprove/siteimprove.install
+++ b/docroot/sites/all/modules/custom/siteimprove/siteimprove.install
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for the SiteImprove Drupal module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function siteimprove_install() {
+}
+
+
+/**
+ * Implements hook_uninstall().
+ */
+function siteimprove_unintsall() {
+  // Delete variables
+  variable_del('siteimprove_track_admin');
+  variable_del('siteimprove_account_code');
+  variable_del('siteimprove_meta_editing_page');
+  variable_del('siteimprove_meta_pageid');
+}

--- a/docroot/sites/all/modules/custom/siteimprove/siteimprove.module
+++ b/docroot/sites/all/modules/custom/siteimprove/siteimprove.module
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @file
+ * Module code for the SiteImprove Drupal module
+ */
+
+
+/**
+ * Implements hook_permission().
+ */
+function siteimprove_permission() {
+  return array(
+    'administer siteimprove' => array(
+      'title' => t('Administer SiteImprove settings'),
+      'description' => t('Allows users to configure settings for the SiteImprove quality assurance module'),
+    ),
+  );
+}
+
+
+/**
+ * Implements hook_menu().
+ *
+ * @see siteimprove_admin_form().
+ */
+function siteimprove_menu() {
+  $items = array();
+
+  // Administration link for the module.
+  $items['admin/config/services/siteimprove'] = array(
+    'title' => t('SiteImprove'),
+    'description' => t('Configure settings for the SiteImprove quality assurance module'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('siteimprove_admin_form'),
+    'access arguments' => array('administer siteimprove'),
+    'file' => 'siteimprove.admin.inc',
+  );
+
+  return $items;
+}
+
+
+/**
+ * Implements hook_theme().
+ */
+function siteimprove_theme() {
+  return array(
+    // Theme implementation for the SiteImprove JavaScript
+    'siteimprove_analytics_javascript' => array(
+      'template' => 'theme/siteimprove-analytics-javascript',
+      'variables' => array(
+        'siteimprove_account_code' => variable_get('siteimprove_account_code'),
+      ),
+    ),
+  );
+}
+
+
+/**
+ * Implements hook_page_alter().
+ * 
+ * @see theme/siteimprove-analytics-javascript.tpl.php
+ */
+function siteimprove_page_alter(&$page) {
+  // Get the SiteImprove account code
+  $account_code = variable_get('siteimprove_account_code');
+  // If we don't have an account code, don't render the script.
+  if (empty($account_code)) {
+    return;
+  }
+  // Get the page path
+  $path = current_path();
+  // If we're on an admin page and the siteimprove_track_admin variable is not
+  // set, then exit now.
+  if (path_is_admin($path) && !variable_get('siteimprove_track_admin')) {
+    return;
+  }
+  // Create a render array for the script
+  $script_element = array(
+    '#theme' => 'siteimprove_analytics_javascript',
+    '#siteimprove_account_code' => $account_code,
+  );
+  // Render the script into code.
+  $script = drupal_render($script_element);
+  // Add the JavaScript file to the site footer.
+  drupal_add_js($script, array('scope' => 'footer', 'type' => 'inline'));
+}
+
+
+/**
+ * Implements hook_node_view().
+ *
+ * We use this to add the SiteImprove meta tags that facilitate CMS deeplinking
+ *
+ * @see http://support.siteimprove.com/hc/en-gb/articles/206343443-What-is-CMS-Deeplinking-and-How-do-I-enable-it-
+ */
+function siteimprove_node_view($node, $view_mode, $langcode) {
+
+  // Act only if the node is being viewed in full.
+  if ($view_mode != 'full' || empty($node->nid)) {
+    return;
+  }
+
+  // Get the Node ID (nid).
+  $nid = $node->nid;
+
+  // Add the pageID meta tag - if required.
+  if (variable_get('siteimprove_meta_pageid', FALSE)) {
+    $page_id = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'name' => 'pageID',
+        'content' => $node->nid,
+      ),
+    );
+    drupal_add_html_head($page_id, 'siteimprove_page_id');
+  }
+
+  // Add the editingPage meta tag - if required.
+  if (variable_get('siteimprove_meta_editing_page', FALSE)) {
+    $editing_page_options = array(
+      'absolute' => TRUE,
+      'https' => TRUE,
+    );
+
+    // Allow modules to alter the editing page options
+    drupal_alter('siteimprove_editing_page_options', $editing_page_options);
+
+    $editing_page = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'name' => 'editingPage',
+        'content' => url("node/$nid/edit", $editing_page_options),
+      ),
+    );
+
+    drupal_add_html_head($editing_page, 'siteimprove_editing_page');
+  }
+}

--- a/docroot/sites/all/modules/custom/siteimprove/theme/siteimprove-analytics-javascript.tpl.php
+++ b/docroot/sites/all/modules/custom/siteimprove/theme/siteimprove-analytics-javascript.tpl.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Default theme implementation for SiteImprove analytics JavaScript.
+ *
+ * It would be nicer to add this as a standard <script></script> element with
+ * the async="async" attribute, but Drupal doesn't currently support this
+ * natively, and although a workaround is possible, it's probably safer to wait
+ * until it gains proper Drupal support.
+ *
+ * @todo Once Drupal supports the async attribute on <script> elements, modify
+ *   the way this script is added to the page.
+ * 
+ * Variables:
+ *   $siteimprove_account_code - The SiteImprove account code, stored in a
+ *     Drupal variable.
+ */
+?>
+<?php if (!empty($siteimprove_account_code)): ?>
+  (function() {
+    var sz = document.createElement('script'); sz.type = 'text/javascript'; sz.async = true;
+    sz.src = '//siteimproveanalytics.com/js/siteanalyze_<?php print render($siteimprove_account_code); ?>.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(sz, s);
+  })();
+<?php endif; ?>


### PR DESCRIPTION
Created a basic module to support integration with SiteImprove.

Currently does the following:

* Adds the SiteImprove JavaScript analytics code
* Adds meta tags for CMS deeplinking

Enable the module
-------------------------
Once the code is deployed, the module will need to be enabled, either through the Drupal admin UI or via Drush: `drush en siteimprove --y`

Once that's done, the caches will need to be cleared: `drush cc all`

Add the SiteImprove account code
----------------------------------------------
Once the module is enabled, the account code will need to be entered via the Drupal admin interface. This is under Admin > Configuration > Web services > Siteimprove

[ Partial fix for [#10286](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=787) and [#10289](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=784) ]