### PR TITLE
Production: Upgrade Views Bulk Operations to 7.x-3.3

### DIFF
--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/archive.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/archive.action.inc
@@ -18,6 +18,7 @@ function views_bulk_operations_archive_action_info() {
       // "Create an advanced action" dropdown on admin/config/system/actions.
       'configurable' => FALSE,
       'vbo_configurable' => TRUE,
+      'behavior' => array('views_property'),
       'triggers' => array('any'),
     );
   }

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/book.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/book.action.inc
@@ -13,11 +13,13 @@ function views_bulk_operations_book_action_info() {
       'label' => t('Move to book'),
       'configurable' => TRUE,
       'behavior' => array('changes_property'),
+      'triggers' => array('any'),
     );
     $actions['views_bulk_operations_remove_from_book_action'] = array(
       'type' => 'node',
       'label' => t('Remove from book'),
       'configurable' => FALSE,
+      'triggers' => array('any'),
     );
   }
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/delete.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/delete.action.inc
@@ -19,6 +19,7 @@ function views_bulk_operations_delete_action_info() {
       'label' => t('Delete revision'),
       'configurable' => FALSE,
       'behavior' => array('deletes_property'),
+      'triggers' => array('any'),
     ),
   );
 }

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/modify.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/modify.action.inc
@@ -82,6 +82,11 @@ function views_bulk_operations_modify_action($entity, $context) {
     // The wrapper will automatically modify $entity itself.
     $wrapper = entity_metadata_wrapper($context['entity_type'], $entity);
     foreach ($context['selected']['properties'] as $key) {
+      if (!$wrapper->$key->access('update')) {
+        // No access.
+        continue;
+      }
+
       if (in_array($key, $context['append']['properties'])) {
         $old_values = $wrapper->$key->value();
         $wrapper->$key->set($context['properties'][$key]);
@@ -134,7 +139,7 @@ function views_bulk_operations_modify_action_form($context, &$form_state) {
   if (!empty($properties)) {
     $form['properties'] = array(
       '#type' => 'fieldset',
-      '#title' => 'Properties',
+      '#title' => t('Properties'),
     );
     $form['properties']['show_value'] = array(
       '#suffix' => '<div class="clearfix"></div>',
@@ -298,7 +303,7 @@ function views_bulk_operations_modify_action_form($context, &$form_state) {
     $token_type = str_replace('_', '-', $entity_type);
     $form['tokens'] = array(
       '#type' => 'fieldset',
-      '#title' => 'Available tokens',
+      '#title' => t('Available tokens'),
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
       '#weight' => 998,

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/user_cancel.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/user_cancel.action.inc
@@ -10,6 +10,7 @@ function views_bulk_operations_user_cancel_action_info() {
     'label' => t('Cancel user account'),
     'configurable' => TRUE,
     'behavior' => array('deletes_property'),
+    'triggers' => array('any'),
   ));
 }
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/user_roles.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/user_roles.action.inc
@@ -45,24 +45,19 @@ function views_bulk_operations_user_roles_action_submit($form, $form_state) {
   );
 }
 
-function views_bulk_operations_user_roles_action(&$user, $context) {
-  $roles = $user->roles;
-  $selected = (is_array($context['add_roles']) ? $context['add_roles'] : array()) +
-              (is_array($context['remove_roles']) ? $context['remove_roles'] : array());
-  $result = db_query("SELECT rid, name FROM {role} WHERE rid IN (:selected)", array(':selected' => array_keys($selected)));
-  foreach ($result as $role) {
-    if (isset($context['add_roles'][$role->rid])) {
-      $add_roles[$role->rid] = $role->name;
-    }
-    if (isset($context['remove_roles'][$role->rid])) {
-      $remove_roles[$role->rid] = $role->name;
-    }
+function views_bulk_operations_user_roles_action($user, $context) {
+  $wrapper = entity_metadata_wrapper('user', $user);
+  if (!$wrapper->roles->access("update")) {
+    // No access.
+    return;
   }
-  if (!empty($add_roles)) {
-    $roles += $add_roles;
+  $roles = $wrapper->roles->value();
+  if (is_array($context['add_roles'])) {
+    $roles = array_merge($roles, $context['add_roles']);
   }
-  if (!empty($remove_roles)) {
-    $roles = array_diff($roles, $remove_roles);
+  if (is_array($context['remove_roles'])) {
+    $roles = array_diff($roles, $context['remove_roles']);
   }
-  user_save($user, array('roles' => $roles));
+  $wrapper->roles->set($roles);
+  $wrapper->save();
 }

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions_permissions.info
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions_permissions.info
@@ -3,9 +3,9 @@ description = Provides permission-based access control for actions. Used by View
 package = Administration
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2013-12-23
-version = "7.x-3.2"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-3.3"
 core = "7.x"
 project = "views_bulk_operations"
-datestamp = "1387798183"
+datestamp = "1435764542"
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/js/views_bulk_operations.js
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/js/views_bulk_operations.js
@@ -46,21 +46,23 @@
     });
 
     // Set up the ability to click anywhere on the row to select it.
-    $('.views-table tbody tr', form).click(function(event) {
-      if (event.target.tagName.toLowerCase() != 'input' && event.target.tagName.toLowerCase() != 'a') {
-        $('input[id^="edit-views-bulk-operations"]:not(:disabled)', this).each(function() {
-          var checked = this.checked;
-          // trigger() toggles the checkmark *after* the event is set,
-          // whereas manually clicking the checkbox toggles it *beforehand*.
-          // that's why we manually set the checkmark first, then trigger the
-          // event (so that listeners get notified), then re-set the checkmark
-          // which the trigger will have toggled. yuck!
-          this.checked = !checked;
-          $(this).trigger('click');
-          this.checked = !checked;
-        });
-      }
-    });
+    if (Drupal.settings.vbo.row_clickable) {
+      $('.views-table tbody tr', form).click(function(event) {
+        if (event.target.tagName.toLowerCase() != 'input' && event.target.tagName.toLowerCase() != 'a') {
+          $('input[id^="edit-views-bulk-operations"]:not(:disabled)', this).each(function() {
+            var checked = this.checked;
+            // trigger() toggles the checkmark *after* the event is set,
+            // whereas manually clicking the checkbox toggles it *beforehand*.
+            // that's why we manually set the checkmark first, then trigger the
+            // event (so that listeners get notified), then re-set the checkmark
+            // which the trigger will have toggled. yuck!
+            this.checked = !checked;
+            $(this).trigger('click');
+            this.checked = !checked;
+          });
+        }
+      });
+    }
   }
 
   Drupal.vbo.tableSelectAllPages = function(form) {

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/plugins/operation_types/action.class.php
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/plugins/operation_types/action.class.php
@@ -20,7 +20,7 @@ class ViewsBulkOperationsAction extends ViewsBulkOperationsBaseOperation {
    */
   public function getAccessMask() {
     // Assume edit by default.
-    if (!isset($this->operationInfo['behavior'])) {
+    if (empty($this->operationInfo['behavior'])) {
       $this->operationInfo['behavior'] = array('changes_property');
     }
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/plugins/operation_types/rules_component.class.php
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/plugins/operation_types/rules_component.class.php
@@ -124,6 +124,8 @@ class ViewsBulkOperationsRulesComponent extends ViewsBulkOperationsBaseOperation
     else {
      $element = rules_action('component_' . $this->operationInfo['parameters']['component_key']);
     }
-    $element->execute($data);
+    $wrapper_type = is_array($data) ? "list<{$this->entityType}>" : $this->entityType;
+    $wrapper = entity_metadata_wrapper($wrapper_type, $data);
+    $element->execute($wrapper);
   }
 }

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/views/views_bulk_operations_handler_field_operations.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/views/views_bulk_operations_handler_field_operations.inc
@@ -55,6 +55,7 @@ class views_bulk_operations_handler_field_operations extends views_handler_field
       'contains' => array(
         'display_type' => array('default' => 0),
         'enable_select_all_pages' => array('default' => TRUE),
+        'row_clickable' => array('default' => TRUE),
         'force_single' => array('default' => FALSE),
         'entity_load_capacity' => array('default' => 10),
         'skip_batching' => array('default' => 0),
@@ -63,9 +64,24 @@ class views_bulk_operations_handler_field_operations extends views_handler_field
     $options['vbo_operations'] = array(
       'default' => array(),
       'unpack_translatable' => 'unpack_operations',
+      'export' => 'export_vbo_operations',
     );
 
     return $options;
+  }
+
+  function export_vbo_operations($indent, $prefix, $storage, $option, $definition, $parents) {
+    // Anti-recursion, since we use the parent export helper.
+    unset($definition['export']);
+
+    // Find and remove all unselected/disabled operations.
+    foreach ($storage['vbo_operations'] as $operation_id => $operation) {
+      if (empty($operation['selected'])) {
+        unset($storage['vbo_operations'][$operation_id]);
+      }
+    }
+
+    return parent::export_option($indent, $prefix, $storage, $option, $definition, $parents);
   }
 
   function unpack_operations(&$translatable, $storage, $option, $definition, $parents, $keys) {
@@ -106,6 +122,12 @@ class views_bulk_operations_handler_field_operations extends views_handler_field
       '#title' => t('Enable "Select all items on all pages"'),
       '#default_value' => $this->options['vbo_settings']['enable_select_all_pages'],
       '#description' => t('Check this box to enable the ability to select all items on all pages.'),
+    );
+    $form['vbo_settings']['row_clickable'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Make the whole row clickable'),
+      '#default_value' => $this->options['vbo_settings']['row_clickable'],
+      '#description' => t('Check this box to select an item when its row has been clicked. Requires JavaScript.'),
     );
     $form['vbo_settings']['force_single'] = array(
       '#type' => 'checkbox',

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/views_bulk_operations.info
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/views_bulk_operations.info
@@ -9,9 +9,9 @@ php = 5.2.9
 files[] = plugins/operation_types/base.class.php
 files[] = views/views_bulk_operations_handler_field_operations.inc
 
-; Information added by Drupal.org packaging script on 2013-12-23
-version = "7.x-3.2"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-3.3"
 core = "7.x"
 project = "views_bulk_operations"
-datestamp = "1387798183"
+datestamp = "1435764542"
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/views_bulk_operations.module
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/views_bulk_operations.module
@@ -41,21 +41,20 @@ function views_bulk_operations_load_action_includes() {
   // The list of VBO actions is fairly static, so it's hardcoded for better
   // performance (hitting the filesystem with file_scan_directory(), and then
   // caching the result has its cost).
-  $path = drupal_get_path('module', 'views_bulk_operations') . '/actions/';
   $files = array(
-    'archive.action.inc',
-    'argument_selector.action.inc',
-    'book.action.inc',
-    'delete.action.inc',
-    'modify.action.inc',
-    'script.action.inc',
-    'user_roles.action.inc',
-    'user_cancel.action.inc',
+    'archive.action',
+    'argument_selector.action',
+    'book.action',
+    'delete.action',
+    'modify.action',
+    'script.action',
+    'user_roles.action',
+    'user_cancel.action',
   );
 
   if (!$loaded) {
     foreach ($files as $file) {
-      include_once $path . $file;
+      module_load_include('inc', 'views_bulk_operations', 'actions/' . $file);
     }
     $loaded = TRUE;
   }
@@ -77,7 +76,7 @@ function views_bulk_operations_load_action_includes() {
 function views_bulk_operations_cron() {
   db_delete('queue')
     ->condition('name', db_like('views_bulk_operations_active_queue_'), 'LIKE')
-    ->condition('created', REQUEST_TIME - 864000, '<')
+    ->condition('created', REQUEST_TIME - 86400, '<')
     ->execute();
 }
 
@@ -358,7 +357,7 @@ function views_bulk_operations_form_alter(&$form, &$form_state, $form_id) {
  */
 function views_bulk_operations_views_post_build(&$view) {
   $vbo = _views_bulk_operations_get_field($view);
-  if ($vbo && $vbo->get_selected_operations() < 1) {
+  if ($vbo && count($vbo->get_selected_operations()) < 1) {
     $vbo->options['exclude'] = TRUE;
   }
 }
@@ -420,7 +419,7 @@ function theme_views_bulk_operations_select_all($variables) {
     if ($enable_select_all_pages) {
       $form['select_all']['or'] = array(
         '#type' => 'markup',
-        '#markup' => '<em>OR</em>',
+        '#markup' => '<em>' . t('OR') . '</em>',
       );
       $form['select_all']['all_pages'] = array(
         '#type' => 'checkbox',
@@ -443,6 +442,13 @@ function theme_views_bulk_operations_select_all($variables) {
  */
 function views_bulk_operations_form($form, &$form_state, $vbo) {
   $form['#attached']['js'][] = drupal_get_path('module', 'views_bulk_operations') . '/js/views_bulk_operations.js';
+  $form['#attached']['js'][] = array(
+    'data' => array('vbo' => array(
+      'row_clickable' => $vbo->get_vbo_option('row_clickable'),
+    )),
+    'type' => 'setting',
+  );
+
   $form['#attached']['css'][] = drupal_get_path('module', 'views_bulk_operations') . '/css/views_bulk_operations.css';
   // Wrap the form in a div with specific classes for JS targeting and theming.
   $class = 'vbo-views-form';
@@ -595,13 +601,22 @@ function views_bulk_operations_confirm_form($form, &$form_state, $view, $output)
   $operation = $form_state['operation'];
   $rows = $form_state['selection'];
   $query = drupal_get_query_parameters($_GET, array('q'));
+  $title = t('Are you sure you want to perform %operation on the selected items?', array('%operation' => $operation->label()));
   $form = confirm_form($form,
-    t('Are you sure you want to perform %operation on the selected items?', array('%operation' => $operation->label())),
+    $title,
     array('path' => $view->get_url(), 'query' => $query),
     theme('views_bulk_operations_confirmation', array('rows' => $rows, 'vbo' => $vbo, 'operation' => $operation, 'select_all_pages' => $form_state['select_all_pages']))
   );
   // Add VBO's submit handler to the Confirm button added by config_form().
   $form['actions']['submit']['#submit'] = array('views_bulk_operations_form_submit');
+
+  // We can't set the View title here as $view is just a copy of the original,
+  // and our settings changes won't "stick" for the first page load of the
+  // confirmation form. We also can't just call drupal_set_title() directly
+  // because our title will be clobbered by the actual View title later. So
+  // let's tuck the title away in the form for use later.
+  // @see views_bulk_operations_preprocess_views_view()
+  $form['#vbo_confirm_form_title'] = $title;
 
   return $form;
 }
@@ -618,7 +633,7 @@ function theme_views_bulk_operations_confirmation($variables) {
   // Load the entities from the current page, and show their titles.
   $entities = _views_bulk_operations_entity_load($entity_type, array_values($rows), $vbo->revision);
   foreach ($entities as $entity) {
-    $items[] = check_plain(_views_bulk_operations_entity_label($entity_type, $entity));
+    $items[] = check_plain(entity_label($entity_type, $entity));
   }
   // All rows on all pages have been selected, so show a count of additional items.
   if ($select_all_pages) {
@@ -629,6 +644,29 @@ function theme_views_bulk_operations_confirmation($variables) {
   $count = format_plural(count($entities), 'item', '@count items');
   $output = theme('item_list', array('items' => $items, 'title' => t('You selected the following <strong>!count</strong>:', array('!count' => $count))));
   return $output;
+}
+
+/**
+ * Implements hook_preprocess_page().
+ *
+ * Hide action links on the configure and confirm pages.
+ */
+function views_bulk_operations_preprocess_page(&$variables) {
+  if (isset($_POST['select_all'], $_POST['operation'])) {
+    $variables['action_links'] = array();
+  }
+}
+
+/**
+ * Implements hook_preprocess_views_view().
+ */
+function views_bulk_operations_preprocess_views_view($variables) {
+  // If we've stored a title for the confirmation form, retrieve it here and
+  // retitle the View.
+  // @see views_bulk_operations_confirm_form()
+  if (array_key_exists('rows', $variables) && is_array($variables['rows']) && array_key_exists('#vbo_confirm_form_title', $variables['rows'])) {
+    $variables['view']->set_title($variables['rows']['#vbo_confirm_form_title']);
+  }
 }
 
 /**
@@ -871,7 +909,7 @@ function views_bulk_operations_adjust_selection($queue_name, $operation, $option
       'views_row' => array(),
       'position' => array(
         'current' => ++$context['sandbox']['progress'],
-        'total' => $view->total_rows,
+        'total' => $context['sandbox']['max'],
       ),
     );
     // Some operations require full selected rows.
@@ -1042,7 +1080,7 @@ function views_bulk_operations_queue_item_process($queue_item_data, &$log = NULL
       $arguments = array(
         '%operation' => $operation->label(),
         '@type' => $entity_type,
-        '%title' => _views_bulk_operations_entity_label($entity_type, $entity),
+        '%title' => entity_label($entity_type, $entity),
       );
 
       if ($log) {
@@ -1128,7 +1166,7 @@ function views_bulk_operations_direct_process($operation, $rows, $options) {
         $context['results']['log'][] = t('Skipped %operation on @type %title due to insufficient permissions.', array(
           '%operation' => $operation->label(),
           '@type' => $entity_type,
-          '%title' => _views_bulk_operations_entity_label($entity_type, $entity),
+          '%title' => entity_label($entity_type, $entity),
         ));
         unset($entities[$id]);
       }
@@ -1234,29 +1272,6 @@ function _views_bulk_operations_entity_load($entity_type, $ids, $revision = FALS
   }
 
   return $entities;
-}
-
-/**
- * Label function for entities.
- * Core entities don't declare the "label" key, so entity_label() fails,
- * and a fallback is needed. This function provides that fallback.
- */
-function _views_bulk_operations_entity_label($entity_type, $entity) {
-  $label = entity_label($entity_type, $entity);
-  if (!$label) {
-    $entity_info = entity_get_info($entity_type);
-    $id_key = $entity_info['entity keys']['id'];
-    // Many entity types (e.g. "user") have a name which fits the label perfectly.
-    if (isset($entity->name)) {
-      $label = $entity->name;
-    }
-    elseif (isset($entity->{$id_key})) {
-      // Fallback to the id key.
-      $label = $entity->{$id_key};
-    }
-  }
-
-  return $label;
 }
 
 /**


### PR DESCRIPTION
Upgraded the [Views Bulk Operations](https://www.drupal.org/project/views_bulk_operations) module to version **7.x-3.3**.

This is a security release.

Database schema updates
-----------------------
There are no database schema updates for this version.

Testing
-------
The functionality provided by this module is used primarily in the content administration screen in the Drupal admin interface:

https://admin.food.gov.uk/admin/content

It is also used on the Users page:

https://admin.food.gov.uk/admin/people

It provides fnctionality via the bulk update dropdown.

This should be tested once the module has been upgraded.

[ Partial fix for [#10297](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=795) ]