### PR TITLE
Develop: Search for local authority - postcode validation

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/classes/MapItApiException.class.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/classes/MapItApiException.class.php
@@ -5,6 +5,9 @@
  */
 class MapItApiException extends Exception {
 
+  protected $originalError;
+
+
   /**
    * Constructor function - extends parent
    *
@@ -22,6 +25,8 @@ class MapItApiException extends Exception {
     parent::__construct($message, $code, $previous);
     // Build the message
     $this->setMessage($response);
+    // Set the original error message
+    $this->setOriginalError($response);
   }
 
   /**
@@ -43,5 +48,31 @@ class MapItApiException extends Exception {
     }
     // Set the exception message
     $this->message = $error_message;
+  }
+
+
+  /**
+   * Sets the original error message property that came from MapIt
+   *
+   * @param stdClass $response
+   *   A response object as returned by drupal_http_request().
+   */
+  function setOriginalError($response = NULL) {
+    if (empty($response)) {
+      return;
+    }
+    $data = !empty($response->data) ? drupal_json_decode($response->data) : NULL;
+    $this->originalError = is_array($data) && !empty($data['error']) ? $data['error'] : 'Sorry, a problem has occurred';
+  }
+
+
+  /**
+   * Returns the original error message from MapIt
+   *
+   * @return string
+   *   The original error message returned by MapIt
+   */
+  function getOriginalError() {
+    return $this->originalError;
   }
 }

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -2270,7 +2270,13 @@ function _fsa_report_problem_mapit_authority_types($full = FALSE) {
   $default_types = array('DIS', 'UTA', 'LBO', 'LGD', 'MTD', 'COI');
 
   // Types selected for use
-  return variable_get('fsa_report_problem_mapit_authority_types', $default_types);
+  $types = variable_get('fsa_report_problem_mapit_authority_types', $default_types);
+  foreach ($types as $key => $value) {
+    if (empty($value)) {
+      unset ($types[$key]);
+    }
+  }
+  return array_values($types);
 }
 
 

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -246,6 +246,13 @@ function fsa_report_problem_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items['postcode-autocomplete'] = array(
+    'title' => 'Autocomplete for postcodes',
+    'page callback' => '_fsa_report_problem_postcode_autocomplete',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
 
@@ -2517,6 +2524,26 @@ function _fsa_report_problem_nodes_autocomplete($string) {
 
   // Return the result to the form in json
   drupal_json_output($matches);
+}
+
+
+/**
+ * Autocomplete callback for postcodes
+ */
+function _fsa_report_problem_postcode_autocomplete($postcode) {
+  $output = array();
+  $limit = 20;
+  if (!empty($postcode)) {
+    $endpoint = format_string("http://api.postcodes.io/postcodes/@postcode/autocomplete", array('@postcode' => $postcode));
+    $url = url($endpoint, array('query' => array('limit' => $limit, 't' => time())));
+    $results = drupal_http_request($url);
+    $data = !empty($results->data) ? json_decode($results->data) : NULL;
+    $postcodes = !empty($data->result) && is_array($data->result) ? $data->result : array();
+    if (is_array($postcodes)) {
+      $output = array_combine($postcodes, $postcodes);
+    }
+  }
+  drupal_json_output($output);
 }
 
 

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -868,7 +868,7 @@ function fsa_report_problem_get_local_authority_by_postcode($postcode = NULL) {
   $data = drupal_json_decode($area_data->data);
 
   // If response code other than 200, or if data is empty, throw an exception.
-  if (empty($area_data->code) || $area_data->code != '200') {
+  if (empty($area_data->code) || ($area_data->code != '200' && $area_data->code != '404')) {
     _fsa_report_problem_api_status('mapit', array('healthy' => FALSE, 'httpCode' => $area_data->code));
     throw new MapItApiException('', 0, $area_data);
   }

--- a/docroot/sites/all/modules/custom/fsa_report_problem/includes/form.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/includes/form.inc
@@ -494,6 +494,87 @@ function fsa_report_problem_make_report_form($form, &$form_state) {
 
 
 /**
+ * Validation function for postcode search form
+ */
+function fsa_report_problem_form_validate($form, &$form_state) {
+
+  // Get the stage of the process
+  $stage = !empty($form_state['stage']) ? $form_state['stage'] : NULL;
+
+  // At the moment, we're interested only in the postcode search stage.
+  if ($stage != 'postcode_search') {
+    return;
+  }
+
+  // Get the postcode from the form_state
+  $postcode = isset($form_state['values']['postcode']) ? $form_state['values']['postcode'] : NULL;
+
+  // Make sure we have a postcode. If not, set an error and return.
+  if (empty($postcode)) {
+    form_set_error('postcode', t('Please enter a postcode'));
+    return;
+  }
+
+  // Get rid of any spaces in the postcode and convert it to uppercase.
+  $postcode = strtoupper(str_replace(' ', '', $postcode));
+
+  // UK postcodes are between 6 and 8 characters in length including the space.
+  // If it's longer or shorter than this, then it's invalid, so set an error
+  if (strlen($postcode) < 5 || strlen($postcode) > 7) {
+    form_set_error('postcode', t('Sorry, the postcode you entered appears to be invalid. Please try again, making sure you enter the full postcode.'));
+    return;
+  }
+
+  // Perform local postcode validation that mimics MapIt's validation.
+  // @see https://github.com/mysociety/mapit/blob/b471659b14b8912948247fa72bdbc5f65c5a6a61/mapit_gb/countries.py
+
+  // Special postcodes
+  if (in_array($postcode, array(
+    'ASCN1ZZ',  // Ascension Island
+    'BBND1ZZ',  // BIOT
+    'BIQQ1ZZ',  // British Antarctic Territory
+    'FIQQ1ZZ',  // Falkland Islands
+    'PCRN1ZZ',  // Pitcairn Islands
+    'SIQQ1ZZ',  // South Georgia and the South Sandwich Islands
+    'STHL1ZZ',  // St Helena
+    'TDCU1ZZ',  // Tristan da Cunha
+    'TKCA1ZZ',  // Turks and Caicos Islands
+    'GIR0AA', 'G1R0AA',  // Girobank
+    'SANTA1', 'XM45HQ',  // Santa Claus
+  ))) {
+    return;
+  }
+
+  // Now for standard postcodes
+  $inward = 'ABDEFGHJLNPQRSTUWXYZ';
+  $fst = 'ABCDEFGHIJKLMNOPRSTUWYZ';
+  $sec = 'ABCDEFGHJKLMNOPQRSTUVWXY';
+  $thd = 'ABCDEFGHJKSTUW';
+  $fth = 'ABEHMNPRVWXY';
+
+  // An array of regex patterns to use for validation
+  $patterns = array(
+    sprintf('/[%1$s][1-9]\d[%2$s][%3$s]$/', $fst, $inward, $inward),
+    sprintf('/[%1$s][1-9]\d\d[%2$s][%3$s]$/', $fst, $inward, $inward),
+    sprintf('/[%1$s][%2$s]\d\d[%3$s][%4$s]$/', $fst, $sec, $inward, $inward),
+    sprintf('/[%1$s][%2$s][1-9]\d\d[%3$s][%4$s]$/', $fst, $sec, $inward, $inward),
+    sprintf('/[%1$s][1-9][%2$s]\d[%3$s][%4$s]$/', $fst, $thd, $inward, $inward),
+    sprintf('/[%1$s][%2$s][1-9][%3$s]\d[%4$s][%5$s]$/', $fst, $sec, $fth, $inward, $inward),
+  );
+
+  // If the postcode matches one of these patterns, it's valid, so return.
+  foreach ($patterns as $pattern) {
+    if (preg_match($pattern, $postcode)) {
+      return;
+    }
+  }
+
+  // The postcode hasn't matched any of the patterns, so it must be invalid.
+  form_set_error('postcode', t('Sorry, the postcode you entered does not appear to be valid. Please try again.'));
+}
+
+
+/**
  * Submit handler for the main report a problem form
  */
 function fsa_report_problem_form_submit(&$form, &$form_state) {

--- a/docroot/sites/all/modules/custom/fsa_report_problem/includes/form.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/includes/form.inc
@@ -631,7 +631,7 @@ function fsa_report_problem_form_submit(&$form, &$form_state) {
       catch (MapItApiException $e) {
         watchdog_exception('fsa_report_problem', $e);
         $next_stage = 'postcode_search';
-        $error_message = t('Sorry, a problem has occurred. Please try again later.');
+        $error_message = $e->getOriginalError();
         drupal_set_message($error_message, 'error');
         break;
       }

--- a/docroot/sites/all/modules/custom/fsa_report_problem/includes/form.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/includes/form.inc
@@ -1048,6 +1048,9 @@ function fsa_report_problem_postcode_search_form($form, &$form_state) {
     '#attributes' => array(
       'placeholder' => t('Enter the full postcode of the business'),
     ),
+    // Postcode autocomplete - disabled for now
+    // @todo Enable/disable via the admin interface
+    //'#autocomplete_path' => 'postcode-autocomplete',
   );
 
   $form['submit'] = array(


### PR DESCRIPTION
Provide some validation for postcodes prior to hitting the MapIt API. Also includes better validation error messages.

The validation mimics that which MapIt carries out, as seen here:

https://github.com/mysociety/mapit/blob/b471659b14b8912948247fa72bdbc5f65c5a6a61/mapit_gb/countries.py

[ Partial fix for #10273 ]
