### PR TITLE
Remove view-dom-id class for node header fields

### DIFF
--- a/docroot/sites/all/themes/site_frontend/preprocess/views-view.preprocess.inc
+++ b/docroot/sites/all/themes/site_frontend/preprocess/views-view.preprocess.inc
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Implements template_preprocess_views_view().
+ *
+ * We use this primarily to remove the 'view-dom-id-...' class from the
+ * node_header_fields view as this changes frequently and causes false positive
+ * problems for the GovDelivery PageWatch service.
+ * @see #10225 - https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=723
+ */
+function site_frontend_preprocess_views_view(&$variables) {
+  // Get the view object.
+  $view = !empty($variables['view']) ? $variables['view'] : NULL;
+  // If no view object, exit now.
+  if (empty($view)) {
+    return;
+  }
+  // We want to operate on the node header fields view.
+  if ($view->name == 'node_header_fields') {
+    // Get the attributes array
+    $attributes_array = !empty($variables['attributes_array']) ? $variables['attributes_array'] : array();
+    // Get the classes array
+    $classes_array = !empty($variables['classes_array']) ? $variables['classes_array'] : array();
+    // Remove the 'view-dom-id-...' class from the attributes array
+    if (!empty($attributes_array['class'])) {
+      foreach ($attributes_array['class'] as $key => $value) {
+        if (strpos($value, 'view-dom-id-') === 0) {
+          unset($variables['attributes_array']['class'][$key]);
+        }
+      }
+    }
+    // Remove the 'view-dom-id-...' class from the classes array
+    foreach ($classes_array as $key => $value) {
+      if (strpos($value, 'view-dom-id-') === 0) {
+        unset($variables['classes_array'][$key]);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Used an implementation of `template_preprocess_views_view()` to remove the `view-dom-id...` class from the node header fields view, which appears at the top of many nodes.

This class is used primarily with exposed filters, and is consequently not used on this view.

Because the class name changes frequently, it causes false positives for the GovDelivery HTML PageWatch mechanism.

No other views are affected.

[ Partial fix for [#10225](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=723) ]