### PR TITLE
Develop: Upgrade Views Bulk Operations to 7.x-3.3

### DIFF
--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/archive.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/archive.action.inc
@@ -18,6 +18,7 @@ function views_bulk_operations_archive_action_info() {
       // "Create an advanced action" dropdown on admin/config/system/actions.
       'configurable' => FALSE,
       'vbo_configurable' => TRUE,
+      'behavior' => array('views_property'),
       'triggers' => array('any'),
     );
   }

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/book.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/book.action.inc
@@ -13,11 +13,13 @@ function views_bulk_operations_book_action_info() {
       'label' => t('Move to book'),
       'configurable' => TRUE,
       'behavior' => array('changes_property'),
+      'triggers' => array('any'),
     );
     $actions['views_bulk_operations_remove_from_book_action'] = array(
       'type' => 'node',
       'label' => t('Remove from book'),
       'configurable' => FALSE,
+      'triggers' => array('any'),
     );
   }
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/delete.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/delete.action.inc
@@ -19,6 +19,7 @@ function views_bulk_operations_delete_action_info() {
       'label' => t('Delete revision'),
       'configurable' => FALSE,
       'behavior' => array('deletes_property'),
+      'triggers' => array('any'),
     ),
   );
 }

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/modify.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/modify.action.inc
@@ -82,6 +82,11 @@ function views_bulk_operations_modify_action($entity, $context) {
     // The wrapper will automatically modify $entity itself.
     $wrapper = entity_metadata_wrapper($context['entity_type'], $entity);
     foreach ($context['selected']['properties'] as $key) {
+      if (!$wrapper->$key->access('update')) {
+        // No access.
+        continue;
+      }
+
       if (in_array($key, $context['append']['properties'])) {
         $old_values = $wrapper->$key->value();
         $wrapper->$key->set($context['properties'][$key]);
@@ -134,7 +139,7 @@ function views_bulk_operations_modify_action_form($context, &$form_state) {
   if (!empty($properties)) {
     $form['properties'] = array(
       '#type' => 'fieldset',
-      '#title' => 'Properties',
+      '#title' => t('Properties'),
     );
     $form['properties']['show_value'] = array(
       '#suffix' => '<div class="clearfix"></div>',
@@ -298,7 +303,7 @@ function views_bulk_operations_modify_action_form($context, &$form_state) {
     $token_type = str_replace('_', '-', $entity_type);
     $form['tokens'] = array(
       '#type' => 'fieldset',
-      '#title' => 'Available tokens',
+      '#title' => t('Available tokens'),
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
       '#weight' => 998,

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/user_cancel.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/user_cancel.action.inc
@@ -10,6 +10,7 @@ function views_bulk_operations_user_cancel_action_info() {
     'label' => t('Cancel user account'),
     'configurable' => TRUE,
     'behavior' => array('deletes_property'),
+    'triggers' => array('any'),
   ));
 }
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions/user_roles.action.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions/user_roles.action.inc
@@ -45,24 +45,19 @@ function views_bulk_operations_user_roles_action_submit($form, $form_state) {
   );
 }
 
-function views_bulk_operations_user_roles_action(&$user, $context) {
-  $roles = $user->roles;
-  $selected = (is_array($context['add_roles']) ? $context['add_roles'] : array()) +
-              (is_array($context['remove_roles']) ? $context['remove_roles'] : array());
-  $result = db_query("SELECT rid, name FROM {role} WHERE rid IN (:selected)", array(':selected' => array_keys($selected)));
-  foreach ($result as $role) {
-    if (isset($context['add_roles'][$role->rid])) {
-      $add_roles[$role->rid] = $role->name;
-    }
-    if (isset($context['remove_roles'][$role->rid])) {
-      $remove_roles[$role->rid] = $role->name;
-    }
+function views_bulk_operations_user_roles_action($user, $context) {
+  $wrapper = entity_metadata_wrapper('user', $user);
+  if (!$wrapper->roles->access("update")) {
+    // No access.
+    return;
   }
-  if (!empty($add_roles)) {
-    $roles += $add_roles;
+  $roles = $wrapper->roles->value();
+  if (is_array($context['add_roles'])) {
+    $roles = array_merge($roles, $context['add_roles']);
   }
-  if (!empty($remove_roles)) {
-    $roles = array_diff($roles, $remove_roles);
+  if (is_array($context['remove_roles'])) {
+    $roles = array_diff($roles, $context['remove_roles']);
   }
-  user_save($user, array('roles' => $roles));
+  $wrapper->roles->set($roles);
+  $wrapper->save();
 }

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/actions_permissions.info
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/actions_permissions.info
@@ -3,9 +3,9 @@ description = Provides permission-based access control for actions. Used by View
 package = Administration
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2013-12-23
-version = "7.x-3.2"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-3.3"
 core = "7.x"
 project = "views_bulk_operations"
-datestamp = "1387798183"
+datestamp = "1435764542"
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/js/views_bulk_operations.js
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/js/views_bulk_operations.js
@@ -46,21 +46,23 @@
     });
 
     // Set up the ability to click anywhere on the row to select it.
-    $('.views-table tbody tr', form).click(function(event) {
-      if (event.target.tagName.toLowerCase() != 'input' && event.target.tagName.toLowerCase() != 'a') {
-        $('input[id^="edit-views-bulk-operations"]:not(:disabled)', this).each(function() {
-          var checked = this.checked;
-          // trigger() toggles the checkmark *after* the event is set,
-          // whereas manually clicking the checkbox toggles it *beforehand*.
-          // that's why we manually set the checkmark first, then trigger the
-          // event (so that listeners get notified), then re-set the checkmark
-          // which the trigger will have toggled. yuck!
-          this.checked = !checked;
-          $(this).trigger('click');
-          this.checked = !checked;
-        });
-      }
-    });
+    if (Drupal.settings.vbo.row_clickable) {
+      $('.views-table tbody tr', form).click(function(event) {
+        if (event.target.tagName.toLowerCase() != 'input' && event.target.tagName.toLowerCase() != 'a') {
+          $('input[id^="edit-views-bulk-operations"]:not(:disabled)', this).each(function() {
+            var checked = this.checked;
+            // trigger() toggles the checkmark *after* the event is set,
+            // whereas manually clicking the checkbox toggles it *beforehand*.
+            // that's why we manually set the checkmark first, then trigger the
+            // event (so that listeners get notified), then re-set the checkmark
+            // which the trigger will have toggled. yuck!
+            this.checked = !checked;
+            $(this).trigger('click');
+            this.checked = !checked;
+          });
+        }
+      });
+    }
   }
 
   Drupal.vbo.tableSelectAllPages = function(form) {

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/plugins/operation_types/action.class.php
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/plugins/operation_types/action.class.php
@@ -20,7 +20,7 @@ class ViewsBulkOperationsAction extends ViewsBulkOperationsBaseOperation {
    */
   public function getAccessMask() {
     // Assume edit by default.
-    if (!isset($this->operationInfo['behavior'])) {
+    if (empty($this->operationInfo['behavior'])) {
       $this->operationInfo['behavior'] = array('changes_property');
     }
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/plugins/operation_types/rules_component.class.php
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/plugins/operation_types/rules_component.class.php
@@ -124,6 +124,8 @@ class ViewsBulkOperationsRulesComponent extends ViewsBulkOperationsBaseOperation
     else {
      $element = rules_action('component_' . $this->operationInfo['parameters']['component_key']);
     }
-    $element->execute($data);
+    $wrapper_type = is_array($data) ? "list<{$this->entityType}>" : $this->entityType;
+    $wrapper = entity_metadata_wrapper($wrapper_type, $data);
+    $element->execute($wrapper);
   }
 }

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/views/views_bulk_operations_handler_field_operations.inc
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/views/views_bulk_operations_handler_field_operations.inc
@@ -55,6 +55,7 @@ class views_bulk_operations_handler_field_operations extends views_handler_field
       'contains' => array(
         'display_type' => array('default' => 0),
         'enable_select_all_pages' => array('default' => TRUE),
+        'row_clickable' => array('default' => TRUE),
         'force_single' => array('default' => FALSE),
         'entity_load_capacity' => array('default' => 10),
         'skip_batching' => array('default' => 0),
@@ -63,9 +64,24 @@ class views_bulk_operations_handler_field_operations extends views_handler_field
     $options['vbo_operations'] = array(
       'default' => array(),
       'unpack_translatable' => 'unpack_operations',
+      'export' => 'export_vbo_operations',
     );
 
     return $options;
+  }
+
+  function export_vbo_operations($indent, $prefix, $storage, $option, $definition, $parents) {
+    // Anti-recursion, since we use the parent export helper.
+    unset($definition['export']);
+
+    // Find and remove all unselected/disabled operations.
+    foreach ($storage['vbo_operations'] as $operation_id => $operation) {
+      if (empty($operation['selected'])) {
+        unset($storage['vbo_operations'][$operation_id]);
+      }
+    }
+
+    return parent::export_option($indent, $prefix, $storage, $option, $definition, $parents);
   }
 
   function unpack_operations(&$translatable, $storage, $option, $definition, $parents, $keys) {
@@ -106,6 +122,12 @@ class views_bulk_operations_handler_field_operations extends views_handler_field
       '#title' => t('Enable "Select all items on all pages"'),
       '#default_value' => $this->options['vbo_settings']['enable_select_all_pages'],
       '#description' => t('Check this box to enable the ability to select all items on all pages.'),
+    );
+    $form['vbo_settings']['row_clickable'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Make the whole row clickable'),
+      '#default_value' => $this->options['vbo_settings']['row_clickable'],
+      '#description' => t('Check this box to select an item when its row has been clicked. Requires JavaScript.'),
     );
     $form['vbo_settings']['force_single'] = array(
       '#type' => 'checkbox',

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/views_bulk_operations.info
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/views_bulk_operations.info
@@ -9,9 +9,9 @@ php = 5.2.9
 files[] = plugins/operation_types/base.class.php
 files[] = views/views_bulk_operations_handler_field_operations.inc
 
-; Information added by Drupal.org packaging script on 2013-12-23
-version = "7.x-3.2"
+; Information added by Drupal.org packaging script on 2015-07-01
+version = "7.x-3.3"
 core = "7.x"
 project = "views_bulk_operations"
-datestamp = "1387798183"
+datestamp = "1435764542"
 

--- a/docroot/sites/all/modules/contrib/views_bulk_operations/views_bulk_operations.module
+++ b/docroot/sites/all/modules/contrib/views_bulk_operations/views_bulk_operations.module
@@ -41,21 +41,20 @@ function views_bulk_operations_load_action_includes() {
   // The list of VBO actions is fairly static, so it's hardcoded for better
   // performance (hitting the filesystem with file_scan_directory(), and then
   // caching the result has its cost).
-  $path = drupal_get_path('module', 'views_bulk_operations') . '/actions/';
   $files = array(
-    'archive.action.inc',
-    'argument_selector.action.inc',
-    'book.action.inc',
-    'delete.action.inc',
-    'modify.action.inc',
-    'script.action.inc',
-    'user_roles.action.inc',
-    'user_cancel.action.inc',
+    'archive.action',
+    'argument_selector.action',
+    'book.action',
+    'delete.action',
+    'modify.action',
+    'script.action',
+    'user_roles.action',
+    'user_cancel.action',
   );
 
   if (!$loaded) {
     foreach ($files as $file) {
-      include_once $path . $file;
+      module_load_include('inc', 'views_bulk_operations', 'actions/' . $file);
     }
     $loaded = TRUE;
   }
@@ -77,7 +76,7 @@ function views_bulk_operations_load_action_includes() {
 function views_bulk_operations_cron() {
   db_delete('queue')
     ->condition('name', db_like('views_bulk_operations_active_queue_'), 'LIKE')
-    ->condition('created', REQUEST_TIME - 864000, '<')
+    ->condition('created', REQUEST_TIME - 86400, '<')
     ->execute();
 }
 
@@ -358,7 +357,7 @@ function views_bulk_operations_form_alter(&$form, &$form_state, $form_id) {
  */
 function views_bulk_operations_views_post_build(&$view) {
   $vbo = _views_bulk_operations_get_field($view);
-  if ($vbo && $vbo->get_selected_operations() < 1) {
+  if ($vbo && count($vbo->get_selected_operations()) < 1) {
     $vbo->options['exclude'] = TRUE;
   }
 }
@@ -420,7 +419,7 @@ function theme_views_bulk_operations_select_all($variables) {
     if ($enable_select_all_pages) {
       $form['select_all']['or'] = array(
         '#type' => 'markup',
-        '#markup' => '<em>OR</em>',
+        '#markup' => '<em>' . t('OR') . '</em>',
       );
       $form['select_all']['all_pages'] = array(
         '#type' => 'checkbox',
@@ -443,6 +442,13 @@ function theme_views_bulk_operations_select_all($variables) {
  */
 function views_bulk_operations_form($form, &$form_state, $vbo) {
   $form['#attached']['js'][] = drupal_get_path('module', 'views_bulk_operations') . '/js/views_bulk_operations.js';
+  $form['#attached']['js'][] = array(
+    'data' => array('vbo' => array(
+      'row_clickable' => $vbo->get_vbo_option('row_clickable'),
+    )),
+    'type' => 'setting',
+  );
+
   $form['#attached']['css'][] = drupal_get_path('module', 'views_bulk_operations') . '/css/views_bulk_operations.css';
   // Wrap the form in a div with specific classes for JS targeting and theming.
   $class = 'vbo-views-form';
@@ -595,13 +601,22 @@ function views_bulk_operations_confirm_form($form, &$form_state, $view, $output)
   $operation = $form_state['operation'];
   $rows = $form_state['selection'];
   $query = drupal_get_query_parameters($_GET, array('q'));
+  $title = t('Are you sure you want to perform %operation on the selected items?', array('%operation' => $operation->label()));
   $form = confirm_form($form,
-    t('Are you sure you want to perform %operation on the selected items?', array('%operation' => $operation->label())),
+    $title,
     array('path' => $view->get_url(), 'query' => $query),
     theme('views_bulk_operations_confirmation', array('rows' => $rows, 'vbo' => $vbo, 'operation' => $operation, 'select_all_pages' => $form_state['select_all_pages']))
   );
   // Add VBO's submit handler to the Confirm button added by config_form().
   $form['actions']['submit']['#submit'] = array('views_bulk_operations_form_submit');
+
+  // We can't set the View title here as $view is just a copy of the original,
+  // and our settings changes won't "stick" for the first page load of the
+  // confirmation form. We also can't just call drupal_set_title() directly
+  // because our title will be clobbered by the actual View title later. So
+  // let's tuck the title away in the form for use later.
+  // @see views_bulk_operations_preprocess_views_view()
+  $form['#vbo_confirm_form_title'] = $title;
 
   return $form;
 }
@@ -618,7 +633,7 @@ function theme_views_bulk_operations_confirmation($variables) {
   // Load the entities from the current page, and show their titles.
   $entities = _views_bulk_operations_entity_load($entity_type, array_values($rows), $vbo->revision);
   foreach ($entities as $entity) {
-    $items[] = check_plain(_views_bulk_operations_entity_label($entity_type, $entity));
+    $items[] = check_plain(entity_label($entity_type, $entity));
   }
   // All rows on all pages have been selected, so show a count of additional items.
   if ($select_all_pages) {
@@ -629,6 +644,29 @@ function theme_views_bulk_operations_confirmation($variables) {
   $count = format_plural(count($entities), 'item', '@count items');
   $output = theme('item_list', array('items' => $items, 'title' => t('You selected the following <strong>!count</strong>:', array('!count' => $count))));
   return $output;
+}
+
+/**
+ * Implements hook_preprocess_page().
+ *
+ * Hide action links on the configure and confirm pages.
+ */
+function views_bulk_operations_preprocess_page(&$variables) {
+  if (isset($_POST['select_all'], $_POST['operation'])) {
+    $variables['action_links'] = array();
+  }
+}
+
+/**
+ * Implements hook_preprocess_views_view().
+ */
+function views_bulk_operations_preprocess_views_view($variables) {
+  // If we've stored a title for the confirmation form, retrieve it here and
+  // retitle the View.
+  // @see views_bulk_operations_confirm_form()
+  if (array_key_exists('rows', $variables) && is_array($variables['rows']) && array_key_exists('#vbo_confirm_form_title', $variables['rows'])) {
+    $variables['view']->set_title($variables['rows']['#vbo_confirm_form_title']);
+  }
 }
 
 /**
@@ -871,7 +909,7 @@ function views_bulk_operations_adjust_selection($queue_name, $operation, $option
       'views_row' => array(),
       'position' => array(
         'current' => ++$context['sandbox']['progress'],
-        'total' => $view->total_rows,
+        'total' => $context['sandbox']['max'],
       ),
     );
     // Some operations require full selected rows.
@@ -1042,7 +1080,7 @@ function views_bulk_operations_queue_item_process($queue_item_data, &$log = NULL
       $arguments = array(
         '%operation' => $operation->label(),
         '@type' => $entity_type,
-        '%title' => _views_bulk_operations_entity_label($entity_type, $entity),
+        '%title' => entity_label($entity_type, $entity),
       );
 
       if ($log) {
@@ -1128,7 +1166,7 @@ function views_bulk_operations_direct_process($operation, $rows, $options) {
         $context['results']['log'][] = t('Skipped %operation on @type %title due to insufficient permissions.', array(
           '%operation' => $operation->label(),
           '@type' => $entity_type,
-          '%title' => _views_bulk_operations_entity_label($entity_type, $entity),
+          '%title' => entity_label($entity_type, $entity),
         ));
         unset($entities[$id]);
       }
@@ -1234,29 +1272,6 @@ function _views_bulk_operations_entity_load($entity_type, $ids, $revision = FALS
   }
 
   return $entities;
-}
-
-/**
- * Label function for entities.
- * Core entities don't declare the "label" key, so entity_label() fails,
- * and a fallback is needed. This function provides that fallback.
- */
-function _views_bulk_operations_entity_label($entity_type, $entity) {
-  $label = entity_label($entity_type, $entity);
-  if (!$label) {
-    $entity_info = entity_get_info($entity_type);
-    $id_key = $entity_info['entity keys']['id'];
-    // Many entity types (e.g. "user") have a name which fits the label perfectly.
-    if (isset($entity->name)) {
-      $label = $entity->name;
-    }
-    elseif (isset($entity->{$id_key})) {
-      // Fallback to the id key.
-      $label = $entity->{$id_key};
-    }
-  }
-
-  return $label;
 }
 
 /**

--- a/docroot/sites/all/modules/custom/fsa_feedback/fsa_feedback.module
+++ b/docroot/sites/all/modules/custom/fsa_feedback/fsa_feedback.module
@@ -77,6 +77,21 @@ function fsa_feedback_page_build(&$page) {
  */
 function fsa_feedback_form_feedback_form_alter(&$form, &$form_state, $form_id) {
 
+  // We want to capture the full originating URL, including any query string
+  // variables. This will help when analysing feedback from pages that
+  // incorporate a query string in their URLs, eg search.
+  // @see #10287 - https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=785
+
+  // First get the current page path
+  $page_path = current_path();
+  // Now get the query string - minus the standard Drupal params
+  $query_string = drupal_get_query_parameters();
+  // Construct a URL using url(), but trim off the initial slash
+  $page_url = ltrim(url($page_path, array('query' => $query_string)), '/');
+  // Amend the values of the page URL in the $form and $form_state arrays.
+  $form_state['inline']['location'] = $page_url;
+  $form['location']['#value'] = $page_url;
+
   // Give the form a class to enable FSA styling to be applied.
   $form['#attributes']['class'][] = 'custom-block-inner';
 
@@ -249,6 +264,29 @@ function fsa_feedback_form_submit($form, &$form_state) {
   entity_form_submit_build_entity('feedback', $entry, $form, $form_state);
   $entry->message = $form_state['values']['message'];
   $entry->location = $form_state['values']['location'];
+
+  // The standard `feedback_save()` function doesn't cater for URLs that contain
+  // query strings. To overcome this issue, we set the url property here. This
+  // prevents the save function from trying to re-set it.
+  // @see #10287 - https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=785
+  // Parse the location URL to get path and query string.
+  $path_parts = !empty($entry->location) ? drupal_parse_url($entry->location) : array();
+  // Create some options suitable for passing to Drupals `url()` function.
+  $url_options = array(
+    'absolute' => TRUE,
+    'query' => !empty($path_parts['query']) ? $path_parts['query'] : array(),
+  );
+  // Get the path part of the URL
+  $path = !empty($path_parts['path']) ? $path_parts['path'] : '';
+  // Set the url property of the entry using `url()`.
+  $entry->url = url($path, $url_options);
+
+  // Unset URL if it's blank, otherwise it doesn't get set as part of
+  // feedback_save().
+  if (isset($entry->url) && empty($entry->url)) {
+    unset($entry->url);
+  }
+
   feedback_save($entry);
 
   // Set the thankyou message for the user. The message is passed from the form,

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.admin.inc
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @file
+ * Administration functions for the FSA filename validation module
+ */
+
+/**
+ * Form builder: filename validation configuration form
+ */
+function fsa_filename_validation_configuration_form($form, &$form_state) {
+
+  $form['intro'] = array(
+    '#prefix' => '<p>',
+    '#markup' => t('Filename validators allow you to control the names of files that can be uploaded to Drupal.'),
+    '#suffix' => '</p>',
+  );
+
+  // Get the validators
+  $validators = _fsa_filename_validation_get_validators();
+
+  // Fieldset for enabled validators
+  $form['enabled_validators'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Enabled validators'),
+    '#description' => t('There are no currently active validators.'),
+  );
+
+  // Fieldset for disabled validators
+  $form['disabled_validators'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Disabled validators'),
+    '#description' => t('These validators are currently disabled.'),
+  );
+
+  $active_validators = array();
+
+  foreach ($validators as $key => $validator) {
+
+    $enabled = $validator['enabled'];
+    $container = $enabled ? 'enabled_validators' : 'disabled_validators';
+
+    if ($enabled) {
+      $active_validators[] = $key;
+    }
+
+    $form[$container]["${key}_container"] = array(
+      '#type' => 'fieldset',
+      '#title' => $validator['name'],
+      '#description' => !empty($validator['description']) ? $validator['description'] : NULL,
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+    );
+
+    $form[$container]["${key}_container"]["filename_validator_${key}_enabled"] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Enabled'),
+      '#default_value' => $enabled,
+    );
+
+    if (!empty($validator['settings_form'])) {
+      foreach ($validator['settings_form'] as $element => $settings) {
+        $settings['#default_value'] = variable_get("filename_validator_${key}_$element", !empty($settings['#default_value']) ? $settings['#default_value'] : NULL);
+        $form[$container]["${key}_container"]["filename_validator_${key}_$element"] = $settings;
+      }
+    }
+
+
+  }
+
+  if (count($active_validators) > 0) {
+    $form['enabled_validators']['#description'] = format_plural(count($active_validators), 'The following validator is currently active.', 'The following validators are currently active.');
+  }
+
+  if (count($active_validators) == count($validators)) {
+    $form['disabled_validators']['#description'] = t('There are no disabled validators.');
+  }
+  else {
+    $form['disabled_validators']['#description'] = format_plural(count($validators) - count($active_validators), 'This validator is currently disabled.', 'These validators are currently disabled.');
+  }
+
+  return system_settings_form($form);
+}

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.api.php
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.api.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the FSA Filename validation module.
+ */
+
+/**
+ * Provide additional filename validators
+ *
+ * By implementing this hook, you can provide additional validators to be used
+ * when uploading files to Drupal.
+ *
+ * Your implementation should return an associative array of validators, each of
+ * which is itself an array as described below.
+ *
+ * @return array
+ *   Array of validators. Each element is itself an array with the following
+ *   elements:
+ *   - name: The translated human-readable name of the validator. This is
+ *     displayed on the administration page
+ *   - description: (optional) A description of what the validator does
+ *   - pattern: (optional) A regex pattern to be used against the filename. This
+ *     is mandatory for validators of type 'regex', which is the default.
+ *   - error_message: The translated error message to display to users. This is
+ *     mandatory unless 'error_message_callback' is provided.
+ *   - replacement: Not currently in use
+ *   - type: The type of validator. Currently recognised types are 'regex',
+ *     'maxlength', 'lowercase', 'custom'.
+ *   - autocorrect: Not currently in use
+ *   - settings_form: Used to add a settings form for use in the administration
+ *     interface. This should be a standard Drupal Form API render array.
+ *   - callback: A custom callback function. Should be used only with validators
+ *     of type 'custom'.
+ *   - arguments: An array of arguments to be passed to the callback function.
+ *     These can be standard variables or settings for the validator. To include
+ *     a user-specified setting, prefix it with 'setting:' eg
+ *     'setting:characters'
+ *   - error_message_callback: A function for generating custom error messages
+ *   - error_message_arguments: An array of arguments to be passed to the
+ *     custom error message function
+ *   - help: Help text to tell users uploading files about the validation
+ *     conditions that apply.
+ *   - help_callback: A function for generating help text
+ *   - help_arguments: An array of arguments to be passed to the help_callback
+ *     function
+ */
+function hook_filename_validators() {
+  $validators = array();
+
+  $validators['no_whitespace'] = array(
+    'name' => t('No whitespace'),
+    'description' => t('Will not allow filenames that contain white space such as spaces, tabs and new lines.'),
+    'pattern' => "/\s/",
+    'error_message' => t('The filename should not contain any spaces.'),
+    'replacement' => '-',
+    'autocorrect' => TRUE,
+  );
+
+  $validators['alphanumeric'] = array(
+    'name' => t('Alphanumeric characters only'),
+    'description' => t('Allows only letters, numbers and the full stop (dot) character. Be aware that this validator will not allow filenames with spaces.'),
+    'pattern' => "/[^a-z|A-Z|0-9|\.]/",
+    'error_message' => t('The filename should contain only alphanumeric characters'),
+  );
+
+  $validators['max_length'] = array(
+    'name' => t('Maximum filename length'),
+    'description' => t('Restricts filenames to a specified maximum length.'),
+    'type' => 'maxlength',
+    'maxlength' => 10,
+    'error_message' => t('The filename should contain no more than '),
+    'settings_form' => array(
+      'max_length' => array(
+        '#type' => 'textfield',
+        '#size' => 3,
+        '#title' => t('Maximum number of characters allowed'),
+        '#default_value' => 10,
+      ),
+    ),
+  );
+
+  $validators['lowercase'] = array(
+    'name' => t('All lowercase'),
+    'description' => t('Allows only lowercase letters in filenames.'),
+    'type' => 'lowercase',
+    'error_message' => t('Filenames should be all lowercase.'),
+  );
+
+  $validators['exclude_characters'] = array(
+    'name' => t('Exclude these characters'),
+    'description' => t('Allows specified characters to be excluded from filenames.'),
+    'type' => 'custom',
+    'callback' => '_fsa_filename_validation_exclude_characters',
+    'arguments' => array("settings:excluded_characters"),
+    'error_message' => t('Sorry, the filename contains invalid characters'),
+    'error_message_callback' => '_fsa_filename_validation_exclude_characters_error',
+    'error_message_arguments' => array("settings:excluded_characters"),
+    'settings_form' => array(
+      'excluded_characters' => array(
+        '#type' => 'textfield',
+        '#title' => t('Characters to be excluded'),
+        '#description' => t('Enter a list of characters to exclude. Leave one space between each character.')
+      ),
+    ),
+  );
+
+  return $validators;
+}
+
+
+/**
+ * Alter the array of validators
+ *
+ * This hook is called by _fsa_filename_validation_get_validators() the first
+ * time it is run during any page request. It is passed the full validators
+ * array, which has already been populated with any settings saved in the
+ * database.
+ *
+ * @param array $validators
+ *   Associative array of filename validators, passed by reference. Validator
+ *   settings have already been retrieved from the database, as have validator
+ *   statuses, so this hook could be used to turn validators on or off if
+ *   required, overriding user settings.
+ *
+ */
+function hook_filename_validators_alter(&$validators) {
+  // Override help text
+  if (!empty($validators['no_whitespace'])) {
+    $validators['no_whitespace']['help'] = t('Filenames cannot contain any whitespace characters.');
+  }
+  // Turn off a validator
+  if (!empty($validators['exclude_characters'])) {
+    $validators['exclude_characters']['enabled'] = FALSE;
+  }
+}
+
+
+/**
+ * Alter the help text for a given validator
+ *
+ * Help text for a validator is displayed beneath the file upload form element.
+ * It explains validation criteria to the user before they attempt to upload a
+ * file.
+ *
+ * Using this hook, you can alter the help text for a specified validator.
+ *
+ * @param string $help_text
+ *   The current help text assigned to the validator (passed by reference).
+ * @param string $key
+ *   The array key of the specified validator. Using
+ *   _fsa_filename_validation_get_validator($key), you can retrieve the full
+ *   validator properties.
+ */
+function hook_filename_validation_help_alter(&$help_text, $key) {
+  // Load the validator details.
+  $validator = _fsa_filename_validation_get_validator($key);
+  switch ($key) {
+    case 'max_length':
+      $maxlength = !empty($validator['settings']['max_length']) ? $validator['settings']['max_length'] : $validator['maxlength'];
+      $help_text = t('Your filename cannot have more than @maxlength characters, including the extension.', array('@maxlength' => $maxlength));
+      break;
+  }
+}
+
+
+/**
+ * Alter error messages displayed when filename validation fails.
+ *
+ * @param string $error_message
+ *   The existing error message after all othe processing has taken place
+ * @param string $key
+ *   The key of the validator that defines the error message
+ */
+function hook_filename_validation_error_alter(&$error_message, $key) {
+  if ($key == 'alphanumeric') {
+    $error_message .= '!';
+  }
+}

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.info
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.info
@@ -1,0 +1,5 @@
+name = FSA File validation
+description = "Adds validation functions to files being uploaded to Drupal"
+core = 7.x
+package = FSA Custom
+configure = admin/config/media/file-settings/validation

--- a/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.module
+++ b/docroot/sites/all/modules/custom/fsa_filename_validation/fsa_filename_validation.module
@@ -1,0 +1,590 @@
+<?php
+/**
+ * @file
+ * Module code for the FSA file validation module.
+ *
+ * This module provides an extensible validation engine for filenames of
+ * uploaded files. In addition to the built-in validators, more can be added
+ * through the use of hook_filename_validators().
+ */
+
+
+/**
+ * Implements hook_permission().
+ */
+function fsa_filename_validation_permission() {
+  return array(
+    'administer filename validation' => array(
+      'title' => t('Administer filename validation'),
+      'description' => t('Change settings for filename validation.'),
+    )
+  );
+}
+
+
+/**
+ * Implements hook_menu().
+ */
+function fsa_filename_validation_menu() {
+  $items = array();
+
+  // Default settings if the file_entity module is not avaiable.
+  $file_entity = FALSE;
+  $admin_menu_link = 'admin/config/media/file-validation';
+
+  // Default local task for the existing file_entity admin form. We add this so
+  // that we can provide navigational tabs in the admin UI.
+  if (module_exists('file_entity')) {
+    $items['admin/config/media/file-settings/default'] = array(
+      'type' => MENU_DEFAULT_LOCAL_TASK,
+      'title' => t('File settings'),
+    );
+    // If the file_entity module exists, we change the menu settings.
+    $file_entity = TRUE;
+    $admin_menu_link = 'admin/config/media/file-settings/validation';
+  }
+
+  // Administration menu link. This is where the validators are enabled,
+  // disabled and configured.
+  $items[$admin_menu_link] = array(
+    'title' => t('Filename validation settings'),
+    'description' => t('Administer filename validation settings'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('fsa_filename_validation_configuration_form'),
+    'access arguments' => array('administer filename validation'),
+    'file' => 'fsa_filename_validation.admin.inc',
+    'type' => $file_entity ? MENU_LOCAL_TASK : MENU_NORMAL_ITEM,
+  );
+
+  return $items;
+}
+
+
+/**
+ * Implements hook_menu_alter().
+ */
+function fsa_filename_validation_menu_alter(&$items) {
+  // If the file_entity module is enabled, add a mention of filename validation
+  // to its description, together with a link to the admin config form.
+  if (!empty($items['admin/config/media/file-settings'])) {
+    $items['admin/config/media/file-settings']['description'] .= ' ' . t('Also configure <a href="@config_link">filename validation</a>.', array('@config_link' => url('admin/config/media/file-settings/validation')));
+  }
+}
+
+
+/**
+ * Implements hook_theme_registry_alter().
+ */
+function fsa_filename_validation_theme_registry_alter(&$theme_registry) {
+  if (empty($theme_registry['file_upload_help'])) {
+    return;
+  }
+  // Override the existing theme function for file upload help text.
+  $theme_registry['file_upload_help']['function'] = 'fsa_filename_validation_theme_file_upload_help';
+}
+
+
+/**
+ * Theme function - override for theme_file_upload_help().
+ *
+ * This function provides text below the file upload form element, explaining
+ * validation criteria for files. This is an override for the existing theme
+ * function, but we call that function first to get the default text.
+ *
+ * @param array $variables
+ *   Array of theming variables
+ *
+ * @return string
+ *   HTML code for the file upload help text
+ *
+ * @see theme_file_upload_help().
+ */
+function fsa_filename_validation_theme_file_upload_help($variables) {
+
+  // Call the default theme implementation to get the standard help text. We'll
+  // add our custom help text after it.
+  $help = theme_file_upload_help($variables);
+
+  // Get the enabled validators
+  $enabled_validators = _fsa_filename_validation_enabled_validators();
+
+  // Now we'll add any custom help text from our validators.
+  $help_messages = array();
+
+  // Loop through the enabled validators
+  foreach ($enabled_validators as $key => $validator) {
+
+    // Special treatment for some validator types.
+    switch ($validator['type']) {
+      case 'maxlength':
+        $maxlength = variable_get("filename_validator_${key}_max_length", $validator['maxlength']);
+        $validator['help'] = t('Filenames are limited to @maxlength characters.', array('@maxlength' => $maxlength));
+        break;
+    }
+
+    // If we have a help callback, use it.
+    if (!empty($validator['help_callback']) && function_exists($validator['help_callback'])) {
+      $arguments = !empty($validator['help_arguments']) ? $validator['help_arguments'] : array();
+      foreach ($arguments as $index => $argument) {
+        if (strpos($argument, 'settings:') !== FALSE) {
+          $arguments[$index] = variable_get("filename_validator_${key}_" . str_replace('settings:', '', $argument));
+        }
+      }
+      $validator['help'] = call_user_func_array($validator['help_callback'], $arguments);
+    }
+
+    // Add the help message to our message array.
+    if (!empty($validator['help'])) {
+      // Allow modules to alter the help text
+      drupal_alter('filename_validation_help', $validator['help'], $key);
+      $help_messages[] = $validator['help'];
+    }
+  }
+
+  // Join the message array with line breaks
+  $help .= '<br>' . implode('<br>', $help_messages);
+
+  // Return the help messages
+  return $help;
+}
+
+
+/**
+ * Implements hook_file_validate().
+ *
+ * This is where the actual filename validation takes place.
+ *
+ * @param object $file
+ *   Object corresponding to the file being uploaded
+ *
+ * @return array
+ *   An array of error messages
+ *
+ * @see _fsa_filename_validation_enabled_validators().
+ * @see hook_filename_validators().
+ *
+ */
+function fsa_filename_validation_file_validate($file) {
+
+  // Create an array to hold the errors. This is what we return at the end.
+  $errors = array();
+
+  // Get the enabled validators - invokes hook_filename_validators()
+  $validators = _fsa_filename_validation_enabled_validators();
+
+  // Call the enabled validators
+  foreach ($validators as $key => $validator) {
+
+    // Is there an error?
+    $error = FALSE;
+
+    // Error message
+    $error_message = '';
+
+    switch($validator['type']) {
+
+      // Simple regex match - if the pattern matches, there's an error.
+      case 'regex':
+        if (preg_match($validator['pattern'], $file->filename)) {
+          $error = TRUE;
+        }
+        break;
+
+      // Maximum filename length
+      case 'maxlength':
+        $maxlength = !empty($validator['settings']['max_length']) ? $validator['settings']['max_length'] : $validator['maxlength'];
+        if (strlen($file->filename) > $maxlength) {
+          // Set a custom error message to include the maximum characters.
+          $error_message = $validator['error_message'] . t('@maxlength characters.', array('@maxlength' => $maxlength));
+          $error = TRUE;
+        }
+        break;
+
+      // All filenames should be lowercase
+      case 'lowercase':
+        if (!_fsa_filename_validation_lowercase($file->filename)) {
+          $error = TRUE;
+        }
+        break;
+
+      // Custom validation
+      case 'custom':
+        // Get the name of the callback function, if set.
+        $callback = !empty($validator['callback']) ? $validator['callback'] : NULL;
+        // If no callback is specified, skip this validator
+        if (empty($callback) || !function_exists($callback)) {
+          continue;
+        }
+        // Get the arguments - if specified
+        $arguments = !empty($validator['arguments']) ? $validator['arguments'] : array();
+
+        // See if any of the arguments come from a config seting.
+        foreach ($arguments as $index => $argument) {
+          if (strpos($argument, 'settings:') !== FALSE) {
+            $arguments[$index] = variable_get("filename_validator_${key}_" . str_replace('settings:', '', $argument));
+          }
+        }
+
+        // Add the filename as the final argument
+        $arguments[] = $file->filename;
+
+        // Call the callback function
+        if (call_user_func_array($callback, $arguments)) {
+          $error = TRUE;
+        }
+        break;
+    }
+
+    // If we have an error, we need to add an error message.
+    if ($error) {
+      // If we have a custom error message callback, call it now.
+      if (!empty($validator['error_message_callback']) && function_exists($validator['error_message_callback'])) {
+        $arguments = !empty($validator['error_message_arguments']) ? $validator['error_message_arguments'] : array();
+        foreach ($arguments as $index => $argument) {
+          if (strpos($argument, 'settings:') !== FALSE) {
+            $arguments[$index] = variable_get("filename_validator_${key}_" . str_replace('settings:', '', $argument));
+          }
+        }
+        $error_message = call_user_func_array($validator['error_message_callback'], $arguments);
+      }
+
+      // Add the error message to the output
+      $error_message = !empty($error_message) ? $error_message : $validator['error_message'];
+      // Allow modules to alter the error message
+      drupal_alter('filename_validation_error', $error_message, $key);
+      // Add the error message to the return array.
+      $errors[] = $error_message;
+    }
+  }
+
+  // Return the errors
+  return $errors;
+}
+
+
+/**
+ * Implements hook_filename_validators().
+ *
+ * Returns an array of validators to be used.
+ *
+ * @return array
+ *   Array of validators. Each element is itself an array with the following
+ *   elements:
+ *   - name: The translated human-readable name of the validator. This is
+ *     displayed on the administration page
+ *   - description: (optional) A description of what the validator does
+ *   - pattern: (optional) A regex pattern to be used against the filename. This
+ *     is mandatory for validators of type 'regex', which is the default.
+ *   - error_message: The translated error message to display to users. This is
+ *     mandatory unless 'error_message_callback' is provided.
+ *   - replacement: Not currently in use
+ *   - type: The type of validator. Currently recognised types are 'regex',
+ *     'maxlength', 'lowercase', 'custom'.
+ *   - autocorrect: Not currently in use
+ *   - settings_form: Used to add a settings form for use in the administration
+ *     interface. This should be a standard Drupal Form API render array.
+ *   - callback: A custom callback function. Should be used only with validators
+ *     of type 'custom'.
+ *   - arguments: An array of arguments to be passed to the callback function.
+ *     These can be standard variables or settings for the validator. To include
+ *     a user-specified setting, prefix it with 'setting:' eg
+ *     'setting:characters'
+ *   - error_message_callback: A function for generating custom error messages
+ *   - error_message_arguments: An array of arguments to be passed to the
+ *     custom error message function
+ *   - help: Help text to tell users uploading files about the validation
+ *     conditions that apply. Note that this element is not required for
+ *     validators of type 'maxlength' as this is created dynamically.
+ *   - help_callback: A function for generating help text
+ *   - help_arguments: An array of arguments to be passed to the help_callback
+ *     function
+ */
+function fsa_filename_validation_filename_validators() {
+  $validators = array();
+
+  $validators['no_whitespace'] = array(
+    'name' => t('No whitespace'),
+    'description' => t('Will not allow filenames that contain white space such as spaces, tabs and new lines.'),
+    'pattern' => "/\s/",
+    'error_message' => t('The filename should not contain any spaces.'),
+    'replacement' => '-',
+    'autocorrect' => TRUE,
+    'help' => t('Filenames cannot contain spaces or tabs.'),
+  );
+
+  $validators['alphanumeric'] = array(
+    'name' => t('Alphanumeric characters only'),
+    'description' => t('Allows only letters, numbers and the full stop (dot) character. Be aware that this validator will not allow filenames with spaces.'),
+    'pattern' => "/[^a-z|A-Z|0-9|\.]/",
+    'error_message' => t('The filename should contain only alphanumeric characters.'),
+    'help' => t('Filenames can contain only letters, numbers and full stops.'),
+  );
+
+  $validators['max_length'] = array(
+    'name' => t('Maximum filename length'),
+    'description' => t('Restricts filenames to a specified maximum length.'),
+    'type' => 'maxlength',
+    'maxlength' => 10,
+    'error_message' => t('The filename should contain no more than '),
+    'settings_form' => array(
+      'max_length' => array(
+        '#type' => 'textfield',
+        '#size' => 3,
+        '#title' => t('Maximum number of characters allowed'),
+        '#default_value' => 10,
+      ),
+    ),
+  );
+
+  $validators['lowercase'] = array(
+    'name' => t('All lowercase'),
+    'description' => t('Allows only lowercase letters in filenames.'),
+    'help' => t('Filenames should be all in lower case.'),
+    'type' => 'lowercase',
+    'error_message' => t('Filenames should be all lowercase.'),
+  );
+
+  $validators['exclude_characters'] = array(
+    'name' => t('Exclude these characters'),
+    'description' => t('Allows specified characters to be excluded from filenames.'),
+    'type' => 'custom',
+    'callback' => '_fsa_filename_validation_exclude_characters',
+    'arguments' => array("settings:excluded_characters"),
+    'error_message' => t('Sorry, the filename contains invalid characters'),
+    'error_message_callback' => '_fsa_filename_validation_exclude_characters_error',
+    'error_message_arguments' => array("settings:excluded_characters"),
+    'help_callback' => '_fsa_filename_validation_exclude_characters_help',
+    'help_arguments' => array("settings:excluded_characters"),
+    'settings_form' => array(
+      'excluded_characters' => array(
+        '#type' => 'textfield',
+        '#title' => t('Characters to be excluded'),
+        '#description' => t('Enter a list of characters to exclude. Leave one space between each character.')
+      ),
+    ),
+  );
+
+  return $validators;
+}
+
+
+/**
+ * Validation callback - exclude specified characters
+ *
+ * @param string $characters
+ *   The set of characters to be excluded from filenames, separated by spaces
+ *
+ * @param string $filename
+ *   The name of the file
+ *
+ * @return boolean
+ *   TRUE if the excluded characters are found in the filename, FALSE otherwise
+ */
+function _fsa_filename_validation_exclude_characters($characters, $filename) {
+
+  // If we don't have a pattern or a filename, return FALSE now.
+  if (empty($characters) || empty($filename)) {
+    return FALSE;
+  }
+
+  $characters = trim($characters);
+
+  // Define an array of potential delimiters
+  $delimiters = array('/', '@', '#', '~');
+  $delimiter = NULL;
+
+  // Find a delimiter that's not in the set of characters supplied
+  foreach ($delimiters as $d) {
+    if (strpos($characters, $d) === FALSE) {
+      $delimiter = $d;
+      break;
+    }
+  }
+
+  $pattern = '';
+  $character_array = explode(' ', $characters);
+  foreach ($character_array as $character) {
+    $pattern .= ctype_alnum($character) ? $character : '\\' . trim($character);
+  }
+  $pattern = "${delimiter}[" . trim($pattern) . "]${delimiter}";
+  return preg_match($pattern, $filename);
+}
+
+
+/**
+ * Error message callback function, excluded characters
+ *
+ * @param string $characters
+ *   The set of excluded characters for this validator
+ *
+ * @return string
+ *   The error message to be displayed to the user
+ *
+ */
+function _fsa_filename_validation_exclude_characters_error($characters) {
+  return t('Sorry, the filename cannot contain any of these characters %characters', array('%characters' => $characters));
+}
+
+/**
+ * Help text callback for excluded characters validator
+ *
+ * @param string $characters
+ *   The set of excluded characters for this validator
+ *
+ * @return string
+ *   The help text to be displayed to the user on the file upload form
+ */
+function _fsa_filename_validation_exclude_characters_help($characters) {
+  return t('Filenames should not contain any of these characters %characters.', array('%characters' => $characters));
+}
+
+
+/**
+ * Validation callback function - all lowercase
+ *
+ * @param string $filename
+ *   The name of the file
+ *
+ * @return boolean
+ *   TRUE if all letters in the filename are lowercase, FALSE otherwise.
+ *
+ * We use this instead of PHP's ctype_lower() function, because we don't want
+ * files that contain non-alpha characters, such as . to fail validation.
+ */
+function _fsa_filename_validation_lowercase($filename) {
+  return $filename == strtolower($filename);
+}
+
+
+/**
+ * Helper function: returns an array of enabled validators
+ * 
+ * @return array
+ *   An array of enabled validators, each of which is an associative array
+ * 
+ * @see _fsa_filename_validation_get_validators().
+ * @see hook_filename_validators().
+ * @see hook_filename_validators_alter().
+ */
+function _fsa_filename_validation_enabled_validators() {
+  // An array to hold the enabled validators
+  $enabled_validators = array();
+
+  // Invoke hook_filename_validators().
+  $validators = _fsa_filename_validation_get_validators();
+
+  foreach ($validators as $key => $validator) {
+    // Determine whether the validator is currently enabled.
+    if ($enabled = variable_get("filename_validator_${key}_enabled", FALSE)) {
+      $enabled_validators[$key] = $validator;
+    }
+  }
+  return $enabled_validators;
+}
+
+
+/**
+ * Helper function: provides a list of validators
+ *
+ * Invokes hook_filename_validators() to create a list of all available
+ * validators. Uses drupal_static() to cache the list, so it's generated only
+ * once per page request.
+ * 
+ * @return array
+ *   An array of enabled validators, each of which is an associative array
+ * 
+ * @see hook_filename_validators().
+ * @see hook_filename_validators_alter().
+ */
+function _fsa_filename_validation_get_validators() {
+  // Use drupal_static() to avoid calling all hooks repeatedly.
+  $validators = &drupal_static(__FUNCTION__);
+  if (empty($validators)) {
+    // Default validator settings
+    $validator_defaults = array(
+      'type' => 'regex',
+    );
+    // Invoke hook_filename_validators().
+    // Note that this hook is invoked only once per page request due to the use
+    // of drupal_static().
+    // @todo If there is ever a use case where we might want to call the hook
+    //   more than once per page request, then we may want to include a
+    //   parameter to specify that validators should be reloaded. There is no
+    //   need for this yet though, so leaving as is for now.
+    $validators = module_invoke_all('filename_validators');
+    foreach ($validators as $key => $validator) {
+      // Add any missing default settings
+      $validators[$key] += $validator_defaults;
+      // Add an element for whether the validator is enabled
+      $validators[$key]['enabled'] = _fsa_filename_validation_validator_enabled($key);
+      // Add an element for the key
+      $validators[$key]['key'] = $key;
+      // Get any settings defined for the validator
+      if (!empty($validator['settings_form'])) {
+        $validators[$key]['settings'] = array();
+        foreach ($validator['settings_form'] as $setting => $details) {
+          $validators[$key]['settings'][$setting] = variable_get("filename_validator_${key}_${setting}");
+        }
+      }
+    }
+    // Allow other modules to alter the validators.
+    drupal_alter('filename_validators', $validators);
+  }
+  return $validators;
+}
+
+
+/**
+ * Helper function: provides details of specified validator
+ *
+ * @param string $key
+ *   The key of the validator, eg 'no_whitespace'
+ *
+ * @return array|boolean
+ *   If the $key parameter corresponds to an element in the validators array
+ *   provided by _fsa_filename_validation_get_validators(), then this function
+ *   will return an associative array of properties for the requested validator.
+ *   If the $key parameter is empty or does not match an entry in the validators
+ *   array, then this function will return boolean FALSE.
+ *
+ * @see _fsa_filename_validation_get_validators()
+ */
+function _fsa_filename_validation_get_validator($key = NULL) {
+  // If no key is provided, return FALSE.
+  if (empty($key)) {
+    return FALSE;
+  }
+  // Get all available validators
+  $validators = _fsa_filename_validation_get_validators();
+
+  // If no validators available, return FALSE
+  if (empty($validators) || !is_array($validators)) {
+    return FALSE;
+  }
+
+  // If the key doesn't correspond to a validator, return FALSE
+  if (empty($validators[$key])) {
+    return FALSE;
+  }
+
+  return $validators[$key];
+}
+
+
+/**
+ * Helper function: determines whether a validator is enabled
+ *
+ * @param string $key
+ *   The key of the validator, eg 'no_whitespace'
+ *
+ * @return boolean
+ *   TRUE if the validator is enabled, FALSE otherwise.
+ */
+function _fsa_filename_validation_validator_enabled($key = NULL) {
+
+  if (empty($key)) {
+    return FALSE;
+  }
+
+  return variable_get("filename_validator_${key}_enabled", FALSE);
+}

--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -398,3 +398,14 @@ function local_field_group_pre_render_alter(&$element, $group, & $form) {
   // around the classes.
   $element['#prefix'] = '<div class="' . $group->classes . '">';
 }
+
+
+/**
+ * Implements hook_siteimprove_editing_page_options_alter().
+ *
+ * This is used to ensure that the editing page URL rendered in the meta tag
+ * for SiteImprove uses the admin domain, rather than the front-end domain.
+ */
+function local_siteimprove_editing_page_options_alter(&$editing_page_options) {
+  $editing_page_options['base_url'] = local_get_site_domain(TRUE, 'https');
+}

--- a/docroot/sites/all/modules/custom/siteimprove/siteimprove.module
+++ b/docroot/sites/all/modules/custom/siteimprove/siteimprove.module
@@ -58,7 +58,7 @@ function siteimprove_theme() {
 
 /**
  * Implements hook_page_alter().
- * 
+ *
  * @see theme/siteimprove-analytics-javascript.tpl.php
  */
 function siteimprove_page_alter(&$page) {
@@ -88,22 +88,25 @@ function siteimprove_page_alter(&$page) {
 
 
 /**
- * Implements hook_node_view().
+ * Implements template_preprocess_page().
  *
  * We use this to add the SiteImprove meta tags that facilitate CMS deeplinking
  *
  * @see http://support.siteimprove.com/hc/en-gb/articles/206343443-What-is-CMS-Deeplinking-and-How-do-I-enable-it-
  */
-function siteimprove_node_view($node, $view_mode, $langcode) {
-
-  // Act only if the node is being viewed in full.
-  if ($view_mode != 'full' || empty($node->nid)) {
+function siteimprove_preprocess_page(&$variables) {
+  // Get the node object from the page variables - if available.
+  $node = !empty($variables['node']) ? $variables['node'] : NULL;
+  // No node object? Exit now.
+  if (empty($node)) {
     return;
   }
-
-  // Get the Node ID (nid).
-  $nid = $node->nid;
-
+  // Get the Nid from the node object
+  $nid = !empty($node->nid) ? $node->nid : NULL;
+  // No Nid? Exit now.
+  if (empty($nid)) {
+    return;
+  }
   // Add the pageID meta tag - if required.
   if (variable_get('siteimprove_meta_pageid', FALSE)) {
     $page_id = array(


### PR DESCRIPTION
Upgraded the [Views Bulk Operations](https://www.drupal.org/project/views_bulk_operations) module to version **7.x-3.3**.

This is a security release.

Database schema updates
-----------------------
There are no database schema updates for this version.

Testing
-------
The functionality provided by this module is used primarily in the content administration screen in the Drupal admin interface:

https://admin.food.gov.uk/admin/content

It is also used on the Users page:

https://admin.food.gov.uk/admin/people

It provides fnctionality via the bulk update dropdown.

This should be tested once the module has been upgraded.

[ Partial fix for [#10297](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=795) ]