### PR TITLE
Develop: Don't overwrite existing child properties

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
+++ b/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
@@ -307,7 +307,10 @@ function fsa_govdelivery_taxonomy_vocabulary_update($vocabulary) {
         'govdelivery_type' => $child_type,
         'govdelivery_code' => NULL,
       );
-      if (!empty($quick_subscribe_page)) {
+      // Get any existing mapping details for the term.
+      $term_mapping = _fsa_govdelivery_get_entity_settings('term', $term->tid);
+      // Overwrite child options only if they are not set.
+      if (!empty($quick_subscribe_page) && empty($term_mapping->quick_subscribe_page)) {
         $params['options']['quick_subscribe_page'] = $quick_subscribe_page;
       }
       $gid = fsa_govdelivery_add_mapping($params);


### PR DESCRIPTION
When updating a taxonomy vocabulary, don't overwrite GovDelivery settings of terms.

[ Partial fix for #10225 ]