### PR TITLE
Make template prompts translatable

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/theme/local-authority-details.tpl.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/theme/local-authority-details.tpl.php
@@ -10,12 +10,12 @@
       <h2><?php print render($name); ?></h2>
     <?php endif; ?>
     <?php if (!empty($email_link)): ?>
-      <p>Email address: <?php print render($email_link); ?></p>
+      <p><?php print t('Email address'); ?>: <?php print render($email_link); ?></p>
     <?php else: ?>
       <p><?php print t('Sorry, we do not have an email address on record for this local authority. Please visit their website or contact their main switchboard for further information.'); ?></p>
     <?php endif; ?>
     <?php if (!empty($website_link)): ?>
-      <p>Website: <?php print render($website_link); ?></p>
+      <p><?php print t('Website'); ?>: <?php print render($website_link); ?></p>
     <?php endif; ?>
   </div>
 </div>


### PR DESCRIPTION
Put the text 'Email address' and 'Website' through the `t()` function in the template `local-authority-details.tpl.php` in order to make them translatable.

[ Partial fix for #10273 ]