### PR TITLE
Develop: Add translation capability for search for local authority

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/classes/ExternalApiStatus.class.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/classes/ExternalApiStatus.class.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @file
+ * Class for returning external API status
+ */
+
+abstract class ExternalApiStatus {
+  
+  public $healthy;
+  public $lastCheck;
+  public $exception;
+  public $httpCode;
+  public $httpError;
+  private $url;
+  
+  public function __construct($url = '') {
+    $this->healthy = TRUE;
+    $this->url = $url;
+  }
+  
+  public function check(){
+    if (!empty($this->url)) {
+      dpm('hello');
+      $request = drupal_http_request($this->url);
+      $this->lastCheck = REQUEST_TIME;
+      $this->healthy = $request->code == 200 ? TRUE : FALSE;
+      $this->httpCode = $request->code;
+      $this->httpError = !empty($request->error) ? $request->error : NULL;
+    }
+    if (!$this->healthy) {
+      $this->logError();
+    }
+    return $this;
+  }
+  
+  private function logError() {
+    //watchdog('fsa_report_problem', 'ExternalApiError')
+  }
+  
+}

--- a/docroot/sites/all/modules/custom/fsa_report_problem/classes/MapItApiStatus.class.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/classes/MapItApiStatus.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Class file for MapIt API status
+ */
+
+class MapItApiStatus extends ExternalApiStatus {
+  function __construct() {
+    parent::__construct();
+    $this->url = 'https://mapit.mysociety.org/postcode/SW1A1AA';
+  }
+}

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.info
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.info
@@ -5,3 +5,5 @@ package = FSA Custom
 files[] = includes/form.inc
 dependencies[] = fhrs_api
 files[] = classes/GooglePlacesApiException.class.php
+files[] = classes/ExternalApiStatus.class.php
+files[] = classes/MapItApiStatus.class.php

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -2437,3 +2437,24 @@ function _fsa_report_problem_format_url($url = '') {
   // Return the replacement
   return preg_replace($pattern, $replacement, $url);
 }
+
+
+/**
+ * Helper function: checks external API status
+ */
+function _fsa_report_problem_check_api_status($api = NULL) {
+
+  $apis = array(
+    'mapit' => new MapItApiStatus(),
+  );
+
+  if (!empty($api)) {
+    $apis[$api]->check();
+  }
+  else {
+    foreach ($apis as $item) {
+      dpm($item->check());
+    }
+  }
+
+}

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -263,6 +263,11 @@ function fsa_report_problem_block_view($delta = '') {
 
     // Search for an establishment form
     case 'report_problem_form':
+
+      // Check the API status - this is just for testing purposes
+      // @todo Remove this/incorporate it properly
+      _fsa_report_problem_check_api_status();
+
       if (FSA_REPORT_PROBLEM_STATUS == FSA_REPORT_PROBLEM_STATUS_OFFLINE) {
         $block['content'] = array(
           'heading' => array(

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -2463,3 +2463,43 @@ function _fsa_report_problem_check_api_status($api = NULL) {
   }
 
 }
+
+
+/**
+ * Helper function: gets the nids of any translations of the given nid
+ *
+ * @param int $nid
+ *   The node ID (nid) of a node for which we want to find translations
+ *
+ * @return array
+ *   An associative array of node titles keyed on node IDs (nids). If no
+ *   translations are found, an empty array is returned.
+ */
+function _fsa_report_problem_get_transaltion_nids($nid = NULL) {
+  // Create an empty array to return
+  $return_array = array();
+
+  // If we don't have a nid, return an empty array.
+  if (empty($nid)) {
+    return $return_array;
+  }
+
+  // Get any translations of the node based on its nid
+  $translations = translation_node_get_translations($nid);
+
+  // If there are no tranlsations, return an empty array
+  if (empty($translations)) {
+    return array();
+  }
+
+  // Build an associative array keyed on nid, but excluding the $nid passed as
+  // @param as we don't want to duplicate
+  foreach ($translations as $lang => $node) {
+    if ($node->nid != $nid) {
+      $return_array[$node->nid] = $node->title;
+    }
+  }
+
+  // Return the array
+  return $return_array;
+}

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -266,7 +266,7 @@ function fsa_report_problem_block_view($delta = '') {
 
       // Check the API status - this is just for testing purposes
       // @todo Remove this/incorporate it properly
-      _fsa_report_problem_check_api_status();
+      //_fsa_report_problem_check_api_status();
 
       if (FSA_REPORT_PROBLEM_STATUS == FSA_REPORT_PROBLEM_STATUS_OFFLINE) {
         $block['content'] = array(

--- a/docroot/sites/all/modules/custom/fsa_report_problem/includes/fsa_report_problem_context_condition_report_problem_node.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/includes/fsa_report_problem_context_condition_report_problem_node.inc
@@ -10,9 +10,17 @@
 class fsa_report_problem_context_condition_report_problem_node extends context_condition {
   function condition_values() {
     $nid = _fsa_report_problem_extract_nid(variable_get('fsa_report_problem_node_nid', 1000000));
+    // See if there are any translations available
+    $translations = _fsa_report_problem_get_transaltion_nids($nid);
+    // Load the node
     $node = node_load($nid);
+    // Get the node's title
     $title = !empty($node->title) ? $node->title : 'No title';
+    // Create an array to hold the nid and its title
     $values = array($nid => $title);
+    // Add translations to the array
+    $values += $translations;
+    // Return the array of nids and titles
     return $values;
   }
  


### PR DESCRIPTION
Amended functionality of the search for a local authority module so that when a node is selected to hold the block, any translations are also included.

[ Partial fix for #10273 ]