### PR TITLE
Enable title attribute for media embeds

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
+++ b/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
@@ -201,37 +201,41 @@ function fsa_shortcodes_shortcode_dailymotion($attrs, $text) {
  */
 function fsa_shortcodes_shortcode_ted($attrs, $text) {
 
-  $url = '';
-
-  foreach ($attrs as $key => $value) {
-    if (is_numeric($key) && $value != '/') {
-      $url = $value;
-    }
-  }
-
-  // Try to extract a TED video ID from a URL
-  // This should work with URLs of the following forms:
-  //
-  if (!empty($url)) {
-    $attrs['id'] = preg_replace('@^(http)?(s)?(://)?(www\.)?(embed-ssl|www)\.ted\.com/talks/(.*)$@', '$6', $url);
-  }
-
-  foreach ($attrs as $key => $value) {
-    if (is_numeric($key) && preg_match("/[0-9]+/", $value)) {
-      $attrs['id'] = $value;
-    }
-  }
-
-  $attrs = shortcode_attrs(
-    array(
-      'id' => 0,
-      'title' => NULL,
-      'caption' => NULL,
-    ),
-    $attrs
+  // Default attribute settings
+  $defaults = array(
+    'id' => 0,
+    'title' => NULL,
+    'caption' => NULL,
+    'error' => NULL,
   );
 
+  // If we don't already have an explicitly set ID, we look for the first
+  // numerically indexed element in the $attrs array and assume that this is
+  // the ID. All other subsequent numerically indexed elements will be ignored.
+  if (!empty($attrs) && empty($attrs['id'])) {
+    foreach ($attrs as $key => $value) {
+      if (is_numeric($key) && $value != '/') {
+        // The ID may be a URL, so try to extract the ID from it based on regex.
+        $attrs['id'] = preg_replace('@^(http)?(s)?(://)?(www\.)?(embed-ssl|www)\.ted\.com/talks/(.*)$@', '$6', $value);
+        break;
+      }
+    }
+  }
+
+  // Clean up the attributes array and set defaults
+  $attrs = shortcode_attrs($defaults, $attrs);
+
+  // Pattern for URLs for TED videos
   $source_pattern = '//embed-ssl.ted.com/talks/@media_id';
+
+  // If we don't have a proper ID, set the error
+  if (empty($attrs['id'])) {
+    $attrs['error'] = array(
+      '#theme' => 'media_embed_error',
+    );
+  }
+
+  // Embed the video
   return _fsa_shortcodes_embed_media('ted', $attrs['id'], $source_pattern, $attrs, $text);
 }
 

--- a/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
+++ b/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
@@ -285,7 +285,9 @@ function fsa_shortcodes_theme() {
       ),
     ),
     'media_embed_error' => array(
-      'variables' => array(),
+      'variables' => array(
+        'message' => t('Sorry, an error occurred displaying this media.'),
+      ),
     ),
   );
   return $items;

--- a/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
+++ b/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
@@ -118,27 +118,28 @@ function fsa_shortcodes_shortcode_video($attrs, $text) {
  */
 function fsa_shortcodes_shortcode_vimeo($attrs, $text) {
 
-  foreach ($attrs as $key => $value) {
-    if (is_numeric($key) && preg_match("/[0-9]+/", $value)) {
-      $attrs['id'] = $value;
+  // Default attribute settings
+  $defaults = array(
+    'id' => 0,
+    'title' => NULL,
+    'caption' => NULL,
+    'error' => NULL,
+  );
+
+  // If we don't already have an explicitly set ID, we look for the first
+  // numerically indexed element in the $attrs array and assume that this is
+  // the ID. All other subsequent numerically indexed elements will be ignored.
+  if (!empty($attrs) && empty($attrs['id'])) {
+    foreach ($attrs as $key => $value) {
+      if (is_numeric($key) && $value != '/') {
+        // The ID may be a URL, so try to extract the ID from it based on regex.
+        $attrs['id'] = preg_replace('!(http)?(s)?(://)(www\.)?(player\.)?vimeo\.com\/(video/)?(.*)!', '$7', $value);
+        break;
+      }
     }
   }
 
-  // Try to extract a Vimeo video ID from a URL
-  // This should work with URLs of the following forms:
-  // 1. https://vimeo.com/149066287
-  // 2. https://player.vimeo.com/video/149066287
-  $pattern = '!(http)?(s)?(://)(www\.)?(player\.)?vimeo\.com\/(video/)?(.*)!';
-  $attrs['id'] = preg_replace($pattern, '$7', $attrs['id']);
-
-  $attrs = shortcode_attrs(
-    array(
-      'id' => 0,
-      'title' => NULL,
-      'caption' => NULL,
-    ),
-    $attrs
-  );
+  $attrs = shortcode_attrs($defaults, $attrs);
 
   $source_pattern = '//player.vimeo.com/video/@media_id';
   return _fsa_shortcodes_embed_media('vimeo', $attrs['id'], $source_pattern, $attrs, $text);
@@ -150,32 +151,29 @@ function fsa_shortcodes_shortcode_vimeo($attrs, $text) {
  */
 function fsa_shortcodes_shortcode_youtube($attrs, $text) {
 
-  $url = '';
+  // Default attribute settings
+  $defaults = array(
+    'id' => 0,
+    'title' => NULL,
+    'caption' => NULL,
+    'error' => NULL,
+  );
 
-  foreach ($attrs as $key => $value) {
-    if (is_numeric($key) && $value != '/') {
-      $url = $value;
+  // If we don't already have an explicitly set ID, we look for the first
+  // numerically indexed element in the $attrs array and assume that this is
+  // the ID. All other subsequent numerically indexed elements will be ignored.
+  if (!empty($attrs) && empty($attrs['id'])) {
+    foreach ($attrs as $key => $value) {
+      if (is_numeric($key) && $value != '/') {
+        // The ID may be a URL, so try to extract the ID from it based on regex.
+        $attrs['id'] = preg_replace('@^(http)?s?(://)?(www\.)?(youtu)\.?(be)(\.com)?/(embed/|watch\?v=)?(.*)$@', '$8', $value);
+        break;
+      }
     }
   }
 
-  // Try to extract a YouTube video ID from a URL
-  // This should work with URLs of the following forms:
-  // 1. https://www.youtube.com/embed/kb58NbiVFXE
-  // 2. https://www.youtube.com/watch?v=kb58NbiVFXE
-  // 3. https://youtu.be/kb58NbiVFXE
-  if (!empty($url)) {
-    $attrs['id'] = preg_replace('@^(http)?s?(://)?(www\.)?(youtu)\.?(be)(\.com)?/(embed/|watch\?v=)?(.*)$@', '$8', $url);
-  }
+  $attrs = shortcode_attrs($defaults, $attrs);
 
-  $attrs = shortcode_attrs(
-    array(
-      'id' => 0,
-      'title' => NULL,
-      'caption' => NULL,
-      'error' => NULL,
-    ),
-    $attrs
-  );
   $source_pattern = '//www.youtube.com/embed/@media_id';
   return _fsa_shortcodes_embed_media('youtube', $attrs['id'], $source_pattern, $attrs, $text);
 }

--- a/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
+++ b/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
@@ -449,5 +449,5 @@ function _fsa_shortcodes_shortcode_preprocess_callback($matches) {
  * Theme function for media embed errors
  */
 function theme_media_embed_error(&$variables) {
-  return '<div class="embed-error">' . t('Sorry, an error ocurred displaying this media.') . '</div>';
+  return '<div class="embed-error">' . $variables['message'] . '</div>';
 }

--- a/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
+++ b/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
@@ -54,6 +54,13 @@ function fsa_shortcodes_shortcode_info() {
     'process callback' => 'fsa_shortcodes_shortcode_dailymotion',
     'tips callback' => 'fsa_shortcodes_shortcode_dailymotion_tips',
   );
+  
+  $shortcodes['slideshare'] = array(
+    'title' => t('SlideShare'),
+    'description' => t('Embed presentations from SlideShare'),
+    'process callback' => 'fsa_shortcodes_shortcode_slideshare',
+    'tips callback' => 'fsa_shortcodes_shortcode_slideshare_tips',
+  );
 
   return $shortcodes;
 }
@@ -450,4 +457,38 @@ function _fsa_shortcodes_shortcode_preprocess_callback($matches) {
  */
 function theme_media_embed_error(&$variables) {
   return '<div class="embed-error">' . $variables['message'] . '</div>';
+}
+
+
+/**
+ * Process callback for SlideShare presentations
+ */
+function fsa_shortcodes_shortcode_slideshare($attrs, $text) {
+
+  // Default attribute settings
+  $defaults = array(
+    'id' => 0,
+    'title' => NULL,
+    'caption' => NULL,
+    'error' => NULL,
+  );
+
+  // If we don't already have an explicitly set ID, we look for the first
+  // numerically indexed element in the $attrs array and assume that this is
+  // the ID. All other subsequent numerically indexed elements will be ignored.
+  if (!empty($attrs) && empty($attrs['id'])) {
+    foreach ($attrs as $key => $value) {
+      if (is_numeric($key) && $value != '/') {
+        // The ID may be a URL, so try to extract the ID from it based on regex.
+        //$attrs['id'] = preg_replace('!(http)?(s)?(://)(www\.)?(player\.)?vimeo\.com\/(video/)?(.*)!', '$7', $value);
+        $attrs['id'] = $value;
+        break;
+      }
+    }
+  }
+  
+  $attrs = shortcode_attrs($defaults, $attrs);
+
+  $source_pattern = '//www.slideshare.net/slideshow/embed_code/key/@media_id';
+  return _fsa_shortcodes_embed_media('vimeo', $attrs['id'], $source_pattern, $attrs, $text);
 }

--- a/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
+++ b/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
@@ -108,6 +108,7 @@ function fsa_shortcodes_shortcode_video($attrs, $text) {
       'caption' => NULL,
       'provider' => 'youtube',
       'error' => NULL,
+      'iframe_title' => NULL,
     ),
     $attrs
   );
@@ -131,6 +132,7 @@ function fsa_shortcodes_shortcode_vimeo($attrs, $text) {
     'title' => NULL,
     'caption' => NULL,
     'error' => NULL,
+    'iframe_title' => NULL,
   );
 
   // If we don't already have an explicitly set ID, we look for the first
@@ -164,6 +166,7 @@ function fsa_shortcodes_shortcode_youtube($attrs, $text) {
     'title' => NULL,
     'caption' => NULL,
     'error' => NULL,
+    'iframe_title' => NULL,
   );
 
   // If we don't already have an explicitly set ID, we look for the first
@@ -214,6 +217,7 @@ function fsa_shortcodes_shortcode_ted($attrs, $text) {
     'title' => NULL,
     'caption' => NULL,
     'error' => NULL,
+    'iframe_title' => NULL,
   );
 
   // If we don't already have an explicitly set ID, we look for the first
@@ -253,6 +257,7 @@ function fsa_shortcodes_shortcode_ted($attrs, $text) {
 function _fsa_shortcodes_embed_media($provider, $media_id, $source_pattern, $attrs = array(), $text = NULL) {
   $title = !empty($attrs['title']) ? $attrs['title'] : NULL;
   $title = !empty($text) ? $text : $title;
+  $iframe_title = !empty($attrs['iframe_title']) ? $attrs['iframe_title'] : $title;
 
   $build = array(
     '#theme' => 'media_embed',
@@ -262,6 +267,7 @@ function _fsa_shortcodes_embed_media($provider, $media_id, $source_pattern, $att
     '#title' => $title,
     '#caption' => !empty($attrs['caption']) ? $attrs['caption'] : NULL,
     '#error' => !empty($attrs['error']) ? $attrs['error'] : NULL,
+    '#iframe_title' => $iframe_title,
   );
   return drupal_render($build);
 }
@@ -289,6 +295,7 @@ function fsa_shortcodes_theme() {
         'title' => NULL,
         'caption' => NULL,
         'error' => NULL,
+        'iframe_title' => NULL,
       ),
     ),
     'media_embed_error' => array(
@@ -345,13 +352,18 @@ function template_preprocess_media_embed(&$variables) {
       '#theme' => 'media_embed_error',
     );
   }
+  $provider = !empty($variables['provider']) ? $variables['provider'] : 'youtube';
+  
+  // Set the title attribute for the iframe
+  $iframe_title = !empty($variables['iframe_title']) ? $variables['iframe_title'] : $variables['title'];
+  
+  $variables['iframe_attributes_array']['title'] = !empty($iframe_title) ? $iframe_title : t('Embedded content from @provider', array('@provider' => _fsa_shortcodes_provider_name($provider)));
 
   // Set height and width attributes
   if (!empty($variables['width']) && !empty($variables['height'])) {
     $variables['iframe_attributes_array']['width'] = $variables['width'];
     $variables['iframe_attributes_array']['height'] = $variables['height'];
   }
-  $provider = !empty($variables['provider']) ? $variables['provider'] : 'youtube';
   $variables['theme_hook_suggestions'][] = "${provider}_embed";
   $variables['classes_array'] = !empty($variables['classes_array']) ? $variables['classes_array'] : array();
   $variables['classes_array'][] = "${provider}-embed";
@@ -471,6 +483,7 @@ function fsa_shortcodes_shortcode_slideshare($attrs, $text) {
     'title' => NULL,
     'caption' => NULL,
     'error' => NULL,
+    'iframe_title' => NULL,
   );
 
   // If we don't already have an explicitly set ID, we look for the first
@@ -486,9 +499,33 @@ function fsa_shortcodes_shortcode_slideshare($attrs, $text) {
       }
     }
   }
-  
+
   $attrs = shortcode_attrs($defaults, $attrs);
 
   $source_pattern = '//www.slideshare.net/slideshow/embed_code/key/@media_id';
-  return _fsa_shortcodes_embed_media('vimeo', $attrs['id'], $source_pattern, $attrs, $text);
+  return _fsa_shortcodes_embed_media('slideshare', $attrs['id'], $source_pattern, $attrs, $text);
+}
+
+
+/**
+ * Helper function: returns a human-friendly provider name - if available
+ *
+ * @param string $provider
+ *   The machine name of the provider, eg 'youtube'
+ *
+ * @return string
+ *   The human-friendly name of the provider - if available. Otherwise the
+ *   original value of $provider
+ */
+function _fsa_shortcodes_provider_name($provider = '') {
+  $providers = array(
+    'youtube' => t('YouTube'),
+    'ted' => t('TED Talks'),
+    'vimeo' => t('Vimeo'),
+    'slideshare' => t('SlideShare'),
+  );
+  if (!empty($provider) && isset($providers[$provider])) {
+    $provider = $providers[$provider];
+  }
+  return $provider;
 }

--- a/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
+++ b/docroot/sites/all/modules/custom/fsa_shortcodes/fsa_shortcodes.module
@@ -325,14 +325,18 @@ function template_preprocess_media_embed(&$variables) {
   $allow_fullscreen = isset($variables['allow_fullscreen']) ? $variables['allow_fullscreen'] : TRUE;
   if ($allow_fullscreen) {
     $variables['iframe_attributes_array']['allowfullscreen'] = 'allowfullscreen';
-    //$variables['iframe_attributes_array']['webkitallowfullscreen'] = 'true';
-    //$variables['iframe_attributes_array']['mozallowfullscreen'] = 'true';
   }
 
   // Populate the source
   if (!empty($variables['source_pattern']) && !empty($variables['media_id'])) {
     $source = format_string($variables['source_pattern'], array('@media_id' => $variables['media_id']));
-    $variables['iframe_attributes_array']['src'] = $source;
+    $variables['iframe_attributes_array']['src'] = filter_xss($source);
+  }
+  else {
+    // If we don't have a source, there must be an error, so set one now.
+    $variables['error'] = array(
+      '#theme' => 'media_embed_error',
+    );
   }
 
   // Set height and width attributes


### PR DESCRIPTION
As requested by Sally, iframes for embedded media now have a title attribute. By default, this will be the title supplied by the user in the `title` attribute, unless there's an `iframe_title` attribute
supplied. 

If neither is present, a generic `title` is added based on the provider name.

Also:
* Provided better attribute handling for Vimeo and YouTube
* Enabled custom error messages
* Used `filter_xss` for embed source
* Allowed SlideShare embeds

[ Partial fix for #10184 ]