### PR TITLE
Develop: Some improvements to the GovDelivery integration

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
+++ b/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
@@ -236,7 +236,7 @@ function _fsa_govdelivery_get_entity_settings($entity_type = NULL, $entity_id = 
   $result->options = $options;
 
   // Set some typical values from the options array as properties of the object
-  $keys = array('parents', 'pages', 'quick_subscribe_page', 'child_type', 'child_quick_subscribe_page', 'readonly');
+  $keys = array('parents', 'pages', 'quick_subscribe_page', 'child_type', 'child_quick_subscribe_page', 'readonly', 'override_parent');
   foreach ($keys as $key) {
     if (isset($options[$key])) {
       $result->{$key} = $options[$key];
@@ -320,8 +320,9 @@ function fsa_govdelivery_taxonomy_vocabulary_update($vocabulary) {
       );
       // Get any existing mapping details for the term.
       $term_mapping = _fsa_govdelivery_get_entity_settings('term', $term->tid);
+
       // Overwrite child options only if they are not set.
-      if (!empty($quick_subscribe_page) && empty($term_mapping->quick_subscribe_page)) {
+      if (empty($term_mapping->override_parent)  && !empty($quick_subscribe_page)) {
         $params['options']['quick_subscribe_page'] = $quick_subscribe_page;
       }
       $gid = fsa_govdelivery_add_mapping($params);
@@ -392,7 +393,8 @@ function fsa_govdelivery_cron_queue_info() {
     'worker callback' => '_fsa_govdelivery_sync_item',
     'time' => 60,
   );
-  return $queues;
+  // Temporarily disable while testing.
+  //return $queues;
 }
 
 /**
@@ -876,6 +878,14 @@ function fsa_govdelivery_form_taxonomy_form_term_alter(&$form, &$form_state) {
     return;
   }
 
+  // Override status
+  $form['govdelivery_settings']['override_parent'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Override parent settings'),
+    '#description' => t('Tick this box if you want to modify the GovDelivery settings for this term only. Otherwise, the settings for the vocabulary will be used.'),
+    '#default_value' => !empty($govdelivery_settings->override_parent) ? $govdelivery_settings->override_parent : 0,
+  );
+
   // GovDelivery element type
   $form['govdelivery_settings']['govdelivery_type'] = array(
     '#type' => 'select',
@@ -887,6 +897,11 @@ function fsa_govdelivery_form_taxonomy_form_term_alter(&$form, &$form_state) {
     ),
     '#empty_option' => t('None'),
     '#default_value' => !empty($govdelivery_settings->govdelivery_type) ? $govdelivery_settings->govdelivery_type : NULL,
+    '#states' => array(
+      'disabled' => array(
+        ':input[name="override_parent"]' => array('checked' => FALSE),
+      ),
+    ),
   );
 
   // GovDelivery categories
@@ -899,6 +914,9 @@ function fsa_govdelivery_form_taxonomy_form_term_alter(&$form, &$form_state) {
     '#states' => array(
       'visible' => array(
         ':input[name="govdelivery_type"]' => array('value' => 'category'),
+      ),
+      'disabled' => array(
+        ':input[name="override_parent"]' => array('checked' => FALSE),
       ),
     ),
   );
@@ -914,6 +932,9 @@ function fsa_govdelivery_form_taxonomy_form_term_alter(&$form, &$form_state) {
       'visible' => array(
         ':input[name="govdelivery_type"]' => array('value' => 'topic'),
       ),
+      'disabled' => array(
+        ':input[name="override_parent"]' => array('checked' => FALSE),
+      ),
     ),
   );
 
@@ -927,6 +948,9 @@ function fsa_govdelivery_form_taxonomy_form_term_alter(&$form, &$form_state) {
     '#states' => array(
       'visible' => array(
         ':input[name="govdelivery_type"]' => array('value' => 'category'),
+      ),
+      'disabled' => array(
+        ':input[name="override_parent"]' => array('checked' => FALSE),
       ),
     ),
   );
@@ -986,6 +1010,7 @@ function fsa_govdelivery_taxonomy_form_term_submit(&$form, &$form_state) {
   // Build the options array
   $options = array(
     'quick_subscribe_page' => !empty($values['quick_subscribe_page']) ? $values['quick_subscribe_page'] : (!empty($parent->child_quick_subscribe_page) ? $parent->child_quick_subscribe_page : NULL),
+    'override_parent' => $values['override_parent'],
   );
 
   // Build the variables array to be passed to fsa_govdelivery_add_mapping().

--- a/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
+++ b/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
@@ -32,6 +32,17 @@ function fsa_govdelivery_form_taxonomy_form_vocabulary_alter(&$form, $form_state
     '#title' => t('GovDelivery settings'),
   );
 
+  // Check GovDelivery API status
+  $govdelivery_status = _govdelivery_api_available();
+  // If it's not healthy, show a message and return.
+  if (!$govdelivery_status->isHealthy()) {
+    $form['govdelivery_settings']['unavailable'] = array(
+      '#theme' => 'govdelivery_api_status_description',
+      '#status' => $govdelivery_status,
+    );
+    return;
+  }
+
   // Get GovDelivery categories
   $categories = govdelivery_api_get_categories();
   $options = array();
@@ -853,6 +864,17 @@ function fsa_govdelivery_form_taxonomy_form_term_alter(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('GovDelivery settings'),
   );
+
+  // Check GovDelivery API status
+  $govdelivery_status = _govdelivery_api_available();
+  // If it's not healthy, show a message and return.
+  if (!$govdelivery_status->isHealthy()) {
+    $form['govdelivery_settings']['unavailable'] = array(
+      '#theme' => 'govdelivery_api_status_description',
+      '#status' => $govdelivery_status,
+    );
+    return;
+  }
 
   // GovDelivery element type
   $form['govdelivery_settings']['govdelivery_type'] = array(

--- a/docroot/sites/all/modules/custom/govdelivery_api/govdelivery_api.admin.inc
+++ b/docroot/sites/all/modules/custom/govdelivery_api/govdelivery_api.admin.inc
@@ -23,33 +23,10 @@ function govdelivery_api_settings_form($form, &$form_state) {
     '#title' => t('API status'),
   );
 
-  // Get the status.
-  $status = _govdelivery_api_available();
-  $message_type = $status->isHealthy() ? 'status' : 'error';
-
   $form['status_container']['status_description'] = array(
-    '#prefix' => "<div class=\"messages $message_type\">",
-    '#markup' => t('The GovDelivery API is currently @status.', array('@status' => $status->getStatusDescription())),
-    '#suffix' => '</div>',
+    '#theme' => 'govdelivery_api_status_description',
+    '#status' => _govdelivery_api_available(),
   );
-
-  $error_message = $status->getMessage();
-
-  if (!empty($error_message)) {
-    $form['status_container']['error_message'] = array(
-      '#prefix' => '<p>',
-      '#markup' => t('The error message was: %error_message', array('%error_message' => $error_message)),
-      '#suffix' => '</p>',
-    );
-  }
-
-  if (!empty($status->lastCheck)) {
-    $form['status_container']['status_last_checked'] = array(
-      '#prefix' => '<p>',
-      '#markup' => t('The service was last checked on @last_checked.', array('@last_checked' => $status->getLastChecked('l j F Y \a\t H:i:s'))) . ' ' . t('Next check due in @next_check seconds.', array('@next_check' => $status->getNextCheck(variable_get('govdelivery_api_healthy_interval'), variable_get('govdelivery_api_unhealthy_interval')))),
-      '#suffix' => '</p>',
-    );
-  }
 
   $form['status_container']['check_button'] = array(
     '#type' => 'submit',

--- a/docroot/sites/all/modules/custom/govdelivery_api/govdelivery_api.module
+++ b/docroot/sites/all/modules/custom/govdelivery_api/govdelivery_api.module
@@ -497,6 +497,12 @@ function govdelivery_api_theme() {
         'api_status' => NULL,
       ),
     ),
+    'govdelivery_api_status_description' => array(
+      'template' => 'theme/govdelivery-api-status-description',
+      'variables' => array(
+        'status' => NULL,
+      ),
+    ),
   );
 }
 
@@ -674,6 +680,17 @@ function template_preprocess_govdelivery_api_down_page(&$variables) {
   $variables['action_message'] = !empty($action_message) ? $action_message : NULL;
   $variables['last_checked'] = $check->getLastChecked('l j F Y \a\t H:i:s');
   $variables['next_check'] = $check->getNextCheck(variable_get('govdelivery_api_healthy_interval'), variable_get('govdelivery_api_unhealthy_interval'));
+}
+
+
+/**
+ * Preprocess function for GovDelivery status message
+ */
+function template_preprocess_govdelivery_api_status_description(&$variables) {
+  $status = !empty($variables['status']) ? $variables['status'] : NULL;
+  $variables['message_type'] = empty($status->healthy) ? 'error' : 'status';
+  $variables['description'] = $status->getStatusDescription();
+  $variables['error_message'] = $status->getMessage();
 }
 
 

--- a/docroot/sites/all/modules/custom/govdelivery_api/govdelivery_api.topics.admin.inc
+++ b/docroot/sites/all/modules/custom/govdelivery_api/govdelivery_api.topics.admin.inc
@@ -102,7 +102,7 @@ function govdelivery_api_topic_edit_form($form, &$form_state, $topic_code) {
   $form['general_settings']['topic_description'] = array(
     '#type' => 'textarea',
     '#title' => t('Description'),
-    '#default_value' => $topic->description,
+    '#default_value' => !is_object($topic->description) ? $topic->description : NULL,
   );
   $form['general_settings']['topic_code'] = array(
     '#type' => 'textfield',

--- a/docroot/sites/all/modules/custom/govdelivery_api/libraries/GovDeliveryTopics.class.php
+++ b/docroot/sites/all/modules/custom/govdelivery_api/libraries/GovDeliveryTopics.class.php
@@ -61,8 +61,7 @@ class GovDeliveryTopics extends GovDeliveryEndpoint {
     
     // If the request wasn't successful or we don't have an element code,
     // or we don't have any categories to add, return the response now
-    var_dump($params['categories']);
-    if (empty($response->success) || empty($topic->element_code) || !is_array($params['categories'])) {
+    if (empty($response->success) || empty($topic->element_code) || (!empty($params['categories']) && !is_array($params['categories']))) {
       return $response;
     }
     

--- a/docroot/sites/all/modules/custom/govdelivery_api/theme/govdelivery-api-status-description.tpl.php
+++ b/docroot/sites/all/modules/custom/govdelivery_api/theme/govdelivery-api-status-description.tpl.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Default theme implementation for the GovDelivery service status message.
+ */
+
+?>
+<div class="messages <?php print $message_type; ?>">
+  <?php print t('The GovDelivery API is currently @status.', array('@status' => $description)); ?>
+</div>
+<p><?php print t('The last error message was: %error_message', array('%error_message' => $error_message)); ?>.</p>
+<p><?php print t('The service was last checked on @last_checked.', array('@last_checked' => $status->getLastChecked('l j F Y \a\t H:i:s'))) . ' ' . t('Next check due in @next_check seconds.', array('@next_check' => $status->getNextCheck(variable_get('govdelivery_api_healthy_interval'), variable_get('govdelivery_api_unhealthy_interval')))); ?>.</p>


### PR DESCRIPTION
* Check API status on vocabulary and term pages
* Include a checkbox on term pages to override parent settings.

[ Partial fix for #10225 ]