### PR TITLE
Enable Welsh-language version to have special paths

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1978,25 +1978,47 @@ function _fsa_report_problem_get_location_by_ip($ip = NULL) {
  * within the report a food problem service.
  */
 function fsa_report_problem_init() {
-  
+
   // Get the request path
   $request_path = request_path();
-  $path = FSA_REPORT_PROBLEM_PATH;
 
   // Get the nid of the node associated with the report a problem block
   $nid = _fsa_report_problem_get_nid();
-  // Get the path alias for the associated node.
-  $path = drupal_get_path_alias("node/$nid");
 
-  // Make sure that the path for the report a problem service is the first part
-  // of the current path. If not, exit now.
-  if (strpos($request_path, $path) !== 0) {
+  // Create an array of nids with the primary node as an element
+  $nids = array($nid);
+
+  // See if there are any translations available
+  $translations = _fsa_report_problem_get_transaltion_nids($nid);
+
+  // If we have any translations, add their nids to the array.
+  if (!empty($translations)) {
+    $nids = array_merge($nids, array_keys($translations));
+  }
+
+  // A variable to hold the actual path. We set it to NULL initially.
+  $path = NULL;
+
+  // For each of the nids, see if its path contains the current path. If it
+  // matches, set the $path variable and break the loop. If no match, then the
+  // $path variable will remain set to NULL.
+  foreach ($nids as $nid) {
+    $temp_path = drupal_get_path_alias("node/$nid");
+    if (strpos($request_path, $temp_path) === 0) {
+      $path = $temp_path;
+      break;
+    }
+  }
+
+  // If we have no path, exit now.
+  if (empty($path)) {
     return;
   }
-  
+
+  // Set the value of the 'q' GET variable
   $_GET['q'] = drupal_get_normal_path($path);
 
-  // The path suffix is any path left after the FSA_REPORT_PROBLEM_PATH.
+  // The path suffix is any path left after the $path variable.
   $path_suffix = str_replace("$path/", '', $request_path);
   $path_suffix_array = explode('/', $path_suffix);
 
@@ -2025,18 +2047,6 @@ function fsa_report_problem_init() {
     ),
   );
 
-  // Check to see if anything after the path is in our array of $path_mappings.
-  // If so, set the $_GET['q'] parameter to our standard path and add $_GET
-  // elements for each of the items in the array within $path_mappings.
-  //if (array_key_exists($path_suffix, $path_mappings)) {
-    //$_GET['q'] = drupal_get_normal_path($path);
-  //  if (is_array($path_mappings[$path_suffix])) {
-  //    foreach ($path_mappings[$path_suffix] as $param => $value) {
-  //      $_GET[$param] = $value;
-  //    }
-  //  }
-  //}
-  
   // New string-based mapping
   foreach ($path_mappings as $path => $settings) {
     if (strpos($path_suffix, $path) === 0) {
@@ -2047,9 +2057,9 @@ function fsa_report_problem_init() {
       }
     }
   }
-  
+
   // If we're looking for a specific local authority, let's try to get its ID
-  if ($path_suffix_array[0] == 'authority' && count($path_suffix_array > 1)) {
+  if ($path_suffix_array[0] == 'authority' && count($path_suffix_array) > 1) {
     $local_authority_alias = $path_suffix_array[1];
     $_GET['aid'] = _fsa_report_problem_load_authority_by_alias($local_authority_alias);
   }


### PR DESCRIPTION
Modified the `hook_init()` implementation in the report a food problem module to enable any translations of the chosen node to use special path suffixes such as `<path>/postcode` and `<path>/authority`.

[ Partial fix for #10273 ]