### PR TITLE
Add implementation of hook_siteimprove_editing_page_options_alter()

### DIFF
--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -398,3 +398,14 @@ function local_field_group_pre_render_alter(&$element, $group, & $form) {
   // around the classes.
   $element['#prefix'] = '<div class="' . $group->classes . '">';
 }
+
+
+/**
+ * Implements hook_siteimprove_editing_page_options_alter().
+ *
+ * This is used to ensure that the editing page URL rendered in the meta tag
+ * for SiteImprove uses the admin domain, rather than the front-end domain.
+ */
+function local_siteimprove_editing_page_options_alter(&$editing_page_options) {
+  $editing_page_options['base_url'] = local_get_site_domain(TRUE, 'https');
+}


### PR DESCRIPTION
Added an implementation of `hook_siteimprove_editing_page_options_alter()` in the local module.

This ensures that if the SiteImprove editing page URL meta tag is present it uses the proper admin URL, not the front-end domain.

[ Partial fix for #10289 ]