### PR TITLE
Develop: Control output of PageWatch delimiters via variable

### DIFF
--- a/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
+++ b/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
@@ -14,15 +14,23 @@ function site_frontend_preprocess_page(&$variables) {
   // @todo Once the FSA GovDelivery module has been deployed to the production
   //   system, move these into an implementation of template_preprocess_page()
   //   in that module, not here.
-  $variables['page']['content']['page_watch_delimiter_start'] = array(
-    '#markup' => '<!--PAGEWATCH-->',
-    '#suffix' => PHP_EOL,
-    '#weight' => -100,
-  );
-  $variables['page']['content']['page_watch_delimiter_end'] = array(
-    '#markup' => '<!--/PAGEWATCH-->',
-    '#weight' => 150,
-  );
+  // The presence of the delimiters is determined by a variable that can be
+  // set via Drush, eg
+  //
+  // `drush vset fsa_govdelivery_add_pagewatch_delimiters 1`
+  //
+  $add_pagewatch_delimiters = variable_get('fsa_govdelivery_add_pagewatch_delimiters', FALSE);
+  if (!empty($add_pagewatch_delimiters)) {
+    $variables['page']['content']['page_watch_delimiter_start'] = array(
+      '#markup' => '<!--PAGEWATCH-->',
+      '#suffix' => PHP_EOL,
+      '#weight' => -100,
+    );
+    $variables['page']['content']['page_watch_delimiter_end'] = array(
+      '#markup' => '<!--/PAGEWATCH-->',
+      '#weight' => 150,
+    );
+  }
 
   // Add current username to the page footer so that we can detect it with Behat tests
   if (user_is_logged_in()) {


### PR DESCRIPTION
Added some code to enable control of the output of the PageWatch delimiters via a variable.

Enabling the delimiters
------------------------------
Using Drush we can tell the delmiters to show using the following:

`drush vset fsa_govdelivery_add_pagewatch_delimiters 1`

[ Partial fix for [#10225](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=723) ]