### PR TITLE
Use production URLs for nodes in GovDelivery

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
+++ b/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
@@ -689,7 +689,9 @@ function fsa_govdelivery_node_update($node) {
 
   $options = array(
     'parents' => $categories,
-    'pages' => array(url('node/' . $node->nid, array('absolute' => TRUE))),
+    //'pages' => array(url('node/' . $node->nid, array('absolute' => TRUE))),
+    // Enforce URLs from production - change this?
+    'pages' => array(url('node/' . $node->nid, array('absolute' => TRUE, 'base_url' => 'http://www.food.gov.uk'))),
   );
 
   $variables = array(

--- a/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
+++ b/docroot/sites/all/modules/custom/fsa_govdelivery/fsa_govdelivery.module
@@ -393,8 +393,7 @@ function fsa_govdelivery_cron_queue_info() {
     'worker callback' => '_fsa_govdelivery_sync_item',
     'time' => 60,
   );
-  // Temporarily disable while testing.
-  //return $queues;
+  return $queues;
 }
 
 /**


### PR DESCRIPTION
* Force URLs to be based on www.food.gov.uk
* Allow queue items to be returned.

[ Partial fix for #10225 ]