### PR TITLE
Add GovDelivery content delimiters

### DIFF
--- a/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
+++ b/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
@@ -14,15 +14,23 @@ function site_frontend_preprocess_page(&$variables) {
   // @todo Once the FSA GovDelivery module has been deployed to the production
   //   system, move these into an implementation of template_preprocess_page()
   //   in that module, not here.
-  $variables['page']['content']['page_watch_delimiter_start'] = array(
-    '#markup' => '<!--PAGEWATCH-->',
-    '#suffix' => PHP_EOL,
-    '#weight' => -100,
-  );
-  $variables['page']['content']['page_watch_delimiter_end'] = array(
-    '#markup' => '<!--/PAGEWATCH-->',
-    '#weight' => 150,
-  );
+  // The presence of the delimiters is determined by a variable that can be
+  // set via Drush, eg
+  //
+  // `drush vset fsa_govdelivery_add_pagewatch_delimiters 1`
+  //
+  $add_pagewatch_delimiters = variable_get('fsa_govdelivery_add_pagewatch_delimiters', FALSE);
+  if (!empty($add_pagewatch_delimiters)) {
+    $variables['page']['content']['page_watch_delimiter_start'] = array(
+      '#markup' => '<!--PAGEWATCH-->',
+      '#suffix' => PHP_EOL,
+      '#weight' => -100,
+    );
+    $variables['page']['content']['page_watch_delimiter_end'] = array(
+      '#markup' => '<!--/PAGEWATCH-->',
+      '#weight' => 150,
+    );
+  }
 
   // Add current username to the page footer so that we can detect it with Behat tests
   if (user_is_logged_in()) {

--- a/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
+++ b/docroot/sites/all/themes/site_frontend/preprocess/page.preprocess.inc
@@ -6,6 +6,24 @@
 
 
 function site_frontend_preprocess_page(&$variables) {
+
+  // Add the GovDelivery PageWatch delimiter comments to the page content array.
+  // These mark the start and end of the real content of the page and are used
+  // by GovDelivery to determine when a page has actually been updated
+  // @see #10225 - https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=723
+  // @todo Once the FSA GovDelivery module has been deployed to the production
+  //   system, move these into an implementation of template_preprocess_page()
+  //   in that module, not here.
+  $variables['page']['content']['page_watch_delimiter_start'] = array(
+    '#markup' => '<!--PAGEWATCH-->',
+    '#suffix' => PHP_EOL,
+    '#weight' => -100,
+  );
+  $variables['page']['content']['page_watch_delimiter_end'] = array(
+    '#markup' => '<!--/PAGEWATCH-->',
+    '#weight' => 150,
+  );
+
   // Add current username to the page footer so that we can detect it with Behat tests
   if (user_is_logged_in()) {
     $variables['page']['footer']['username'] = array(


### PR DESCRIPTION
As recommended by Richard Fong from GovDelivery, added special comments before and after the main content area to help identify genuine changes to the page.

These have initially been added to the SiteFrontend theme, as the GovDelivery modules are not currently installed on production. Once they have been deployed, these should be moved there.

The delimiters look like this:

```HTML
<!--PAGEWATCH-->
The content that you wish use to monitor
<!--/PAGEWATCH-->
```

The delimiters are controlled by a Drupal variable called `fsa_govdelivery_add_pagewatch_delimiters`

Enabling the delimiters
------------------------------
Using Drush we can tell the delmiters to show using the following:

`drush vset fsa_govdelivery_add_pagewatch_delimiters 1`

[ Partial fix for [#10225](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=723) ]