### PR TITLE
Improvements to CloudFlare cache clearing

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.admin.inc
@@ -247,7 +247,7 @@ function fsa_cache_clear_purge_form($form, &$form_state) {
 function fsa_cache_clear_purge_form_submit($form, &$form_state) {
   $form_state['rebuild'] = TRUE;
   
-  $url = !empty($form_state['values']['url']) ? $form_state['values']['url'] : NULL;
+  $url = !empty($form_state['values']['url']) ? drupal_encode_path($form_state['values']['url']) : NULL;
   
   if (empty($url)) {
     drupal_set_message('No URL supplied', 'error');

--- a/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.admin.inc
@@ -263,6 +263,7 @@ function fsa_cache_clear_purge_form_submit($form, &$form_state) {
   
   if (!empty($caches_to_clear['cloudflare'])) {
     _fsa_cache_clear_cloudflare_queue_url($url, _fsa_cache_clear_get_object_type_from_path($url), FALSE);
+    // @todo Let the user know if any problems occurred.
     drupal_set_message(t('CloudFlare cache cleared for @url', array('@url' => $url)));
   }
   

--- a/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.module
+++ b/docroot/sites/all/modules/custom/fsa_cache_clear/fsa_cache_clear.module
@@ -210,6 +210,11 @@ function _fsa_cache_clear_cloudflare_purge($paths = array(), $object_type = NULL
     "/^system\/temporary.*$/",
   );
 
+  // If we're purging a file, don't bother to clear the homepage
+  if ($object_type == 'file') {
+    $ignore_patterns[] = "/^<front>$/";
+  }
+
   // Remove paths to be ignored.
   foreach ($paths as $index => $path) {
     foreach ($ignore_patterns as $pattern) {


### PR DESCRIPTION
1. When using purge now, encode the URL
2. Don't clear the homepage when purging a file

[ Partial fix for #10312 ]