### PR TITLE
Change implementation for SiteImprove meta tags

### DIFF
--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -398,3 +398,14 @@ function local_field_group_pre_render_alter(&$element, $group, & $form) {
   // around the classes.
   $element['#prefix'] = '<div class="' . $group->classes . '">';
 }
+
+
+/**
+ * Implements hook_siteimprove_editing_page_options_alter().
+ *
+ * This is used to ensure that the editing page URL rendered in the meta tag
+ * for SiteImprove uses the admin domain, rather than the front-end domain.
+ */
+function local_siteimprove_editing_page_options_alter(&$editing_page_options) {
+  $editing_page_options['base_url'] = local_get_site_domain(TRUE, 'https');
+}

--- a/docroot/sites/all/modules/custom/siteimprove/siteimprove.module
+++ b/docroot/sites/all/modules/custom/siteimprove/siteimprove.module
@@ -58,7 +58,7 @@ function siteimprove_theme() {
 
 /**
  * Implements hook_page_alter().
- * 
+ *
  * @see theme/siteimprove-analytics-javascript.tpl.php
  */
 function siteimprove_page_alter(&$page) {
@@ -88,22 +88,25 @@ function siteimprove_page_alter(&$page) {
 
 
 /**
- * Implements hook_node_view().
+ * Implements template_preprocess_page().
  *
  * We use this to add the SiteImprove meta tags that facilitate CMS deeplinking
  *
  * @see http://support.siteimprove.com/hc/en-gb/articles/206343443-What-is-CMS-Deeplinking-and-How-do-I-enable-it-
  */
-function siteimprove_node_view($node, $view_mode, $langcode) {
-
-  // Act only if the node is being viewed in full.
-  if ($view_mode != 'full' || empty($node->nid)) {
+function siteimprove_preprocess_page(&$variables) {
+  // Get the node object from the page variables - if available.
+  $node = !empty($variables['node']) ? $variables['node'] : NULL;
+  // No node object? Exit now.
+  if (empty($node)) {
     return;
   }
-
-  // Get the Node ID (nid).
-  $nid = $node->nid;
-
+  // Get the Nid from the node object
+  $nid = !empty($node->nid) ? $node->nid : NULL;
+  // No Nid? Exit now.
+  if (empty($nid)) {
+    return;
+  }
   // Add the pageID meta tag - if required.
   if (variable_get('siteimprove_meta_pageid', FALSE)) {
     $page_id = array(


### PR DESCRIPTION
Was previously using `hook_node_view()` to add the meta tags to the page. However, on the FSA site, this was being triggered by an embedded node that was being displayed in 'full' view mode.

Instead, use an implementation of `template_preprocess_page()` to ensure that the node is the main page one.

In addition added an implementation of `hook_siteimprove_editing_page_options_alter()` in the **local** module.

This ensures that if the SiteImprove editing page URL meta tag is present it uses the proper admin URL, not the front-end domain.

[ Partial fix for [#10289](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=787) ]