### PR TITLE
Create FSA filename validation module

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.admin.inc
@@ -6,9 +6,6 @@
 
 /**
  * Form builder: filename validation configuration form
- * @param type $form
- * @param type $form_state
- * @return type
  */
 function fsa_filename_validation_configuration_form($form, &$form_state) {
 
@@ -18,18 +15,17 @@ function fsa_filename_validation_configuration_form($form, &$form_state) {
     '#suffix' => '</p>',
   );
 
-  $validators = module_invoke_all('filename_validators');
-  $validator_defaults = array(
-    'type' => 'regex',
-  );
+  // Get the validators
+  $validators = _fsa_filename_validation_get_validators();
 
-
+  // Fieldset for enabled validators
   $form['enabled_validators'] = array(
     '#type' => 'fieldset',
     '#title' => t('Enabled validators'),
     '#description' => t('There are no currently active validators.'),
   );
 
+  // Fieldset for disabled validators
   $form['disabled_validators'] = array(
     '#type' => 'fieldset',
     '#title' => t('Disabled validators'),
@@ -40,7 +36,7 @@ function fsa_filename_validation_configuration_form($form, &$form_state) {
 
   foreach ($validators as $key => $validator) {
 
-    $enabled = variable_get("filename_validator_${key}_enabled", FALSE);
+    $enabled = $validator['enabled'];
     $container = $enabled ? 'enabled_validators' : 'disabled_validators';
 
     if ($enabled) {

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.admin.inc
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @file
+ * Administration functions for the FSA filename validation module
+ */
+
+/**
+ * Form builder: filename validation configuration form
+ * @param type $form
+ * @param type $form_state
+ * @return type
+ */
+function fsa_filename_validation_configuration_form($form, &$form_state) {
+
+  $form['intro'] = array(
+    '#prefix' => '<p>',
+    '#markup' => t('Filename validators allow you to control the names of files that can be uploaded to Drupal.'),
+    '#suffix' => '</p>',
+  );
+
+  $validators = module_invoke_all('filename_validators');
+  $validator_defaults = array(
+    'type' => 'regex',
+  );
+
+
+  $form['enabled_validators'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Enabled validators'),
+    '#description' => t('There are no currently active validators.'),
+  );
+
+  $form['disabled_validators'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Disabled validators'),
+    '#description' => t('These validators are currently disabled.'),
+  );
+
+  $active_validators = array();
+
+  foreach ($validators as $key => $validator) {
+
+    $enabled = variable_get("filename_validator_${key}_enabled", FALSE);
+    $container = $enabled ? 'enabled_validators' : 'disabled_validators';
+
+    if ($enabled) {
+      $active_validators[] = $key;
+    }
+
+    $form[$container]["${key}_container"] = array(
+      '#type' => 'fieldset',
+      '#title' => $validator['name'],
+      '#description' => !empty($validator['description']) ? $validator['description'] : NULL,
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+    );
+
+    $form[$container]["${key}_container"]["filename_validator_${key}_enabled"] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Enabled'),
+      '#default_value' => $enabled,
+    );
+
+    if (!empty($validator['settings_form'])) {
+      foreach ($validator['settings_form'] as $element => $settings) {
+        $settings['#default_value'] = variable_get("filename_validator_${key}_$element", !empty($settings['#default_value']) ? $settings['#default_value'] : NULL);
+        $form[$container]["${key}_container"]["filename_validator_${key}_$element"] = $settings;
+      }
+    }
+
+
+  }
+
+  if (count($active_validators) > 0) {
+    $form['enabled_validators']['#description'] = format_plural(count($active_validators), 'The following validator is currently active.', 'The following validators are currently active.');
+  }
+
+  if (count($active_validators) == count($validators)) {
+    $form['disabled_validators']['#description'] = t('There are no disabled validators.');
+  }
+  else {
+    $form['disabled_validators']['#description'] = format_plural(count($validators) - count($active_validators), 'This validator is currently disabled.', 'These validators are currently disabled.');
+  }
+
+  return system_settings_form($form);
+}

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.api.php
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.api.php
@@ -39,6 +39,11 @@
  *   - error_message_callback: A function for generating custom error messages
  *   - error_message_arguments: An array of arguments to be passed to the
  *     custom error message function
+ *   - help: Help text to tell users uploading files about the validation
+ *     conditions that apply.
+ *   - help_callback: A function for generating help text
+ *   - help_arguments: An array of arguments to be passed to the help_callback
+ *     function
  */
 function hook_filename_validators() {
   $validators = array();

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.api.php
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.api.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the FSA Filename validation module.
+ */
+
+/**
+ * Provide additional filename validators
+ *
+ * By implementing this hook, you can provide additional validators to be used
+ * when uploading files to Drupal.
+ *
+ * Your implementation should return an associative array of validators, each of
+ * which is itself an array as described below.
+ *
+ * @return array
+ *   Array of validators. Each element is itself an array with the following
+ *   elements:
+ *   - name: The translated human-readable name of the validator. This is
+ *     displayed on the administration page
+ *   - description: (optional) A description of what the validator does
+ *   - pattern: (optional) A regex pattern to be used against the filename. This
+ *     is mandatory for validators of type 'regex', which is the default.
+ *   - error_message: The translated error message to display to users. This is
+ *     mandatory unless 'error_message_callback' is provided.
+ *   - replacement: Not currently in use
+ *   - type: The type of validator. Currently recognised types are 'regex',
+ *     'maxlength', 'lowercase', 'custom'.
+ *   - autocorrect: Not currently in use
+ *   - settings_form: Used to add a settings form for use in the administration
+ *     interface. This should be a standard Drupal Form API render array.
+ *   - callback: A custom callback function. Should be used only with validators
+ *     of type 'custom'.
+ *   - arguments: An array of arguments to be passed to the callback function.
+ *     These can be standard variables or settings for the validator. To include
+ *     a user-specified setting, prefix it with 'setting:' eg
+ *     'setting:characters'
+ *   - error_message_callback: A function for generating custom error messages
+ *   - error_message_arguments: An array of arguments to be passed to the
+ *     custom error message function
+ */
+function hook_filename_validators() {
+  $validators = array();
+
+  $validators['no_whitespace'] = array(
+    'name' => t('No whitespace'),
+    'description' => t('Will not allow filenames that contain white space such as spaces, tabs and new lines.'),
+    'pattern' => "/\s/",
+    'error_message' => t('The filename should not contain any spaces.'),
+    'replacement' => '-',
+    'autocorrect' => TRUE,
+  );
+
+  $validators['alphanumeric'] = array(
+    'name' => t('Alphanumeric characters only'),
+    'description' => t('Allows only letters, numbers and the full stop (dot) character. Be aware that this validator will not allow filenames with spaces.'),
+    'pattern' => "/[^a-z|A-Z|0-9|\.]/",
+    'error_message' => t('The filename should contain only alphanumeric characters'),
+  );
+
+  $validators['max_length'] = array(
+    'name' => t('Maximum filename length'),
+    'description' => t('Restricts filenames to a specified maximum length.'),
+    'type' => 'maxlength',
+    'maxlength' => 10,
+    'error_message' => t('The filename should contain no more than '),
+    'settings_form' => array(
+      'max_length' => array(
+        '#type' => 'textfield',
+        '#size' => 3,
+        '#title' => t('Maximum number of characters allowed'),
+        '#default_value' => 10,
+      ),
+    ),
+  );
+
+  $validators['lowercase'] = array(
+    'name' => t('All lowercase'),
+    'description' => t('Allows only lowercase letters in filenames.'),
+    'type' => 'lowercase',
+    'error_message' => t('Filenames should be all lowercase.'),
+  );
+
+  $validators['exclude_characters'] = array(
+    'name' => t('Exclude these characters'),
+    'description' => t('Allows specified characters to be excluded from filenames.'),
+    'type' => 'custom',
+    'callback' => '_fsa_filename_validation_exclude_characters',
+    'arguments' => array("settings:excluded_characters"),
+    'error_message' => t('Sorry, the filename contains invalid characters'),
+    'error_message_callback' => '_fsa_filename_validation_exclude_characters_error',
+    'error_message_arguments' => array("settings:excluded_characters"),
+    'settings_form' => array(
+      'excluded_characters' => array(
+        '#type' => 'textfield',
+        '#title' => t('Characters to be excluded'),
+        '#description' => t('Enter a list of characters to exclude. Leave one space between each character.')
+      ),
+    ),
+  );
+
+  return $validators;
+}

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.api.php
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.api.php
@@ -107,3 +107,73 @@ function hook_filename_validators() {
 
   return $validators;
 }
+
+
+/**
+ * Alter the array of validators
+ *
+ * This hook is called by _fsa_filename_validation_get_validators() the first
+ * time it is run during any page request. It is passed the full validators
+ * array, which has already been populated with any settings saved in the
+ * database.
+ *
+ * @param array $validators
+ *   Associative array of filename validators, passed by reference. Validator
+ *   settings have already been retrieved from the database, as have validator
+ *   statuses, so this hook could be used to turn validators on or off if
+ *   required, overriding user settings.
+ *
+ */
+function hook_filename_validators_alter(&$validators) {
+  // Override help text
+  if (!empty($validators['no_whitespace'])) {
+    $validators['no_whitespace']['help'] = t('Filenames cannot contain any whitespace characters.');
+  }
+  // Turn off a validator
+  if (!empty($validators['exclude_characters'])) {
+    $validators['exclude_characters']['enabled'] = FALSE;
+  }
+}
+
+
+/**
+ * Alter the help text for a given validator
+ *
+ * Help text for a validator is displayed beneath the file upload form element.
+ * It explains validation criteria to the user before they attempt to upload a
+ * file.
+ *
+ * Using this hook, you can alter the help text for a specified validator.
+ *
+ * @param string $help_text
+ *   The current help text assigned to the validator (passed by reference).
+ * @param string $key
+ *   The array key of the specified validator. Using
+ *   _fsa_filename_validation_get_validator($key), you can retrieve the full
+ *   validator properties.
+ */
+function hook_filename_validation_help_alter(&$help_text, $key) {
+  // Load the validator details.
+  $validator = _fsa_filename_validation_get_validator($key);
+  switch ($key) {
+    case 'max_length':
+      $maxlength = !empty($validator['settings']['max_length']) ? $validator['settings']['max_length'] : $validator['maxlength'];
+      $help_text = t('Your filename cannot have more than @maxlength characters, including the extension.', array('@maxlength' => $maxlength));
+      break;
+  }
+}
+
+
+/**
+ * Alter error messages displayed when filename validation fails.
+ *
+ * @param string $error_message
+ *   The existing error message after all othe processing has taken place
+ * @param string $key
+ *   The key of the validator that defines the error message
+ */
+function hook_filename_validation_error_alter(&$error_message, $key) {
+  if ($key == 'alphanumeric') {
+    $error_message .= '!';
+  }
+}

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.info
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.info
@@ -1,0 +1,5 @@
+name = FSA File validation
+description = "Adds validation functions to files being uploaded to Drupal"
+core = 7.x
+package = FSA Custom
+configure = admin/config/media/file-settings/validation

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.module
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.module
@@ -73,6 +73,72 @@ function fsa_filename_validation_menu_alter(&$items) {
 
 
 /**
+ * Implements hook_theme_registry_alter().
+ */
+function fsa_filename_validation_theme_registry_alter(&$theme_registry) {
+  if (empty($theme_registry['file_upload_help'])) {
+    return;
+  }
+ $theme_registry['file_upload_help']['function'] = 'fsa_filename_validation_theme_file_upload_help';
+}
+
+
+/**
+ * Theme function - override for theme_file_upload_help().
+ */
+function fsa_filename_validation_theme_file_upload_help($variables) {
+
+  // Call the default theme implementation to get the standard help text. We'll
+  // add our custom help text after it.
+  $help = theme_file_upload_help($variables);
+
+  // Get the enabled validators
+  $enabled_validators = _fsa_filename_validation_enabled_validators();
+
+  // Now we'll add any custom help text from our validators.
+  $help_messages = array();
+
+  // Set validator defaults
+  $defaults = array('type' => 'regex');
+
+  // Loop through the enabled validators
+  foreach ($enabled_validators as $key => $validator) {
+    $validator += $defaults;
+
+    // Special treatment for some validator types.
+    switch ($validator['type']) {
+      case 'maxlength':
+        $maxlength = variable_get("filename_validator_${key}_max_length", $validator['maxlength']);
+        $validator['help'] = t('Filenames are limited to @maxlength characters.', array('@maxlength' => $maxlength));
+        break;
+    }
+
+    // If we have a help callback, use it.
+    if (!empty($validator['help_callback']) && function_exists($validator['help_callback'])) {
+      $arguments = !empty($validator['help_arguments']) ? $validator['help_arguments'] : array();
+      foreach ($arguments as $index => $argument) {
+        if (strpos($argument, 'settings:') !== FALSE) {
+          $arguments[$index] = variable_get("filename_validator_${key}_" . str_replace('settings:', '', $argument));
+        }
+      }
+      $validator['help'] = call_user_func_array($validator['help_callback'], $arguments);
+    }
+
+    // Add the help message to our message array.
+    if (!empty($validator['help'])) {
+      $help_messages[] = $validator['help'];
+    }
+  }
+
+  // Join the message array with line breaks
+  $help .= '<br>' . implode('<br>', $help_messages);
+
+  // Return the help messages
+  return $help;
+}
+
+
+/**
  * Implements hook_file_validate().
  *
  * This is where the actual filename validation takes place.
@@ -220,6 +286,12 @@ function fsa_filename_validation_file_validate($file) {
  *   - error_message_callback: A function for generating custom error messages
  *   - error_message_arguments: An array of arguments to be passed to the
  *     custom error message function
+ *   - help: Help text to tell users uploading files about the validation
+ *     conditions that apply. Note that this element is not required for
+ *     validators of type 'maxlength' as this is created dynamically.
+ *   - help_callback: A function for generating help text
+ *   - help_arguments: An array of arguments to be passed to the help_callback
+ *     function
  */
 function fsa_filename_validation_filename_validators() {
   $validators = array();
@@ -231,6 +303,7 @@ function fsa_filename_validation_filename_validators() {
     'error_message' => t('The filename should not contain any spaces.'),
     'replacement' => '-',
     'autocorrect' => TRUE,
+    'help' => t('Filenames cannot contain spaces or tabs.'),
   );
 
   $validators['alphanumeric'] = array(
@@ -238,6 +311,7 @@ function fsa_filename_validation_filename_validators() {
     'description' => t('Allows only letters, numbers and the full stop (dot) character. Be aware that this validator will not allow filenames with spaces.'),
     'pattern' => "/[^a-z|A-Z|0-9|\.]/",
     'error_message' => t('The filename should contain only alphanumeric characters'),
+    'help' => t('Filenames can contain only letters, numbers and full stops.'),
   );
 
   $validators['max_length'] = array(
@@ -259,6 +333,7 @@ function fsa_filename_validation_filename_validators() {
   $validators['lowercase'] = array(
     'name' => t('All lowercase'),
     'description' => t('Allows only lowercase letters in filenames.'),
+    'help' => t('Filenames should be all in lower case.'),
     'type' => 'lowercase',
     'error_message' => t('Filenames should be all lowercase.'),
   );
@@ -272,6 +347,8 @@ function fsa_filename_validation_filename_validators() {
     'error_message' => t('Sorry, the filename contains invalid characters'),
     'error_message_callback' => '_fsa_filename_validation_exclude_characters_error',
     'error_message_arguments' => array("settings:excluded_characters"),
+    'help_callback' => '_fsa_filename_validation_exclude_characters_help',
+    'help_arguments' => array("settings:excluded_characters"),
     'settings_form' => array(
       'excluded_characters' => array(
         '#type' => 'textfield',
@@ -344,6 +421,13 @@ function _fsa_filename_validation_exclude_characters_error($characters) {
   return t('Sorry, the filename cannot contain any of these characters %characters', array('%characters' => $characters));
 }
 
+/**
+ * Help text callback for excluded characters validator
+ */
+function _fsa_filename_validation_exclude_characters_help($characters) {
+  return t('Filenames should not contain any of these characters %characters.', array('%characters' => $characters));
+}
+
 
 /**
  * Validation callback function - all lowercase
@@ -359,4 +443,24 @@ function _fsa_filename_validation_exclude_characters_error($characters) {
  */
 function _fsa_filename_validation_lowercase($filename) {
   return $filename == strtolower($filename);
+}
+
+
+/**
+ * Helper function: returns an array of enabled validators
+ */
+function _fsa_filename_validation_enabled_validators() {
+  // An array to hold the enabled validators
+  $enabled_validators = array();
+
+  // Invoke hook_filename_validators().
+  $validators = module_invoke_all('filename_validators');
+
+  foreach ($validators as $key => $validator) {
+    // Determine whether the validator is currently enabled.
+    if ($enabled = variable_get("filename_validator_${key}_enabled", FALSE)) {
+      $enabled_validators[$key] = $validator;
+    }
+  }
+  return $enabled_validators;
 }

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.module
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.module
@@ -44,8 +44,8 @@ function fsa_filename_validation_menu() {
     $admin_menu_link = 'admin/config/media/file-settings/validation';
   }
 
-  // Administration menu link. This is where the validators are turned on and
-  // off.
+  // Administration menu link. This is where the validators are enabled,
+  // disabled and configured.
   $items[$admin_menu_link] = array(
     'title' => t('Filename validation settings'),
     'description' => t('Administer filename validation settings'),
@@ -79,12 +79,25 @@ function fsa_filename_validation_theme_registry_alter(&$theme_registry) {
   if (empty($theme_registry['file_upload_help'])) {
     return;
   }
- $theme_registry['file_upload_help']['function'] = 'fsa_filename_validation_theme_file_upload_help';
+  // Override the existing theme function for file upload help text.
+  $theme_registry['file_upload_help']['function'] = 'fsa_filename_validation_theme_file_upload_help';
 }
 
 
 /**
  * Theme function - override for theme_file_upload_help().
+ *
+ * This function provides text below the file upload form element, explaining
+ * validation criteria for files. This is an override for the existing theme
+ * function, but we call that function first to get the default text.
+ *
+ * @param array $variables
+ *   Array of theming variables
+ *
+ * @return string
+ *   HTML code for the file upload help text
+ *
+ * @see theme_file_upload_help().
  */
 function fsa_filename_validation_theme_file_upload_help($variables) {
 
@@ -98,12 +111,8 @@ function fsa_filename_validation_theme_file_upload_help($variables) {
   // Now we'll add any custom help text from our validators.
   $help_messages = array();
 
-  // Set validator defaults
-  $defaults = array('type' => 'regex');
-
   // Loop through the enabled validators
   foreach ($enabled_validators as $key => $validator) {
-    $validator += $defaults;
 
     // Special treatment for some validator types.
     switch ($validator['type']) {
@@ -126,6 +135,8 @@ function fsa_filename_validation_theme_file_upload_help($variables) {
 
     // Add the help message to our message array.
     if (!empty($validator['help'])) {
+      // Allow modules to alter the help text
+      drupal_alter('filename_validation_help', $validator['help'], $key);
       $help_messages[] = $validator['help'];
     }
   }
@@ -143,19 +154,23 @@ function fsa_filename_validation_theme_file_upload_help($variables) {
  *
  * This is where the actual filename validation takes place.
  *
+ * @param object $file
+ *   Object corresponding to the file being uploaded
+ *
+ * @return array
+ *   An array of error messages
+ *
+ * @see _fsa_filename_validation_enabled_validators().
+ * @see hook_filename_validators().
+ *
  */
 function fsa_filename_validation_file_validate($file) {
 
   // Create an array to hold the errors. This is what we return at the end.
   $errors = array();
 
-  // Invoke hook_filename_validators().
-  $validators = module_invoke_all('filename_validators');
-
-  // Set the default validator type.
-  $validator_defaults = array(
-    'type' => 'regex',
-  );
+  // Get the enabled validators - invokes hook_filename_validators()
+  $validators = _fsa_filename_validation_enabled_validators();
 
   // Call the enabled validators
   foreach ($validators as $key => $validator) {
@@ -165,17 +180,6 @@ function fsa_filename_validation_file_validate($file) {
 
     // Error message
     $error_message = '';
-
-    // Determine whether the validator is currently enabled.
-    $enabled = variable_get("filename_validator_${key}_enabled", FALSE);
-
-    // If not enabled, skip to the next one
-    if (!$enabled) {
-      continue;
-    }
-
-    // Add defaults
-    $validator += $validator_defaults;
 
     switch($validator['type']) {
 
@@ -188,7 +192,7 @@ function fsa_filename_validation_file_validate($file) {
 
       // Maximum filename length
       case 'maxlength':
-        $maxlength = variable_get("filename_validator_${key}_max_length", $validator['maxlength']);
+        $maxlength = !empty($validator['settings']['max_length']) ? $validator['settings']['max_length'] : $validator['maxlength'];
         if (strlen($file->filename) > $maxlength) {
           // Set a custom error message to include the maximum characters.
           $error_message = $validator['error_message'] . t('@maxlength characters.', array('@maxlength' => $maxlength));
@@ -245,14 +249,16 @@ function fsa_filename_validation_file_validate($file) {
       }
 
       // Add the error message to the output
-      $errors[] = !empty($error_message) ? $error_message : $validator['error_message'];
+      $error_message = !empty($error_message) ? $error_message : $validator['error_message'];
+      // Allow modules to alter the error message
+      drupal_alter('filename_validation_error', $error_message, $key);
+      // Add the error message to the return array.
+      $errors[] = $error_message;
     }
-
   }
 
   // Return the errors
   return $errors;
-
 }
 
 
@@ -310,7 +316,7 @@ function fsa_filename_validation_filename_validators() {
     'name' => t('Alphanumeric characters only'),
     'description' => t('Allows only letters, numbers and the full stop (dot) character. Be aware that this validator will not allow filenames with spaces.'),
     'pattern' => "/[^a-z|A-Z|0-9|\.]/",
-    'error_message' => t('The filename should contain only alphanumeric characters'),
+    'error_message' => t('The filename should contain only alphanumeric characters.'),
     'help' => t('Filenames can contain only letters, numbers and full stops.'),
   );
 
@@ -373,7 +379,6 @@ function fsa_filename_validation_filename_validators() {
  *
  * @return boolean
  *   TRUE if the excluded characters are found in the filename, FALSE otherwise
- *
  */
 function _fsa_filename_validation_exclude_characters($characters, $filename) {
 
@@ -403,7 +408,6 @@ function _fsa_filename_validation_exclude_characters($characters, $filename) {
   }
   $pattern = "${delimiter}[" . trim($pattern) . "]${delimiter}";
   return preg_match($pattern, $filename);
-
 }
 
 
@@ -423,6 +427,12 @@ function _fsa_filename_validation_exclude_characters_error($characters) {
 
 /**
  * Help text callback for excluded characters validator
+ *
+ * @param string $characters
+ *   The set of excluded characters for this validator
+ *
+ * @return string
+ *   The help text to be displayed to the user on the file upload form
  */
 function _fsa_filename_validation_exclude_characters_help($characters) {
   return t('Filenames should not contain any of these characters %characters.', array('%characters' => $characters));
@@ -448,13 +458,20 @@ function _fsa_filename_validation_lowercase($filename) {
 
 /**
  * Helper function: returns an array of enabled validators
+ * 
+ * @return array
+ *   An array of enabled validators, each of which is an associative array
+ * 
+ * @see _fsa_filename_validation_get_validators().
+ * @see hook_filename_validators().
+ * @see hook_filename_validators_alter().
  */
 function _fsa_filename_validation_enabled_validators() {
   // An array to hold the enabled validators
   $enabled_validators = array();
 
   // Invoke hook_filename_validators().
-  $validators = module_invoke_all('filename_validators');
+  $validators = _fsa_filename_validation_get_validators();
 
   foreach ($validators as $key => $validator) {
     // Determine whether the validator is currently enabled.
@@ -463,4 +480,111 @@ function _fsa_filename_validation_enabled_validators() {
     }
   }
   return $enabled_validators;
+}
+
+
+/**
+ * Helper function: provides a list of validators
+ *
+ * Invokes hook_filename_validators() to create a list of all available
+ * validators. Uses drupal_static() to cache the list, so it's generated only
+ * once per page request.
+ * 
+ * @return array
+ *   An array of enabled validators, each of which is an associative array
+ * 
+ * @see hook_filename_validators().
+ * @see hook_filename_validators_alter().
+ */
+function _fsa_filename_validation_get_validators() {
+  // Use drupal_static() to avoid calling all hooks repeatedly.
+  $validators = &drupal_static(__FUNCTION__);
+  if (empty($validators)) {
+    // Default validator settings
+    $validator_defaults = array(
+      'type' => 'regex',
+    );
+    // Invoke hook_filename_validators().
+    // Note that this hook is invoked only once per page request due to the use
+    // of drupal_static().
+    // @todo If there is ever a use case where we might want to call the hook
+    //   more than once per page request, then we may want to include a
+    //   parameter to specify that validators should be reloaded. There is no
+    //   need for this yet though, so leaving as is for now.
+    $validators = module_invoke_all('filename_validators');
+    foreach ($validators as $key => $validator) {
+      // Add any missing default settings
+      $validators[$key] += $validator_defaults;
+      // Add an element for whether the validator is enabled
+      $validators[$key]['enabled'] = _fsa_filename_validation_validator_enabled($key);
+      // Add an element for the key
+      $validators[$key]['key'] = $key;
+      // Get any settings defined for the validator
+      if (!empty($validator['settings_form'])) {
+        $validators[$key]['settings'] = array();
+        foreach ($validator['settings_form'] as $setting => $details) {
+          $validators[$key]['settings'][$setting] = variable_get("filename_validator_${key}_${setting}");
+        }
+      }
+    }
+    // Allow other modules to alter the validators.
+    drupal_alter('filename_validators', $validators);
+  }
+  return $validators;
+}
+
+
+/**
+ * Helper function: provides details of specified validator
+ *
+ * @param string $key
+ *   The key of the validator, eg 'no_whitespace'
+ *
+ * @return array|boolean
+ *   If the $key parameter corresponds to an element in the validators array
+ *   provided by _fsa_filename_validation_get_validators(), then this function
+ *   will return an associative array of properties for the requested validator.
+ *   If the $key parameter is empty or does not match an entry in the validators
+ *   array, then this function will return boolean FALSE.
+ *
+ * @see _fsa_filename_validation_get_validators()
+ */
+function _fsa_filename_validation_get_validator($key = NULL) {
+  // If no key is provided, return FALSE.
+  if (empty($key)) {
+    return FALSE;
+  }
+  // Get all available validators
+  $validators = _fsa_filename_validation_get_validators();
+
+  // If no validators available, return FALSE
+  if (empty($validators) || !is_array($validators)) {
+    return FALSE;
+  }
+
+  // If the key doesn't correspond to a validator, return FALSE
+  if (empty($validators[$key])) {
+    return FALSE;
+  }
+
+  return $validators[$key];
+}
+
+
+/**
+ * Helper function: determines whether a validator is enabled
+ *
+ * @param string $key
+ *   The key of the validator, eg 'no_whitespace'
+ *
+ * @return boolean
+ *   TRUE if the validator is enabled, FALSE otherwise.
+ */
+function _fsa_filename_validation_validator_enabled($key = NULL) {
+
+  if (empty($key)) {
+    return FALSE;
+  }
+
+  return variable_get("filename_validator_${key}_enabled", FALSE);
 }

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.module
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.module
@@ -1,0 +1,362 @@
+<?php
+/**
+ * @file
+ * Module code for the FSA file validation module.
+ *
+ * This module provides an extensible validation engine for filenames of
+ * uploaded files. In addition to the built-in validators, more can be added
+ * through the use of hook_filename_validators().
+ */
+
+
+/**
+ * Implements hook_permission().
+ */
+function fsa_filename_validation_permission() {
+  return array(
+    'administer filename validation' => array(
+      'title' => t('Administer filename validation'),
+      'description' => t('Change settings for filename validation.'),
+    )
+  );
+}
+
+
+/**
+ * Implements hook_menu().
+ */
+function fsa_filename_validation_menu() {
+  $items = array();
+
+  // Default settings if the file_entity module is not avaiable.
+  $file_entity = FALSE;
+  $admin_menu_link = 'admin/config/media/file-validation';
+
+  // Default local task for the existing file_entity admin form. We add this so
+  // that we can provide navigational tabs in the admin UI.
+  if (module_exists('file_entity')) {
+    $items['admin/config/media/file-settings/default'] = array(
+      'type' => MENU_DEFAULT_LOCAL_TASK,
+      'title' => t('File settings'),
+    );
+    // If the file_entity module exists, we change the menu settings.
+    $file_entity = TRUE;
+    $admin_menu_link = 'admin/config/media/file-settings/validation';
+  }
+
+  // Administration menu link. This is where the validators are turned on and
+  // off.
+  $items[$admin_menu_link] = array(
+    'title' => t('Filename validation settings'),
+    'description' => t('Administer filename validation settings'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('fsa_filename_validation_configuration_form'),
+    'access arguments' => array('administer filename validation'),
+    'file' => 'fsa_filename_validation.admin.inc',
+    'type' => $file_entity ? MENU_LOCAL_TASK : MENU_NORMAL_ITEM,
+  );
+
+  return $items;
+}
+
+
+/**
+ * Implements hook_menu_alter().
+ */
+function fsa_filename_validation_menu_alter(&$items) {
+  // If the file_entity module is enabled, add a mention of filename validation
+  // to its description, together with a link to the admin config form.
+  if (!empty($items['admin/config/media/file-settings'])) {
+    $items['admin/config/media/file-settings']['description'] .= ' ' . t('Also configure <a href="@config_link">filename validation</a>.', array('@config_link' => url('admin/config/media/file-settings/validation')));
+  }
+}
+
+
+/**
+ * Implements hook_file_validate().
+ *
+ * This is where the actual filename validation takes place.
+ *
+ */
+function fsa_filename_validation_file_validate($file) {
+
+  // Create an array to hold the errors. This is what we return at the end.
+  $errors = array();
+
+  // Invoke hook_filename_validators().
+  $validators = module_invoke_all('filename_validators');
+
+  // Set the default validator type.
+  $validator_defaults = array(
+    'type' => 'regex',
+  );
+
+  // Call the enabled validators
+  foreach ($validators as $key => $validator) {
+
+    // Is there an error?
+    $error = FALSE;
+
+    // Error message
+    $error_message = '';
+
+    // Determine whether the validator is currently enabled.
+    $enabled = variable_get("filename_validator_${key}_enabled", FALSE);
+
+    // If not enabled, skip to the next one
+    if (!$enabled) {
+      continue;
+    }
+
+    // Add defaults
+    $validator += $validator_defaults;
+
+    switch($validator['type']) {
+
+      // Simple regex match - if the pattern matches, there's an error.
+      case 'regex':
+        if (preg_match($validator['pattern'], $file->filename)) {
+          $error = TRUE;
+        }
+        break;
+
+      // Maximum filename length
+      case 'maxlength':
+        $maxlength = variable_get("filename_validator_${key}_max_length", $validator['maxlength']);
+        if (strlen($file->filename) > $maxlength) {
+          // Set a custom error message to include the maximum characters.
+          $error_message = $validator['error_message'] . t('@maxlength characters.', array('@maxlength' => $maxlength));
+          $error = TRUE;
+        }
+        break;
+
+      // All filenames should be lowercase
+      case 'lowercase':
+        if (!_fsa_filename_validation_lowercase($file->filename)) {
+          $error = TRUE;
+        }
+        break;
+
+      // Custom validation
+      case 'custom':
+        // Get the name of the callback function, if set.
+        $callback = !empty($validator['callback']) ? $validator['callback'] : NULL;
+        // If no callback is specified, skip this validator
+        if (empty($callback) || !function_exists($callback)) {
+          continue;
+        }
+        // Get the arguments - if specified
+        $arguments = !empty($validator['arguments']) ? $validator['arguments'] : array();
+
+        // See if any of the arguments come from a config seting.
+        foreach ($arguments as $index => $argument) {
+          if (strpos($argument, 'settings:') !== FALSE) {
+            $arguments[$index] = variable_get("filename_validator_${key}_" . str_replace('settings:', '', $argument));
+          }
+        }
+
+        // Add the filename as the final argument
+        $arguments[] = $file->filename;
+
+        // Call the callback function
+        if (call_user_func_array($callback, $arguments)) {
+          $error = TRUE;
+        }
+        break;
+    }
+
+    // If we have an error, we need to add an error message.
+    if ($error) {
+      // If we have a custom error message callback, call it now.
+      if (!empty($validator['error_message_callback']) && function_exists($validator['error_message_callback'])) {
+        $arguments = !empty($validator['error_message_arguments']) ? $validator['error_message_arguments'] : array();
+        foreach ($arguments as $index => $argument) {
+          if (strpos($argument, 'settings:') !== FALSE) {
+            $arguments[$index] = variable_get("filename_validator_${key}_" . str_replace('settings:', '', $argument));
+          }
+        }
+        $error_message = call_user_func_array($validator['error_message_callback'], $arguments);
+      }
+
+      // Add the error message to the output
+      $errors[] = !empty($error_message) ? $error_message : $validator['error_message'];
+    }
+
+  }
+
+  // Return the errors
+  return $errors;
+
+}
+
+
+/**
+ * Implements hook_filename_validators().
+ *
+ * Returns an array of validators to be used.
+ *
+ * @return array
+ *   Array of validators. Each element is itself an array with the following
+ *   elements:
+ *   - name: The translated human-readable name of the validator. This is
+ *     displayed on the administration page
+ *   - description: (optional) A description of what the validator does
+ *   - pattern: (optional) A regex pattern to be used against the filename. This
+ *     is mandatory for validators of type 'regex', which is the default.
+ *   - error_message: The translated error message to display to users. This is
+ *     mandatory unless 'error_message_callback' is provided.
+ *   - replacement: Not currently in use
+ *   - type: The type of validator. Currently recognised types are 'regex',
+ *     'maxlength', 'lowercase', 'custom'.
+ *   - autocorrect: Not currently in use
+ *   - settings_form: Used to add a settings form for use in the administration
+ *     interface. This should be a standard Drupal Form API render array.
+ *   - callback: A custom callback function. Should be used only with validators
+ *     of type 'custom'.
+ *   - arguments: An array of arguments to be passed to the callback function.
+ *     These can be standard variables or settings for the validator. To include
+ *     a user-specified setting, prefix it with 'setting:' eg
+ *     'setting:characters'
+ *   - error_message_callback: A function for generating custom error messages
+ *   - error_message_arguments: An array of arguments to be passed to the
+ *     custom error message function
+ */
+function fsa_filename_validation_filename_validators() {
+  $validators = array();
+
+  $validators['no_whitespace'] = array(
+    'name' => t('No whitespace'),
+    'description' => t('Will not allow filenames that contain white space such as spaces, tabs and new lines.'),
+    'pattern' => "/\s/",
+    'error_message' => t('The filename should not contain any spaces.'),
+    'replacement' => '-',
+    'autocorrect' => TRUE,
+  );
+
+  $validators['alphanumeric'] = array(
+    'name' => t('Alphanumeric characters only'),
+    'description' => t('Allows only letters, numbers and the full stop (dot) character. Be aware that this validator will not allow filenames with spaces.'),
+    'pattern' => "/[^a-z|A-Z|0-9|\.]/",
+    'error_message' => t('The filename should contain only alphanumeric characters'),
+  );
+
+  $validators['max_length'] = array(
+    'name' => t('Maximum filename length'),
+    'description' => t('Restricts filenames to a specified maximum length.'),
+    'type' => 'maxlength',
+    'maxlength' => 10,
+    'error_message' => t('The filename should contain no more than '),
+    'settings_form' => array(
+      'max_length' => array(
+        '#type' => 'textfield',
+        '#size' => 3,
+        '#title' => t('Maximum number of characters allowed'),
+        '#default_value' => 10,
+      ),
+    ),
+  );
+
+  $validators['lowercase'] = array(
+    'name' => t('All lowercase'),
+    'description' => t('Allows only lowercase letters in filenames.'),
+    'type' => 'lowercase',
+    'error_message' => t('Filenames should be all lowercase.'),
+  );
+
+  $validators['exclude_characters'] = array(
+    'name' => t('Exclude these characters'),
+    'description' => t('Allows specified characters to be excluded from filenames.'),
+    'type' => 'custom',
+    'callback' => '_fsa_filename_validation_exclude_characters',
+    'arguments' => array("settings:excluded_characters"),
+    'error_message' => t('Sorry, the filename contains invalid characters'),
+    'error_message_callback' => '_fsa_filename_validation_exclude_characters_error',
+    'error_message_arguments' => array("settings:excluded_characters"),
+    'settings_form' => array(
+      'excluded_characters' => array(
+        '#type' => 'textfield',
+        '#title' => t('Characters to be excluded'),
+        '#description' => t('Enter a list of characters to exclude. Leave one space between each character.')
+      ),
+    ),
+  );
+
+  return $validators;
+}
+
+
+/**
+ * Validation callback - exclude specified characters
+ *
+ * @param string $characters
+ *   The set of characters to be excluded from filenames, separated by spaces
+ *
+ * @param string $filename
+ *   The name of the file
+ *
+ * @return boolean
+ *   TRUE if the excluded characters are found in the filename, FALSE otherwise
+ *
+ */
+function _fsa_filename_validation_exclude_characters($characters, $filename) {
+
+  // If we don't have a pattern or a filename, return FALSE now.
+  if (empty($characters) || empty($filename)) {
+    return FALSE;
+  }
+
+  $characters = trim($characters);
+
+  // Define an array of potential delimiters
+  $delimiters = array('/', '@', '#', '~');
+  $delimiter = NULL;
+
+  // Find a delimiter that's not in the set of characters supplied
+  foreach ($delimiters as $d) {
+    if (strpos($characters, $d) === FALSE) {
+      $delimiter = $d;
+      break;
+    }
+  }
+
+  $pattern = '';
+  $character_array = explode(' ', $characters);
+  foreach ($character_array as $character) {
+    $pattern .= ctype_alnum($character) ? $character : '\\' . trim($character);
+  }
+  $pattern = "${delimiter}[" . trim($pattern) . "]${delimiter}";
+  return preg_match($pattern, $filename);
+
+}
+
+
+/**
+ * Error message callback function, excluded characters
+ *
+ * @param string $characters
+ *   The set of excluded characters for this validator
+ *
+ * @return string
+ *   The error message to be displayed to the user
+ *
+ */
+function _fsa_filename_validation_exclude_characters_error($characters) {
+  return t('Sorry, the filename cannot contain any of these characters %characters', array('%characters' => $characters));
+}
+
+
+/**
+ * Validation callback function - all lowercase
+ *
+ * @param string $filename
+ *   The name of the file
+ *
+ * @return boolean
+ *   TRUE if all letters in the filename are lowercase, FALSE otherwise.
+ *
+ * We use this instead of PHP's ctype_lower() function, because we don't want
+ * files that contain non-alpha characters, such as . to fail validation.
+ */
+function _fsa_filename_validation_lowercase($filename) {
+  return $filename == strtolower($filename);
+}


### PR DESCRIPTION
This module provides an extensible framework for validating filenames based on various criteria.

Enable the module
-------------------------
After deploying the code, the module will need to be enabled - either via the Drupal admin UI or using Drush: `drush en fsa_filename_validation --y`

Remember to clear the caches once the module is enabled

Configure the module
-----------------------------
Once the module has been enabled, go to **Admin > Configuration > Media > File settings > Filename validation settings** and configure the validators to be used.

[ Partial fix for [#10282](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=780) ]