### PR TITLE
Develop: Add file operations for clearing CloudFlare cache

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.module
+++ b/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.module
@@ -891,3 +891,79 @@ function _fsa_cache_clear_get_object_type_from_path($path) {
 
   return 'unknown';
 }
+
+
+/**
+ * Implements hook_file_operations().
+ */
+function fsa_cache_clear_file_operations() {
+  $operations = array(
+    'delete' => array(
+      'label' => t('Purge from CloudFlare cache'),
+      'callback' => '_fsa_cache_clear_file_operation_cloudflare_purge',
+    ),
+  );
+  return $operations;
+}
+
+
+/**
+ * Implements hook_action_info().
+ *
+ * @see fsa_cache_clear_file_purge_cloudflare_action()
+ */
+function fsa_cache_clear_action_info() {
+  return array(
+    'fsa_cache_clear_file_purge_cloudflare_action' => array(
+      'type' => 'file',
+      'label' => t('Purge from CloudFlare cache'),
+      'configurable' => FALSE,
+      //'behavior' => array('changes_property'),
+      'vbo_configurable' => FALSE,
+      'triggers' => array('any'),
+    ),
+  );
+}
+
+
+/**
+ * Action callback for purging files from CloudFlare
+ */
+function fsa_cache_clear_file_purge_cloudflare_action($file, $context) {
+
+  // If we don't have a file, exit now
+  if (empty($file)) {
+    return;
+  }
+
+  // Get the filename
+  $filename = file_uri_target($file->uri);
+  // Get the path for public files.
+  $public_path = variable_get('file_public_path');
+  // Add the filename to the URLs for clearing
+  $urls = array("$public_path/$filename");
+  // Handle image derivatives
+  if ($file->type == 'image') {
+    $image_styles = image_styles();
+    foreach ($image_styles as $style_name => $style_properties) {
+      if (file_exists(image_style_path($style_name, $filename))) {
+        // Get the image style token to add to the URL for CloudFlare
+        $image_style_path_token = image_style_path_token($style_name,  "public://$filename");
+        // Add the path to be cleared from the CloudFlare cache, including the
+        // image derivative token as this is stored in CloudFlare.
+        $urls[] = $public_path . '/' . file_uri_target(image_style_path($style_name, $filename)) . "?" . IMAGE_DERIVATIVE_TOKEN . "=$image_style_path_token";
+      }
+    }
+  }
+  foreach ($urls as $url) {
+    _fsa_cache_clear_cloudflare_queue_url($url, 'file', TRUE, TRUE);
+  }
+}
+
+/**
+ * Callback for CloudFlare purge file operation
+ */
+function _fsa_cache_clear_file_operation_cloudflare_purge() {
+  // Not currently implemented as a view is used in place of the standard
+  // files admin page.
+}

--- a/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.module
+++ b/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.module
@@ -355,22 +355,37 @@ function _fsa_cache_clear_cloudflare_purge_url($path = NULL) {
  * @param string $object_type
  *   The type of object corresponding to the path
  *
- * @param $queue
+ * @param boolean $queue
  *   (optional) Determines whether the request to clear the CloudFlare cache for
  *   the given path will be queued for execution on cron run or carried out
  *   immediately. The default is TRUE.
+ *
+ * @param boolean $force_committee_domains
+ *   (optional) If set to TRUE, then if the $object_type is set to file, URLs
+ *   will be generated for each committee domain. Defaults to FALSE.
  *
  * @return NULL
  *
  * @see fsa_cache_clear_file_entity_edit_submit()
  * @see _fsa_cache_clear_cloudflare_queue_add_items()
  */
-function _fsa_cache_clear_cloudflare_queue_url($path = NULL, $object_type = NULL, $queue = TRUE) {
+function _fsa_cache_clear_cloudflare_queue_url($path = NULL, $object_type = NULL, $queue = TRUE, $force_committe_domains = FALSE) {
 
   // If we have no URL, return now.
   if (empty($path)) {
     //drupal_set_message('No path supplied', 'error');
     return;
+  }
+
+  // Exclude certain URLs from being purged (mainly internal ones)
+  $exclude = array(
+    "@^batch$@",
+  );
+
+  foreach ($exclude as $pattern) {
+    if (preg_match($pattern, $path)) {
+      return;
+    }
   }
 
   // An array to hold the URLs to be purged from CloudFlare
@@ -384,7 +399,7 @@ function _fsa_cache_clear_cloudflare_queue_url($path = NULL, $object_type = NULL
 
   // If we're purging a file object, we need to make sure we purge it from all
   // of the committee subdomains as well as any configured by the users.
-  if ($object_type == 'file' && !$queue) {
+  if ($object_type == 'file' && (!$queue || $force_committe_domains)) {
     // Purging of files is now usually handled by the custom submit function:
     // `fsa_cache_clear_file_entity_edit_submit()`. This function handles image
     // derivative files, which can't easily be handled here. The exception to


### PR DESCRIPTION
Added an action and callback. Also added an implementation of `hook_file_operations()`, which is currently unused due to the fact that we're using a view for the files page.

[ Partial fix for [#10312](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=810) ]