### PR TITLE
Check for status field in views handler

### DIFF
--- a/docroot/sites/all/modules/custom/national_archives/includes/views_handler_archived_field.inc
+++ b/docroot/sites/all/modules/custom/national_archives/includes/views_handler_archived_field.inc
@@ -73,7 +73,9 @@ class views_handler_archived_field extends views_handler_field {
     $query->entityCondition('entity_type', 'redirect');
     $query->propertyCondition('redirect', NATIONAL_ARCHIVES_PSEUDO_PROTOCOL . '%', 'like');
     $query->propertyCondition('source', $uri, '=');
-    $query->propertyCondition('status', 1);
+    if (db_field_exists('redirect', 'status')) {
+      $query->propertyCondition('status', 1);
+    }
     $redirects = $query->execute();
     if (empty($redirects)) {
       return $default_return;


### PR DESCRIPTION
If the redirect table has a status field, use this property, otherwise don't.

[ Partial fix for #2014090110000295 ]