### PR TITLE
Develop: Upgrade module_filter to version 7.x-2.0

### DIFF
--- a/docroot/sites/all/modules/development/module_filter/CHANGELOG.txt
+++ b/docroot/sites/all/modules/development/module_filter/CHANGELOG.txt
@@ -1,41 +1,182 @@
-Module Filter 7.x-1.7, 2012-07-05
+Module Filter 7.x-2.x, 2015-02-20
 ---------------------------------
+Simplifying the table rows by hiding version and requirements until a
+  particular description is clicked.
+
+
+Module Filter 7.x-2.x, 2014-09-01
+---------------------------------
+#2235553 by greenSkin: Fixed latest jquery_update breaks module filter.
+#2304687 by mpdonadio: Fixed Remove hardcoded operations.
+#2293029 by topsitemakers: Fixed Take header offset into account when selecting
+  a tab.
+#2290213 by topsitemakers: Minor typo in description - "has no affect" -> "has
+  no effect".
+
+
+Module Filter 7.x-2.0-alpha2, 2013-12-06
+----------------------------------------
+#2141743, #2141743 by greenSkin: Fixed issues related to the new dynamically
+  positioned tabs and using the dynamically positioned save button.
+
+
+Module Filter 7.x-2.0-alpha1, 2013-11-18
+----------------------------------------
+by greenSkin: Tabs now should always be visible while scrolling large lists of
+  modules.
+#1854348 by alexweber, greenSkin: Make filter textfield wider on modules page
+  when viewing as tabs.
+by greenSkin: Fixed what was suppose to be a call to variable_set().
+#1370492 by greenSkin: Remember selected tab after modules form submit.
+by greenSkin: Changed the title for the 'module_filter_dynamic_save_position'
+  checkbox to make it clearer what it does.
+#1166414 by greenSkin: Fixed broken submit when tabs are disabled. We no longer
+  reroute the theme of the system modules page unless tabs are enabled.
+by greenSkin: Fixed issue on Available updates page where the update state
+  would not be remembered.
+by greenSkin: Fixed 7200 update to rebuild the theme registry at the same time
+  as rebuilding the menu.
+by greenSkin: Fixed issue relating to row coloring when enabling/disabling
+  modules via switch due to recent fix for jQuery Update module.
+by greenSkin: Added functionality to show recently enabled/disabled modules.
+#1710230 by littlekoala, greenSkin: Fixed On | Off buttons does not change
+  state with jquery_update() module active.
+by greenSkin: Added description to filter textfield on permissions page.
+by greenSkin: Added filter to user permissions page.
+by greenSkin: Fixed styling when JavaScript is disabled.
+by greenSkin: Fixed compatiblility with page_actions.
+#1351184 klonos, greenSkin: Added support for update_advanced "Ignored from
+  settings".
+#1149978 by good_man, greenSkin: Added RTL Styling for tabs and toggle switch.
+by greenSkin: Hide toggle switch when JavaScript is disabled.
+by greenSkin: Added support for ctools dropbutton as well as views styling for
+  ctools dropbutton.
+by greenSkin: Improved hash validation.
+by greenSkin: Added ability for tabs to be disabled. Direct use case is when
+  the "New" tab contains zero new modules.
+by greenSkin: Added title to "New" tab link that helps to describe the criteria
+  of a "new" module.
+#1320796 by greenSkin: Added some validation checks before trying to select a
+  tab in case the tab does not actually exist.
+#1429248 by klonos, greenSkin: Fixed Modules page table header overlaps
+  admin_menu().
+#1494694 by greenSkin: Added Let me decide if I want the cursor to focus on the
+  search box or not.
+#1515256 by catmat, greenSkin: Fixed Tabbed theme may remove functional
+  content.
+by greenSkin: Integrated dynamic positioning of the save button back in, but
+  if the module page_actions is enabled we let it handle the save button. See
+  issue #1424994.
+by greenSkin: Clicking on module name now affects the toggle switch.
+by greenSkin: Do not render the switch for incompatible modules.
 #1033012 by greenSkin: Hide incompatible module rows when the 'Unavailable'
   checkbox is unchecked.
-#1170388 by greenSkin: Fixed conflict with Overlay module. Added class
-  "overlay-exclude" to tab links.
+by greenSkin: Performance tweak to counting the number of enabled modules.
+by greenSkin: Base new modules on the filectime of their .info file.
+#1424034 by greenSkin: Now adds the jquery.cookie.js file when needed.
+by greenSkin: Removed tweaks to the save configuration button in favor
+  http://drupal.org/project/page_actions.
+by greenSkin: Updated hook_uninstall to del all Module Filter variables.
+by greenSkin: No longer including machine name in the tab summary of modules to
+  enable/disable.
+by greenSkin: Made switches honor disabled checkboxes. A disabled switch can
+  not be turned on or off.
+by greenSkin: Added setting to toggle between using the switch or checkbox for
+  enabling/disabling modules.
+by greenSkin: Centered enable switch.
+by greenSkin: Moved couple styles to be applied via JavaScript instead of CSS
+  so they get applied once the initial loading has finished.
+by greenSkin: Implemented a "switch" look instead of checkboxes.
+by greenSkin: Remember last selected state on "Available updates" page.
+by greenSkin: Switched to using filectime() rather than filemtime() for
+  determining new modules.
+#1354134 by klonos, greenSkin: Module list now formats correctly in core
+  "Garland" theme.
+#1354134 by klonos, greenSkin: Module list now formats correctly in core
+  "Garland" theme.
 #1124218 by jyee, greenSkin: Suppress form submission when hitting the enter
   key while the filter input is focused.
-
-
-Module Filter 7.x-1.6, 2011-09-15
----------------------------------
-#1241662 by Niklas Fiekas: Sort modules by display name.
+by greenSkin: Simplified filter rules for updates page. Instead of checkboxes,
+  now using radios.
+by greenSkin: Fixed "All" tab to be selected by default when the page is first
+  loaded.
+#1350124 by greenSkin: Fixed filtering on package tab.
+by greenSkin: Added the "All" tab back. Added a "New" tab that lists modules
+  installed within the last week.
+by greenSkin: Fixed "No Results" not showing within selected tabs.
+#1259876 by greenSkin: Filter criteria remembered after save.
+by greenSkin: Remove deprecated function moduleGetID() from JavaScript code.
+by greenSkin: Filter now uses OR instead of AND when filtering multiply
+  queries.
+#1288590 by greenSkin: Fixed Drupal.settings.moduleFilter.enabledCounts[id] is
+  undefined.
+#1344214 by eMPee584: Fixed Notice: Undefined index: #default_value in
+  theme_module_filter_system_modules_tabs().
+#1170388 by greenSkin: Fixed confict with Overlay module. Added class
+  "overlay-exclude" to tab links. Added setting to toggle the use of a URL
+  fragment when selecting tabs.
+by greenSkin: Added README.txt.
+by greenSkin: Fixed table row striping.
+by greenSkin: Fixed regular expression to not require an operator be at the
+  beginning. Make filter queries filter with AND instead of OR. Each query will
+  further filter the list rather than potentially add to it.
+by greenSkin: Spruced up the regular expression for splitting query strings.
+by greenSkin: Added "description:" operator.
+by greenSkin: Added operator support to filter. Added "requires:" and
+  "requiredBy:" operators.
+by greenSkin: Filter now processes multiple queries separated by spaces. Use
+  quotes for a single query that includes space(s).
+by greenSkin: Fixed not updating the index when a module is enabled/disabled.
+by greenSkin: Fixed visual aid for enabling/disabling modules. Previously had
+  failed to remove +/- from tab summary.
+by Kiphaas7, greenSkin: Tabs can now be configured to hide when they contain
+  no results.
+by Kiphaas7, greenSkin: Added result info to tabs. When a filter is performed,
+  a count per tab is displayed of the number of visible results for that tab.
+by greenSkin: Now more descriptive of what modules are being enabled/disabled.
+by greenSkin: Moved module operation links to below "Requires" and
+  "Required by" section.
+by greenSkin: Added a suggest class to tabs when their module is hovered.
+by greenSkin: Distinguished difference between tab ID and hash.
+by greenSkin: Only alter the menu item 'admin/reports/updates' if it first
+  exists.
+by greenSkin: Added update to force a menu rebuild. This is needed to let
+  Module Filter alter the Update Status menu item in order to provide our
+  filter on its page.
 #1254140 by greenSkin: No longer return anything in hook_update_7100.
-by greenSkin: Fixed bug with visual aids sometimes not updating correctly.
-
-
-Module Filter 7.x-1.5, 2011-08-16
----------------------------------
-by greenSkin: Brought the 7.x branch current with the 6.x branch features.
-
-
-Module Filter 7.x-1.3, 2011-03-07
----------------------------------
-by realityloop: Updated CHANGELOG.txt
-
-
-Module Filter 7.x-1.2, 2011-03-07
----------------------------------
-by realityloop: Changed placement of Submit buttons for other languages
-
-
-Module Filter 7.x-1.1, 2011-03-07
----------------------------------
-by realityloop: first commit via git, broke the release somehow :/
-
-
-Module Filter 7.x-1.0, 2011-01-04
----------------------------------
-by realityloop: Fixed Undefined index error.
-by greenSkin: Removed unused .css and .js files.
+#1257860 by greenSkin: Added filter to update status report.
+by greenSkin: Moved hiding of the inputs wrapper to css rather than a style
+  attribute.
+by greenSkin: Added missing semi-colons in JavaScript.
+by greenSkin: Changed hook comment from using "Implementation of" to
+  "Implements".
+by greenSkin: Fixed showing all modules by default when no hash is present.
+by greenSkin: Turned off autocomplete for filter textfield.
+by greenSkin: Now using "all" for hash when no tab is selected.
+by greenSkin: Implemented visual aids (displays number of modules being
+  enabled/disabled as well as coloring the modules row accordingly).
+by greenSkin: Implemented the enabled count (displays the number of enabled
+  modules of total for a package.
+by greenSkin: Updated tabs setting description.
+by greenSkin: Added missing period.
+by greenSkin: Made dynamic save position default to on. Updated element title
+  on admin page and removed "DEVELOPMENTAL" from description.
+by greenSkin: Improved fixed-top positioning when toolbar is enabled.
+by greenSkin: Added fixed classes for submit button wrapper.
+by greenSkin: Changed module-filter-tabs from a class to an id.
+by greenSkin: Fixed filter on modules page when tabs are disabled.
+by greenSkin: Set min-height to #module-filter-modules.
+by greenSkin: Implemented module_filter element and using attached js and css
+  more.
+by greenSkin: Filter input and checkboxes can now have their default values set
+  based on query params.
+by greenSkin: Tabs now use URL fragments.
+by greenSkin: Fixed regular expression used to determine tab ID.
+by greenSkin: Tabs have been re-written and are functioning.
+by greenSkin: Added Module Filter to "Administration" package.
+by greenSkin: Improved filtering performance.
+by greenSkin: New filter code.
+by greenSkin: Initial tab layout modified. Modules are all in one table but
+  look like they are in packages. All JavaScript has to do on load now is
+  remove the package name and header rows from tbody then sort the rows.
+by greenSkin: Modified the menu item's description.

--- a/docroot/sites/all/modules/development/module_filter/README.txt
+++ b/docroot/sites/all/modules/development/module_filter/README.txt
@@ -1,0 +1,107 @@
+Description
+-----------
+This module provides a method for filtering modules on the modules page as well
+as for filtering projects on the update status report.
+
+The supplied filter is simpler than using your browsers find feature which
+searches the entire page. The provided filter will filter modules/projects that
+do not meet your input.
+
+Along with the filter textfield there are additional
+checkboxes that help to narrow the search more. The modules page contains four
+checkboxes: Enabled, Disabled, Required, and Unavailable. While the first two
+are self-explanatory, the latter two can take an explanation. The Required
+checkbox affects visibility of modules that are enabled and have other
+module(s) that require it also enabled. The Unavailable checkbox affects
+visibility of modules that are disabled and depend on module(s) that are
+missing.
+
+The update status report filter also contains four checkboxes: Up-to-Date,
+Update availabe, Security update, and Unknown. These directly affect the
+visibilty of each project; whether it is up-to-date, there is an update
+available, a security update is available, or the status is unknown.
+
+Installation
+------------
+To install this module, do the following:
+
+1. Extract the tar ball that you downloaded from Drupal.org.
+
+2. Upload the entire directory and all its contents to your modules directory.
+
+Configuration
+-------------
+To enable and configure this module do the following:
+
+1. Go to Admin -> Modules, and enable Module Filter.
+
+2. Go to Admin -> Configuration -> User interface -> Module filter, and make
+   any necessary configuration changes. 
+
+Tabs
+----
+By default Module Filter alters the modules page into tabs (Can be disabled on
+configuration page). In the tabs view, each package is converted to a vertical
+tab rather than a fieldset which greatly increases the ability to browse them.
+
+There are several benefits to using the tabs view over the standard view for
+the modules page. I've listed the key benefits below as well as additional
+information that pertains to each.
+
+1.  The increased ease of browsing between packages.
+
+2.  Allows all modules to be listed alphabetically outside of their package,
+    making it all the easier to find the module by name rather than package it
+    happens to be in.
+
+3.  The operations for a module are moved within the description column giving
+    the description more "elbow room".
+
+4.  Filtering is restricted to within the active tab or globally when no tab is
+    selected. By default no tab is selected which will list all modules. When a
+    tab is active and you want to get back to the 'all' state click on the
+    active tab to deselect it.
+
+5.  The number of enabled modules per tab is shown on the active tab. (Can be
+    disabled on configuration page)
+
+6.  Nice visual aids become available showing what modules are to be
+    enabled/disabled and the number of matching modules in each tab when
+    filtering. (Can be disabled on configuration page)
+
+7.  The save configuration button becomes more accessible, either staying at
+    the bottom of the window when the tabs exceed past the bottom and at the
+    top when scrolling past the tabs. (Can be disabled on configuration page)
+
+8.  When filtering, tabs that do not contain matches can be hidden. (Can be
+    enabled on configuration page)
+
+9.  Tab states are remembered like individual pages allowing you to move
+    forward and backward within your selections via your browsers
+    forward/backward buttons.
+
+10. When viewing all modules (no active tab) and mousing over modules it's tab
+    becomes highlighted to signify which tab it belongs to.
+
+Filter operators
+----------------
+The modules page's filter has three filter operators available. Filter
+operators allow alternative filtering techniques. A filter operator is applied
+by typing within the filter textfield 'operator:' (where operator is the
+operator type) followed immediately with the string to pass to the operator
+function (e.g. 'requires:block'). The available operators are:
+
+description:
+   Filter based on a module's description.
+
+requiredBy:
+   Filter based on what a module is required by.
+
+requires:
+   Filter based on what a module requires.
+
+Multiple filters (or queries) can be applied by space delimiting. For example,
+the filter string 'description:ctools views' would filter down to modules with
+"ctools" in the description and "views" within the module's name. To pass a
+space within a single query wrap it within double quotes (e.g. 'requires:"chaos
+tools"' or '"bulk export"').

--- a/docroot/sites/all/modules/development/module_filter/css/dynamic_position.css
+++ b/docroot/sites/all/modules/development/module_filter/css/dynamic_position.css
@@ -1,0 +1,23 @@
+html.js #module-filter-submit {
+  background-color: #F6F6F6;
+  width: 239px;
+  border: 1px solid #ccc;
+  border-top: 0;
+}
+html.js #module-filter-submit .form-actions {
+  text-align: center;
+  margin: 0;
+}
+html.js #module-filter-submit input {
+  margin: 2em 0 1em;
+}
+html.js #module-filter-submit.fixed {
+  position: fixed;
+  border-top: 1px solid #ccc;
+}
+html.js #module-filter-submit.fixed-top {
+  top: 0;
+}
+html.js #module-filter-submit.fixed-bottom {
+  bottom: 0;
+}

--- a/docroot/sites/all/modules/development/module_filter/css/module_filter.css
+++ b/docroot/sites/all/modules/development/module_filter/css/module_filter.css
@@ -1,4 +1,20 @@
-
+.module-filter-inputs-wrapper {
+  display: none;
+}
+.module-filter-clear {
+  display: inline;
+  position: relative;
+}
+.module-filter-clear a {
+  margin-left: 5px;
+  font-size: 11px;
+  position: absolute;
+}
 #module-filter-show-wrapper .form-item {
   display: inline;
+}
+.module-filter-no-results {
+  text-align: center;
+  text-transform: uppercase;
+  color: #888;
 }

--- a/docroot/sites/all/modules/development/module_filter/css/module_filter_tab-rtl.css
+++ b/docroot/sites/all/modules/development/module_filter/css/module_filter_tab-rtl.css
@@ -1,0 +1,54 @@
+#module-filter-tabs {
+  float: right;
+}
+#module-filter-tabs li.selected a,
+#module-filter-tabs li.selected a:hover,
+#module-filter-tabs li.selected a:focus,
+#module-filter-tabs li.selected a:active {
+  background-color: #fff;
+  margin-left: -1px;
+  margin-right: 0;
+}
+.admin-operations {
+  float: left;
+}
+#module-filter-modules {
+  margin-right: 240px;
+}
+html.js .toggle-enable {
+  background-image: -webkit-gradient(linear, 100% 0%, 0% 0%, color-stop(50%, red), color-stop(50%, orange), color-stop(100%, orange));
+  background-image: -moz-linear-gradient(right, red 50%, orange 50%, orange 100%);
+  background-image: linear-gradient(right, red 50%, orange 50%, orange 100%);
+}
+html.js .toggle-enable.enabled {
+  background-image: -webkit-gradient(linear, 100% 0%, 0% 0%, color-stop(50%, orange), color-stop(50%, green), color-stop(100%, green));
+  background-image: -moz-linear-gradient(right, orange 50%, green 50%, green 100%);
+  background-image: linear-gradient(right, orange 50%, green 50%, green 100%);
+}
+html.js .toggle-enable.disabled {
+  background: #ccc;
+  border-color: #ddd;
+  cursor: auto;
+}
+html.js .toggle-enable.disabled div {
+  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, color-stop(0%, #FEFEFE), color-stop(100%, #EEEEEE));
+  background-image: -moz-linear-gradient(top, #FEFEFE 0%, #EEEEEE 100%);
+  background-image: linear-gradient(top, #FEFEFE 0%, #EEEEEE 100%);
+}
+html.js .toggle-enable div {
+  -webkit-transition: right 0.2s;
+  -mox-transition: right 0.2s;
+  -o-transition: right 0.2s;
+  transition: right 0.2s;
+}
+html.js .toggle-enable div:before {
+  content: "ON";
+  left: -24px;
+}
+html.js .toggle-enable div:after {
+  content: "OFF";
+  left: -24px;
+}
+html.js .toggle-enable.off div {
+  right: 24px;
+}

--- a/docroot/sites/all/modules/development/module_filter/css/module_filter_tab.css
+++ b/docroot/sites/all/modules/development/module_filter/css/module_filter_tab.css
@@ -1,136 +1,262 @@
+.sticky-header {
+  z-index: 1;
+}
 
-#module-filter-wrapper .form-item {
-  border: 0px none;
+#module-filter-tabs {
+  float: left;
+}
+#module-filter-tabs ul {
+  width: 239px;
+  list-style: none;
+  list-style-image: none;
+  background-color: #ddd;
+  border: 1px solid #ccc;
+  border-top: none;
+  margin: 0;
+  padding: 0;
+  line-height: 1;
+}
+#module-filter-tabs li {
+  background: #eee;
+  border-top: 1px solid #ccc;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+#module-filter-tabs li#new-tab {
+  margin-bottom: 10px;
+  border-bottom: 1px solid #ccc;
+}
+#module-filter-tabs li.disabled,
+#module-filter-tabs li#new-tab.disabled {
+  pointer-events: none;
+  cursor: default;
+  background: #ccc;
+  border-top-color: #bbb;
+  border-bottom-color: #bbb;
+}
+#module-filter-tabs li.disabled a,
+#module-filter-tabs li.disabled span {
+  color: #999;
+}
+#module-filter-tabs li.suggest {
+  background: #F9F9F9;
+}
+#module-filter-tabs li a {
+  display: block;
+  text-decoration: none;
+  padding: 10px;
+}
+#module-filter-tabs li a span.result-info {
+  float: right;
+  font-size: 10px;
+  color: #999;
+  margin-top: 3px;
+}
+#module-filter-tabs li a span.visual-aid {
+  font-size: 8px;
+/*  float: right;*/
+}
+#module-filter-tabs li span.visual-aid {
+  font-weight: bold;
+}
+#module-filter-tabs li a span.enabling {
+  color: green;
+}
+#module-filter-tabs li a span.disabling {
+  color: red;
+}
+#module-filter-tabs li strong {
+  font-size: 0.923em;
+}
+#module-filter-tabs li a:hover,
+#module-filter-tabs li a:focus {
+  outline: 1px dotted;
+  background: #d5d5d5;
+  text-decoration: none;
+  outline: 0;
+}
+#module-filter-tabs li.selected a,
+#module-filter-tabs li.selected a:hover,
+#module-filter-tabs li.selected a:focus,
+#module-filter-tabs li.selected a:active {
+  background-color: #fff;
+  margin-right: -1px;
+}
+#module-filter-tabs li .summary {
+  display: block;
+  margin-bottom: 0;
+  color: #666;
+  font-size: 0.846em;
+  padding-top: 0.4em;
+}
+#module-filter-tabs li .summary .count {
+  display: none;
+}
+#module-filter-tabs li.selected .summary .count {
+  display: block;
+}
+html.js #module-filter-submit input {
+  margin: 2em 2em 1em;
+}
+html.js .module-filter-inputs-wrapper {
+  text-align: center;
+}
+html.js .module-filter-inputs-wrapper .form-item {
   margin: 0;
   padding: 9px;
 }
-#module-filter-wrapper .form-item:after {
-/*  display: block;*/
-  clear: none;
+html.js .module-filter-inputs-wrapper label {
+  display: inline;
 }
-#module-filter-left {
-  float: left;
-  background-color: #F6F6F6;
-  border: 1px solid #D6DBDE;
-  margin-right: -1px;
-  width: 185px;
+html.js .module-filter-inputs-wrapper input[name="module_filter[name]"] {
+  width: 80%;
 }
-#module-filter-left ul {
-  margin: 0px;
-  padding: 0px;
-  list-style: none;
+html.js #module-filter-show-wrapper {
+  margin-bottom: 1em;
 }
-#module-filter-left ul li {
-  background: #EFEFEF none repeat scroll 0 0;;
-  border-bottom: 1px solid #D6DBDE;
-  margin: 0px;
-  padding: 0px;
-  list-style-image: none;
+html.js #module-filter-modules {
+  margin-left: 240px;
+  border: 1px solid #ccc;
 }
-#module-filter-left ul li.active {
-  margin-right: -1px;
-  width: 186px;
-  background-color: #FFFFFF;
-  position: relative;
+#module-filter-modules table {
+  border-top: none;
+  border-right: none;
+  border-left: none;
 }
-#module-filter-left ul li a {
-  color: #777777;
-  display: block;
-  padding: 0.5em;
-  line-height: 100%;
-  font-size: 90%;
-  outline: none;
-}
-#module-filter-left ul li.active a {
-  background-color: #FFFFFF;
-  color: #000000;
-  font-weight: bold;
-}
-#module-filter-left ul li a:hover {
-  background-color: #F6F6F6;
-  text-decoration: none;
-}
-#module-filter-left ul li.active a:hover {
-  background-color: #FFFFFF;
-}
-#module-filter-left ul li a span.visual-aid {
-  font-size: 8px;
-  float: right;
-}
-#module-filter-left ul li a span.enabling {
-  color: green;
-}
-#module-filter-left ul li a span.disabling {
-  color: red;
-  margin-left: 5px;
-}
-#module-filter-left ul li a span.counts {
-  font-weight: normal;
-  display: none;
-  font-size: 0.8em;
-  color: #333333;
-  padding: 2px 0 0;
-}
-#module-filter-left ul li.active a span.counts {
-  display: block;
-}
-#module-filter-submit {
+html.js #module-filter-modules table {
   margin: 0;
+  border-bottom: none;
 }
-#module-filter-submit .form-actions {
-  text-align: center;
+html.js #module-filter-modules table tr,
+html.js #module-filter-modules table td {
+  border-left: 0;
+  border-right: 0;
 }
-#module-filter-submit input.form-submit {
-  margin: 1em 0 0;
+#module-filter-modules table thead {
+  display: none;
 }
-#module-filter-submit.fixed {
-  position: fixed;
-  background-color: #F6F6F6;
-  border: 1px solid #D6DBDE;
-  margin-left: -1px;
-  width: 185px;
+#module-filter-modules table tr.admin-package-title,
+#module-filter-modules table tr.admin-package-title td {
+  border: none !important;
+  border-top: 1px solid #ccc !important;
+  background-color: transparent !important;
+  padding: 10px 0 0;
 }
-#module-filter-submit.fixed-top {
-  top: 0;
+#module-filter-modules table tr.admin-package-title.first,
+#module-filter-modules table tr.admin-package-title.first td {
+  border-top: none !important;
 }
-#module-filter-submit.fixed-bottom {
-  bottom: 0;
+#module-filter-modules table tr.admin-package-header td {
+  border: 1px solid #ccc;
+  text-transform: uppercase;
+  background: #E1E2DC;
+  font-weight: normal;
+  padding: 3px 10px;
 }
-#module-filter-right {
-  display: block;
-}
-#module-filter-squeeze {
-  margin-left: 186px;
-  background-color: #FFFFFF;
-  border: 1px solid #D6DBDE;
-  height: auto !important;
-}
-.form-item-module-filter-name {
-  text-align: center;
-}
-.form-item-module-filter-name label {
-  display: inline;
-}
-#module-filter-show-wrapper .form-checkboxes {
-  text-align: center;
-}
-#module-filter-show-wrapper .form-item:after {
-  display: inline;
-}
-table.package {
-  margin: 1em 0;
-}
-table.package,
-table.package thead,
-table.package tbody,
-table.package tbody tr,
-table.package td:last-child {
-  border-right: 0 none;
-  border-left: 0 none;
-}
-table.package tr.enabling {
+#module-filter-modules table tr.enabling {
   background-color: #dfd;
 }
-table.package tr.disabling {
+#module-filter-modules table tr.disabling {
   background-color: #fcc;
+}
+#module-filter-modules span.module-machine-name {
+  font-size: 0.9em;
+  font-weight: normal;
+}
+.admin-version {
+  white-space: nowrap;
+}
+.admin-operations {
+  float: right;
+}
+.admin-operations a.module-link {
+  display: inline;
+}
+
+html.js .toggle-enable {
+  margin: auto;
+  position: relative;
+  width: 50px;
+  overflow: hidden;
+  height: 18px;
+  line-height: 18px;
+  font-size: 11px;
+  text-align: center;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  -khtml-border-radius: 3px;
+  border-radius: 3px;
+  -moz-box-shadow: 0 0 10px rgba(0,0,0,0.50) inset;
+  -webkit-box-shadow: 0 0 10px rgba(0,0,0,0.50) inset;
+  box-shadow: 0 0 10px rgba(0,0,0,0.50) inset;
+  background-clip: padding-box;
+  background-image: -webkit-gradient(linear, 0% 0%, 100% 0%, color-stop(50%, red), color-stop(50%, orange), color-stop(100%, orange));
+  background-image: -moz-linear-gradient(left, red 50%, orange 50%, orange 100%);
+  background-image: linear-gradient(left, red 50%, orange 50%, orange 100%);
+}
+html.js .toggle-enable.enabled {
+  background-image: -webkit-gradient(linear, 0% 0%, 100% 0%, color-stop(50%, orange), color-stop(50%, green), color-stop(100%, green));
+  background-image: -moz-linear-gradient(left, orange 50%, green 50%, green 100%);
+  background-image: linear-gradient(left, orange 50%, green 50%, green 100%);
+}
+html.js .toggle-enable.disabled {
+  background: #ccc;
+  border-color: #ddd;
+  cursor: auto;
+}
+html.js .toggle-enable div {
+  position: relative;
+  color: #777;
+  width: 26px;
+  -moz-border-radius: 2px;
+  -webkit-border-radius: 2px;
+  -khtml-border-radius: 2px;
+  border-radius: 2px;
+  background: white;
+  text-shadow: 1px 1px 0 white;
+  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, color-stop(0%, #FEFEFE), color-stop(100%, #EAEAEA));
+  background-image: -moz-linear-gradient(top, #FEFEFE 0%, #EAEAEA 100%);
+  background-image: linear-gradient(top, #FEFEFE 0%, #EAEAEA 100%);
+  -webkit-transition: left 0.2s;
+  -mox-transition: left 0.2s;
+  -o-transition: left 0.2s;
+  transition: left 0.2s;
+}
+html.js .toggle-enable.disabled div {
+  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, color-stop(0%, #FEFEFE), color-stop(100%, #EEEEEE));
+  background-image: -moz-linear-gradient(top, #FEFEFE 0%, #EEEEEE 100%);
+  background-image: linear-gradient(top, #FEFEFE 0%, #EEEEEE 100%);
+}
+html.js .toggle-enable div:after,
+html.js .toggle-enable div:before {
+  color: white;
+  text-shadow: none;
+  width: 25px;
+  position: absolute;
+  top: 0;
+  font-size: 9px;
+  font-weight: bold;
+}
+html.js .toggle-enable div:before {
+  content: "OFF";
+  left: -24px;
+}
+html.js .toggle-enable div:after {
+  content: "ON";
+  right: -24px;
+}
+html.js .toggle-enable.off div {
+  left: 24px;
+}
+
+#module-filter-tabs.top-fixed {
+  position: fixed;
+  top: 0;
+}
+#module-filter-tabs.bottom-fixed {
+  position: fixed;
+  bottom: 0;
 }

--- a/docroot/sites/all/modules/development/module_filter/css/modules.css
+++ b/docroot/sites/all/modules/development/module_filter/css/modules.css
@@ -1,0 +1,47 @@
+#system-modules table {
+  table-layout: fixed;
+}
+#system-modules th.checkbox {
+  width: 8%;
+}
+#system-modules th.name {
+  width: 25%;
+}
+#system-modules th.links {
+  width: 15%;
+}
+#system-modules td {
+  vertical-align: top;
+}
+#system-modules .expand.inner {
+  background: transparent url(/misc/menu-collapsed.png) left 0.6em no-repeat;
+  margin-left: -12px;
+  padding-left: 12px;
+}
+#system-modules .expanded.expand.inner {
+  background: transparent url(/misc/menu-expanded.png) left 0.6em no-repeat;
+}
+#system-modules .description {
+  cursor: pointer;
+}
+#system-modules .description .inner {
+  overflow: hidden; /* truncates descriptions if too long */
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+#system-modules .description .requirements,
+#system-modules .description .links {
+  display: none;
+}
+#system-modules .description .expanded.inner {
+  overflow: visible;
+  white-space: normal;
+}
+#system-modules .description .expanded .requirements,
+#system-modules .description .expanded .links {
+  display: block;
+}
+#system-modules .requirements {
+  padding: 5px 0;
+  max-width: 490px;
+}

--- a/docroot/sites/all/modules/development/module_filter/css/update_status.css
+++ b/docroot/sites/all/modules/development/module_filter/css/update_status.css
@@ -1,0 +1,18 @@
+#module-filter-update-status-form {
+  float: right;
+}
+.module-filter-inputs-wrapper label {
+  display: inline;
+}
+.module-filter-inputs-wrapper .form-item-module-filter-name {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  text-align: right;
+}
+#module-filter-show-wrapper .form-item {
+  padding: 5px;
+}
+p.module-filter-no-results {
+  clear: both;
+  padding-top: 30px;
+}

--- a/docroot/sites/all/modules/development/module_filter/js/dynamic_position.js
+++ b/docroot/sites/all/modules/development/module_filter/js/dynamic_position.js
@@ -1,33 +1,48 @@
 (function($) {
-  Drupal.behaviors.moduleFilterDynamicPosition = {
-    attach: function() {
-      $(window).scroll(function() {
+
+Drupal.behaviors.moduleFilterDynamicPosition = {
+  attach: function(context) {
+    var $window = $(window);
+
+    $('#module-filter-wrapper', context).once('dynamic-position', function() {
+      // Move the submit button just below the tabs.
+      $('#module-filter-tabs').append($('#module-filter-submit'));
+
+      var positionSubmit = function() {
+        var $tabs = $('#module-filter-tabs');
+        var $submit = $('#module-filter-submit', $tabs);
+
         // Vertical movement.
-        var top = $('#module-filter-tabs').offset().top;
-        var bottom = top + $('#module-filter-tabs').height();
-        var windowHeight = $(window).height();
-        if (((bottom - windowHeight) > ($(window).scrollTop() - $('#module-filter-submit').height())) && $(window).scrollTop() + windowHeight - $('#module-filter-submit').height() - $('#all-tab').height() > top) {
-          $('#module-filter-submit').removeClass('fixed-top').addClass('fixed fixed-bottom');
+        var bottom = $tabs.offset().top + $tabs.outerHeight();
+        if ($submit.hasClass('fixed-bottom')) {
+          bottom += $submit.height();
         }
-        else if (bottom < $(window).scrollTop()) {
-          $('#module-filter-submit').removeClass('fixed-bottom').addClass('fixed fixed-top');
+        if (bottom >= $window.height() + $window.scrollTop()) {
+          $submit.addClass('fixed fixed-bottom');
+          $tabs.css('padding-bottom', $submit.height());
         }
         else {
-          $('#module-filter-submit').removeClass('fixed fixed-bottom fixed-top');
+          $submit.removeClass('fixed fixed-bottom');
+          $tabs.css('padding-bottom', 0);
         }
 
         // Horizontal movement.
-        if ($('#module-filter-submit').hasClass('fixed-bottom') || $('#module-filter-submit').hasClass('fixed-top')) {
-          var left = $('#module-filter-tabs').offset().left - $(window).scrollLeft();
-          if (left != $('#module-filter-submit').offset().left - $(window).scrollLeft()) {
-            $('#module-filter-submit').css('left', left);
+        if ($submit.hasClass('fixed-bottom') || $submit.hasClass('fixed-top')) {
+          var left = $tabs.offset().left - $window.scrollLeft();
+          if (left != $submit.offset().left - $window.scrollLeft()) {
+            $submit.css('left', left);
           }
         }
-      });
-      $(window).trigger('scroll');
-      $(window).resize(function() {
-        $(window).trigger('scroll');
-      });
-    }
+      };
+
+      // Control the positioning.
+      $window.scroll(positionSubmit);
+      $window.resize(positionSubmit);
+      var moduleFilter = $('input[name="module_filter[name]"]').data('moduleFilter');
+      moduleFilter.element.bind('moduleFilter:adjustHeight', positionSubmit);
+      moduleFilter.adjustHeight();
+    });
   }
+};
+
 })(jQuery);

--- a/docroot/sites/all/modules/development/module_filter/js/module_filter.js
+++ b/docroot/sites/all/modules/development/module_filter/js/module_filter.js
@@ -1,120 +1,271 @@
-
 (function ($) {
-  var moduleFilterTimeOut;
-  var moduleFilterTextFilter = '';
 
-  Drupal.behaviors.moduleFilter = {
-    attach: function() {
-      $("#module-filter-wrapper").show();
-      $('input[name="module_filter[name]"]').focus();
-      $('input[name="module_filter[name]"]').keyup(function(e) {
-        switch (e.which) {
-          case 13:
-            if (moduleFilterTimeOut) {
-              clearTimeout(moduleFilterTimeOut);
-            }
+Drupal.ModuleFilter = {};
 
-            moduleFilter(moduleFilterTextFilter);
-            break;
-          default:
-            if (moduleFilterTextFilter != $(this).val()) {
-              moduleFilterTextFilter = this.value;
-              if (moduleFilterTimeOut) {
-                clearTimeout(moduleFilterTimeOut);
-              }
+Drupal.ModuleFilter.explode = function(string) {
+  var queryArray = string.match(/([a-zA-Z]+\:(\w+|"[^"]+")*)|\w+|"[^"]+"/g);
+  if (!queryArray) {
+    queryArray = new Array();
+  }
+  var i = queryArray.length;
+  while (i--) {
+    queryArray[i] = queryArray[i].replace(/"/g, "");
+  }
+  return queryArray;
+};
 
-              moduleFilterTimeOut = setTimeout('moduleFilter("' + moduleFilterTextFilter + '")', 500);
-            }
-            break;
+Drupal.ModuleFilter.getState = function(key) {
+  if (!Drupal.ModuleFilter.state) {
+    Drupal.ModuleFilter.state = {};
+    var cookie = $.cookie('DrupalModuleFilter');
+    var query = cookie ? cookie.split('&') : [];
+    if (query) {
+      for (var i in query) {
+        // Extra check to avoid js errors in Chrome, IE and Safari when
+        // combined with JS like twitter's widget.js.
+        // See http://drupal.org/node/798764.
+        if (typeof(query[i]) == 'string' && query[i].indexOf('=') != -1) {
+          var values = query[i].split('=');
+          if (values.length === 2) {
+            Drupal.ModuleFilter.state[values[0]] = values[1];
+          }
         }
-      });
-      $('input[name="module_filter[name]"]').keypress(function(e) {
-        if (e.which == 13) e.preventDefault();
-      });
-
-      $('#edit-module-filter-show-enabled').change(function() {
-        moduleFilter($('input[name="module_filter[name]"]').val());
-      });
-      $('#edit-module-filter-show-disabled').change(function() {
-        moduleFilter($('input[name="module_filter[name]"]').val());
-      });
-      $('#edit-module-filter-show-required').change(function() {
-        moduleFilter($('input[name="module_filter[name]"]').val());
-      });
-      $('#edit-module-filter-show-unavailable').change(function() {
-        moduleFilter($('input[name="module_filter[name]"]').val());
-      });
+      }
     }
   }
+  return Drupal.ModuleFilter.state[key] ? Drupal.ModuleFilter.state[key] : false;
+};
 
-  moduleFilter = function(string) {
-    stringLowerCase = string.toLowerCase();
+Drupal.ModuleFilter.setState = function(key, value) {
+  var existing = Drupal.ModuleFilter.getState(key);
+  if (existing != value) {
+    Drupal.ModuleFilter.state[key] = value;
+    var query = [];
+    for (var i in Drupal.ModuleFilter.state) {
+      query.push(i + '=' + Drupal.ModuleFilter.state[i]);
+    }
+    $.cookie('DrupalModuleFilter', query.join('&'), { expires: 7, path: '/' });
+  }
+};
 
-    $("fieldset table tbody tr td label > strong").each(function(i) {
-      var $row = $(this).parents('tr');
-      var module = $(this).text();
-      var moduleLowerCase = module.toLowerCase();
-      var $fieldset = $row.parents('fieldset');
+Drupal.ModuleFilter.Filter = function(element, selector, options) {
+  var self = this;
 
-      if (string != '') {
-        if ($fieldset.hasClass('collapsed')) {
-          $fieldset.removeClass('collapsed');
+  this.element = element;
+  this.text = $(this.element).val();
+
+  this.settings = Drupal.settings.moduleFilter;
+
+  this.selector = selector;
+
+  this.options = $.extend({
+    delay: 500,
+    striping: false,
+    childSelector: null,
+    empty: Drupal.t('No results'),
+    rules: new Array()
+  }, options);
+  if (this.options.wrapper == undefined) {
+    this.options.wrapper = $(self.selector).parent();
+  }
+
+  // Add clear button.
+  this.element.after('<div class="module-filter-clear"><a href="#" class="js-hide">' + Drupal.t('clear') + '</a></div>');
+  if (this.text) {
+    $('.module-filter-clear a', this.element.parent()).removeClass('js-hide');
+  }
+  $('.module-filter-clear a', this.element.parent()).click(function() {
+    self.element.val('');
+    self.text = '';
+    delete self.queries;
+    self.applyFilter();
+    self.element.focus();
+    $(this).addClass('js-hide');
+    return false;
+  });
+
+  this.updateQueries = function() {
+    var queryStrings = Drupal.ModuleFilter.explode(self.text);
+
+    self.queries = new Array();
+    for (var i in queryStrings) {
+      var query = { operator: 'text', string: queryStrings[i] };
+
+      if (self.operators != undefined) {
+        // Check if an operator is possibly used.
+        if (queryStrings[i].indexOf(':') > 0) {
+          // Determine operator used.
+          var args = queryStrings[i].split(':', 2);
+          var operator = args.shift();
+          if (self.operators[operator] != undefined) {
+            query.operator = operator;
+            query.string = args.shift();
+          }
         }
       }
 
-      if (moduleLowerCase.match(stringLowerCase)) {
-        if (moduleFilterVisible($('td.checkbox input', $row))) {
-          if (!$row.is(':visible')) {
-            $row.show();
-            if ($fieldset.hasClass('collapsed')) {
-              $fieldset.removeClass('collapsed');
-            }
-            if (!$fieldset.is(':visible')) {
-              $fieldset.show();
-            }
+      query.string = query.string.toLowerCase();
+
+      self.queries.push(query);
+    }
+
+    if (self.queries.length <= 0) {
+      // Add a blank string query.
+      self.queries.push({ operator: 'text', string: '' });
+    }
+  };
+
+  this.applyFilter = function() {
+    self.results = new Array();
+
+    self.updateQueries();
+
+    if (self.index == undefined) {
+      self.buildIndex();
+    }
+
+    self.element.trigger('moduleFilter:start');
+
+    $.each(self.index, function(key, item) {
+      var $item = item.element;
+
+      for (var i in self.queries) {
+        var query = self.queries[i];
+        if (query.operator == 'text') {
+          if (item.text.indexOf(query.string) < 0) {
+            continue;
           }
         }
         else {
-          $row.hide();
-          if ($row.siblings(':visible').html() == null) {
-            $fieldset.hide();
+          var func = self.operators[query.operator];
+          if (!(func(query.string, self, item))) {
+            continue;
           }
         }
-      }
-      else {
-        if ($row.is(':visible')) {
-          $row.hide();
-          if ($row.siblings(':visible').html() == null) {
-            $fieldset.hide();
-          }
-        }
-      }
-    });
-  }
 
-  moduleFilterVisible = function(checkbox) {
-    if (checkbox.length > 0) {
-      if ($('#edit-module-filter-show-enabled').is(':checked')) {
-        if ($(checkbox).is(':checked') && !$(checkbox).is(':disabled')) {
+        var rulesResult = self.processRules(item);
+        if (rulesResult !== false) {
           return true;
         }
       }
-      if ($('#edit-module-filter-show-disabled').is(':checked')) {
-        if (!$(checkbox).is(':checked') && !$(checkbox).is(':disabled')) {
-          return true;
+
+      $item.addClass('js-hide');
+    });
+
+    self.element.trigger('moduleFilter:finish', { results: self.results });
+
+    if (self.options.striping) {
+      self.stripe();
+    }
+
+    if (self.results.length > 0) {
+      self.options.wrapper.find('.module-filter-no-results').remove();
+    }
+    else {
+      if (!self.options.wrapper.find('.module-filter-no-results').length) {
+        self.options.wrapper.append($('<p class="module-filter-no-results"/>').text(self.options.empty));
+      };
+    }
+  };
+
+  self.element.keyup(function(e) {
+    switch (e.which) {
+      case 13:
+        if (self.timeOut) {
+          clearTimeout(self.timeOut);
         }
-      }
-      if ($('#edit-module-filter-show-required').is(':checked')) {
-        if ($(checkbox).is(':checked') && $(checkbox).is(':disabled')) {
-          return true;
+        self.applyFilter();
+        break;
+      default:
+        if (self.text != $(this).val()) {
+          if (self.timeOut) {
+            clearTimeout(self.timeOut);
+          }
+
+          self.text = $(this).val();
+
+          if (self.text) {
+            self.element.parent().find('.module-filter-clear a').removeClass('js-hide');
+          }
+          else {
+            self.element.parent().find('.module-filter-clear a').addClass('js-hide');
+          }
+
+          self.element.trigger('moduleFilter:keyup');
+
+          self.timeOut = setTimeout(self.applyFilter, self.options.delay);
         }
+        break;
+    }
+  });
+
+  self.element.keypress(function(e) {
+    if (e.which == 13) e.preventDefault();
+  });
+};
+
+Drupal.ModuleFilter.Filter.prototype.buildIndex = function() {
+  var self = this;
+  var index = new Array();
+  $(this.selector).each(function(i) {
+    var text = (self.options.childSelector) ? $(self.options.childSelector, this).text() : $(this).text();
+    var item = {
+      key: i,
+      element: $(this),
+      text: text.toLowerCase()
+    };
+    for (var j in self.options.buildIndex) {
+      var func = self.options.buildIndex[j];
+      item = $.extend(func(self, item), item);
+    }
+    $(this).data('indexKey', i);
+    index.push(item);
+    delete item;
+  });
+  this.index = index;
+};
+
+Drupal.ModuleFilter.Filter.prototype.processRules = function(item) {
+  var self = this;
+  var $item = item.element;
+  var rulesResult = true;
+  if (self.options.rules.length > 0) {
+    for (var i in self.options.rules) {
+      var func = self.options.rules[i];
+      rulesResult = func(self, item);
+      if (rulesResult === false) {
+        break;
       }
     }
-    if ($('#edit-module-filter-show-unavailable').is(':checked')) {
-      if (checkbox.length == 0 || ($(checkbox).size() > 0 && !$(checkbox).is(':checked') && $(checkbox).is(':disabled'))) {
-        return true;
-      }
-    }
-    return false;
   }
+  if (rulesResult !== false) {
+    $item.removeClass('js-hide');
+    self.results.push(item);
+  }
+  return rulesResult;
+};
+
+Drupal.ModuleFilter.Filter.prototype.stripe = function() {
+  var self = this;
+  var flip = { even: 'odd', odd: 'even' };
+  var stripe = 'odd';
+
+  $.each(self.index, function(key, item) {
+    if (!item.element.hasClass('js-hide')) {
+      item.element.removeClass('odd even')
+        .addClass(stripe);
+      stripe = flip[stripe];
+    }
+  });
+};
+
+$.fn.moduleFilter = function(selector, options) {
+  var filterInput = this;
+  filterInput.parents('.module-filter-inputs-wrapper').show();
+  if (Drupal.settings.moduleFilter.setFocus) {
+    filterInput.focus();
+  }
+  filterInput.data('moduleFilter', new Drupal.ModuleFilter.Filter(this, selector, options));
+};
+
 })(jQuery);

--- a/docroot/sites/all/modules/development/module_filter/js/module_filter_tab.js
+++ b/docroot/sites/all/modules/development/module_filter/js/module_filter_tab.js
@@ -1,281 +1,562 @@
 
 (function ($) {
-  Drupal.ModuleFilter = Drupal.ModuleFilter || {};
-  Drupal.ModuleFilter.textFilter = '';
-  Drupal.ModuleFilter.timeout;
-  Drupal.ModuleFilter.tabs = {};
-  Drupal.ModuleFilter.enabling = {};
-  Drupal.ModuleFilter.disabling = {};
 
-  Drupal.behaviors.moduleFilter = {
-    attach: function() {
-      // Set the focus on the module filter textfield.
-      $('input[name="module_filter[name]"]').focus();
+Drupal.ModuleFilter.tabs = {};
+Drupal.ModuleFilter.enabling = {};
+Drupal.ModuleFilter.disabling = {};
 
-      $('#module-filter-squeeze').css('min-height', $('#module-filter-tabs').height());
+Drupal.ModuleFilter.jQueryIsNewer = function() {
+  if (Drupal.ModuleFilter.jQueryNewer == undefined) {
+    var v1parts = $.fn.jquery.split('.');
+    var v2parts = new Array('1', '4', '4');
 
-      $('#module-filter-left a.project-tab').each(function(i) {
-        Drupal.ModuleFilter.tabs[$(this).attr('id')] = new Drupal.ModuleFilter.Tab(this);
-      });
+    for (var i = 0; i < v1parts.length; ++i) {
+      if (v2parts.length == i) {
+        Drupal.ModuleFilter.jQueryNewer = true;
+        return Drupal.ModuleFilter.jQueryNewer;
+      }
 
-      // Move anchors to top of tabs.
-      $('a.anchor', $('#module-filter-left')).remove().prependTo('#module-filter-tabs');
+      if (v1parts[i] == v2parts[i]) {
+        continue;
+      }
+      else if (v1parts[i] > v2parts[i]) {
+        Drupal.ModuleFilter.jQueryNewer = true;
+        return Drupal.ModuleFilter.jQueryNewer;
+      }
+      else {
+        Drupal.ModuleFilter.jQueryNewer = false;
+        return Drupal.ModuleFilter.jQueryNewer;
+      }
+    }
 
-      $('input[name="module_filter[name]"]').keyup(function(e) {
-        switch (e.which) {
-          case 13:
-            if (Drupal.ModuleFilter.timeout) {
-              clearTimeout(Drupal.ModuleFilter.timeout);
-            }
+    if (v1parts.length != v2parts.length) {
+      Drupal.ModuleFilter.jQueryNewer = false;
+      return Drupal.ModuleFilter.jQueryNewer;
+    }
 
-            Drupal.ModuleFilter.filter(Drupal.ModuleFilter.textFilter);
-            break;
-          default:
-            if (Drupal.ModuleFilter.textFilter != $(this).val()) {
-              Drupal.ModuleFilter.textFilter = this.value;
-              if (Drupal.ModuleFilter.timeout) {
-                clearTimeout(Drupal.ModuleFilter.timeout);
+    Drupal.ModuleFilter.jQueryNewer = false;
+  }
+  return Drupal.ModuleFilter.jQueryNewer;
+};
+
+Drupal.behaviors.moduleFilterTabs = {
+  attach: function(context) {
+    if (Drupal.settings.moduleFilter.tabs) {
+      $('#module-filter-wrapper table:not(.sticky-header)', context).once('module-filter-tabs', function() {
+        var $modules = $('#module-filter-modules');
+        var moduleFilter = $('input[name="module_filter[name]"]').data('moduleFilter');
+        var table = $(this);
+
+        $('thead', table).show();
+
+        // Remove package header rows.
+        $('tr.admin-package-header', table).remove();
+
+        var $tabsWrapper = $('<div id="module-filter-tabs"></div>');
+
+        // Build tabs from package title rows.
+        var tabs = '<ul>';
+        for (var i in Drupal.settings.moduleFilter.packageIDs) {
+          var id = Drupal.settings.moduleFilter.packageIDs[i];
+
+          var name = id;
+          var tabClass = 'project-tab';
+          var title = null;
+          var summary = (Drupal.settings.moduleFilter.countEnabled) ? '<span class="count">' + Drupal.ModuleFilter.countSummary(id) + '</span>' : '';
+
+          switch (id) {
+            case 'all':
+              name = Drupal.t('All');
+              break;
+            case 'new':
+              name = Drupal.t('New');
+              title = Drupal.t('Modules installed within the last week.');
+              if (Drupal.settings.moduleFilter.enabledCounts['new'].total == 0) {
+                tabClass += ' disabled';
+                summary += '<span>' + Drupal.t('No modules added within the last week.') + '</span>';
               }
-              Drupal.ModuleFilter.timeout = setTimeout('Drupal.ModuleFilter.filter("' + Drupal.ModuleFilter.textFilter + '")', 500);
-            }
-            break;
-        }
-      });
-      $('input[name="module_filter[name]"]').keypress(function(e) {
-        if (e.which == 13) e.preventDefault();
-      });
-
-      Drupal.ModuleFilter.showEnabled = $('#edit-module-filter-show-enabled').is(':checked');
-      $('#edit-module-filter-show-enabled').change(function() {
-        Drupal.ModuleFilter.showEnabled = $(this).is(':checked');
-        Drupal.ModuleFilter.filter($('input[name="module_filter[name]"]').val());
-      });
-      Drupal.ModuleFilter.showDisabled = $('#edit-module-filter-show-disabled').is(':checked');
-      $('#edit-module-filter-show-disabled').change(function() {
-        Drupal.ModuleFilter.showDisabled = $(this).is(':checked');
-        Drupal.ModuleFilter.filter($('input[name="module_filter[name]"]').val());
-      });
-      Drupal.ModuleFilter.showRequired = $('#edit-module-filter-show-required').is(':checked');
-      $('#edit-module-filter-show-required').change(function() {
-        Drupal.ModuleFilter.showRequired = $(this).is(':checked');
-        Drupal.ModuleFilter.filter($('input[name="module_filter[name]"]').val());
-      });
-      Drupal.ModuleFilter.showUnavailable = $('#edit-module-filter-show-unavailable').is(':checked');
-      $('#edit-module-filter-show-unavailable').change(function() {
-        Drupal.ModuleFilter.showUnavailable = $(this).is(':checked');
-        Drupal.ModuleFilter.filter($('input[name="module_filter[name]"]').val());
-      });
-
-      if (Drupal.settings.moduleFilter.visualAid == 1) {
-        $('table.package tbody td.checkbox input').change(function() {
-          if ($(this).is(':checked')) {
-            Drupal.ModuleFilter.updateVisualAid('enable', $(this).parents('tr'));
+              break;
+            case 'recent':
+              name = Drupal.t('Recent');
+              title = Drupal.t('Modules enabled/disabled within the last week.');
+              if (Drupal.settings.moduleFilter.enabledCounts['recent'].total == 0) {
+                tabClass += ' disabled';
+                summary += '<span>' + Drupal.t('No modules were enabled or disabled within the last week.') + '</span>';
+              }
+              break;
+            default: 
+              var $row = $('#' + id + '-package');
+              name = $.trim($row.text());
+              $row.remove();
+              break;
           }
-          else {
-            Drupal.ModuleFilter.updateVisualAid('disable', $(this).parents('tr'));
+
+          tabs += '<li id="' + id + '-tab" class="' + tabClass + '"><a href="#' + id + '" class="overlay-exclude"' + (title ? ' title="' + title + '"' : '') + '><strong>' + name + '</strong><span class="summary">' + summary + '</span></a></li>';
+        }
+        tabs += '</ul>';
+        $tabsWrapper.append(tabs);
+        $modules.before($tabsWrapper);
+
+        // Index tabs.
+        $('#module-filter-tabs li').each(function() {
+          var $tab = $(this);
+          var id = $tab.attr('id');
+          Drupal.ModuleFilter.tabs[id] = new Drupal.ModuleFilter.Tab($tab, id);
+        });
+
+        $('tbody td.checkbox input', $modules).change(function() {
+          var $checkbox = $(this);
+          var key = $checkbox.parents('tr').data('indexKey');
+
+          moduleFilter.index[key].status = $checkbox.is(':checked');
+
+          if (Drupal.settings.moduleFilter.visualAid) {
+            var type = ($checkbox.is(':checked')) ? 'enable' : 'disable';
+            Drupal.ModuleFilter.updateVisualAid(type, $checkbox.parents('tr'));
           }
         });
-      }
 
-      // Check for anchor.
-      var url = document.location.toString();
-      if (url.match('#')) {
-        // Make tab active based on anchor.
-        var anchor = '#' + url.split('#')[1];
-        $('a[href="' + anchor + '"]').click();
+        // Sort rows.
+        var rows = $('tbody tr.module', table).get();
+        rows.sort(function(a, b) {
+          var compA = $('td:nth(1)', a).text().toLowerCase();
+          var compB = $('td:nth(1)', b).text().toLowerCase();
+          return (compA < compB) ? -1 : (compA > compB) ? 1 : 0;
+        });
+        $.each(rows, function(idx, itm) { table.append(itm); });
+
+        // Re-stripe rows.
+        $('tr.module', table)
+          .removeClass('odd even')
+          .filter(':odd').addClass('even').end()
+          .filter(':even').addClass('odd');
+
+        moduleFilter.adjustHeight();
+
+        moduleFilter.element.bind('moduleFilter:start', function() {
+          moduleFilter.tabResults = {
+            'all-tab': { items: {}, count: 0 },
+            'recent-tab': { items: {}, count: 0 },
+            'new-tab': { items: {}, count: 0 }
+          };
+
+          // Empty result info from tabs.
+          for (var i in Drupal.ModuleFilter.tabs) {
+            if (Drupal.ModuleFilter.tabs[i].resultInfo != undefined) {
+              Drupal.ModuleFilter.tabs[i].resultInfo.empty();
+            }
+          }
+        });
+
+        moduleFilter.element.bind('moduleFilter:finish', function(e, data) {
+          $.each(moduleFilter.index, function(key, item) {
+            if (!item.element.hasClass('js-hide')) {
+              var id = Drupal.ModuleFilter.getTabID(item.element);
+
+              if (moduleFilter.tabResults[id] == undefined) {
+                moduleFilter.tabResults[id] = { items: {}, count: 0 };
+              }
+              if (moduleFilter.tabResults[id].items[item.key] == undefined) {
+                // All tab
+                moduleFilter.tabResults['all-tab'].count++;
+
+                // Recent tab
+                if (item.element.hasClass('recent-module')) {
+                  moduleFilter.tabResults['recent-tab'].count++;
+                }
+
+                // New tab
+                if (item.element.hasClass('new-module')) {
+                  moduleFilter.tabResults['new-tab'].count++;
+                }
+
+                moduleFilter.tabResults[id].items[item.key] = item;
+                moduleFilter.tabResults[id].count++;
+              }
+
+              if (Drupal.ModuleFilter.activeTab != undefined && Drupal.ModuleFilter.activeTab.id != 'all-tab') {
+                if ((Drupal.ModuleFilter.activeTab.id == 'recent-tab' && !item.element.hasClass('recent-module')) || (Drupal.ModuleFilter.activeTab.id == 'new-tab' && !item.element.hasClass('new-module')) || (Drupal.ModuleFilter.activeTab.id != 'recent-tab' && Drupal.ModuleFilter.activeTab.id != 'new-tab' && id != Drupal.ModuleFilter.activeTab.id)) {
+                  // The item is not in the active tab, so hide it.
+                  item.element.addClass('js-hide');
+                }
+              }
+            }
+          });
+
+          if (Drupal.settings.moduleFilter.visualAid) {
+            if (moduleFilter.text) {
+              // Add result info to tabs.
+              for (var id in moduleFilter.tabResults) {
+                var tab = Drupal.ModuleFilter.tabs[id];
+
+                if (tab.resultInfo == undefined) {
+                  var resultInfo = '<span class="result-info"></span>'
+                  $('a', tab.element).prepend(resultInfo);
+                  tab.resultInfo = $('span.result-info', tab.element);
+                }
+
+                tab.resultInfo.append(moduleFilter.tabResults[id].count);
+              }
+
+              if (Drupal.settings.moduleFilter.hideEmptyTabs) {
+                for (var id in Drupal.ModuleFilter.tabs) {
+                  if (moduleFilter.tabResults[id] != undefined) {
+                    Drupal.ModuleFilter.tabs[id].element.show();
+                  }
+                  else if (Drupal.ModuleFilter.activeTab == undefined || Drupal.ModuleFilter.activeTab.id != id) {
+                    Drupal.ModuleFilter.tabs[id].element.hide();
+                  }
+                }
+              }
+            }
+            else {
+              // Make sure all tabs are visible.
+              if (Drupal.settings.moduleFilter.hideEmptyTabs) {
+                $('#module-filter-tabs li').show();
+              }
+            }
+          }
+
+          if ((Drupal.ModuleFilter.activeTab != undefined && (moduleFilter.tabResults[Drupal.ModuleFilter.activeTab.id] == undefined || moduleFilter.tabResults[Drupal.ModuleFilter.activeTab.id].count <= 0))) {
+            // The current tab contains no results.
+            moduleFilter.results = 0;
+          }
+
+          moduleFilter.adjustHeight();
+        });
+
+        if (Drupal.settings.moduleFilter.useURLFragment) {
+          $(window).bind('hashchange.module-filter', $.proxy(Drupal.ModuleFilter, 'eventHandlerOperateByURLFragment')).triggerHandler('hashchange.module-filter');
+        }
+        else {
+          Drupal.ModuleFilter.selectTab();
+        }
+
+        if (Drupal.settings.moduleFilter.useSwitch) {
+          $('td.checkbox div.form-item').hide();
+          $('td.checkbox').each(function(i) {
+            var $cell = $(this);
+            var $checkbox = $(':checkbox', $cell);
+            var $switch = $('.toggle-enable', $cell);
+            $switch.removeClass('js-hide').click(function() {
+              if (!$(this).hasClass('disabled')) {
+                if (Drupal.ModuleFilter.jQueryIsNewer()) {
+                  $checkbox.click();
+                }
+                else {
+                  $checkbox.click().change();
+                }
+              }
+            });
+            $checkbox.click(function() {
+              if (!$switch.hasClass('disabled')) {
+                $switch.toggleClass('off');
+              }
+            });
+          });
+        }
+
+        var $tabs = $('#module-filter-tabs');
+
+        function getParentTopOffset($obj, offset) {
+          var $parent = $obj.offsetParent();
+          if ($obj[0] != $parent[0]) {
+            offset += $parent.position().top;
+            return getParentTopOffset($parent, offset);
+          }
+          return offset;
+        }
+
+        var tabsTopOffset = null;
+        function getParentsTopOffset() {
+          if (tabsTopOffset === null) {
+            tabsTopOffset = getParentTopOffset($tabs.parent(), 0);
+          }
+          return tabsTopOffset;
+        }
+
+        function viewportTop() {
+          var top = $(window).scrollTop();
+          return top;
+        }
+
+        function viewportBottom() {
+          var top = $(window).scrollTop();
+          var bottom = top + $(window).height();
+
+          bottom -= $('#page-actions').height();
+
+          return bottom;
+        }
+
+        function fixToTop(top) {
+          if ($tabs.hasClass('bottom-fixed')) {
+            $tabs.css({
+              'position': 'absolute',
+              'top': $tabs.position().top - getParentsTopOffset(),
+              'bottom': 'auto'
+            });
+            $tabs.removeClass('bottom-fixed');
+          }
+
+          if (($tabs.css('position') == 'absolute' && $tabs.offset().top - top >= 0) || ($tabs.css('position') != 'absolute' && $tabs.offset().top - top <= 0)) {
+            $tabs.addClass('top-fixed');
+            $tabs.attr('style', '');
+          }
+        }
+
+        function fixToBottom(bottom) {
+          if ($tabs.hasClass('top-fixed')) {
+            $tabs.css({
+              'position': 'absolute',
+              'top': $tabs.position().top - getParentsTopOffset(),
+              'bottom': 'auto'
+            });
+            $tabs.removeClass('top-fixed');
+          }
+
+          if ($tabs.offset().top + $tabs.height() - bottom <= 0) {
+            $tabs.addClass('bottom-fixed');
+            var style = '';
+            var pageActionsHeight = $('#page-actions').height();
+            if (pageActionsHeight > 0) {
+              style = 'bottom: ' + pageActionsHeight + 'px';
+            }
+            else if (Drupal.settings.moduleFilter.dynamicPosition) {
+              // style = 'bottom: ' + $('#module-filter-submit', $tabs).height() + 'px';
+            }
+            $tabs.attr('style', style);
+          }
+        }
+
+        var lastTop = 0;
+        $(window).scroll(function() {
+          var top = viewportTop();
+          var bottom = viewportBottom();
+
+          if ($modules.offset().top >= top) {
+            $tabs.removeClass('top-fixed').attr('style', '');
+          }
+          else {
+            if (top > lastTop) { // Downward scroll.
+              if ($tabs.height() > bottom - top) {
+                fixToBottom(bottom);
+              }
+              else {
+                fixToTop(top);
+              }
+            }
+            else { // Upward scroll.
+              fixToTop(top);
+            }
+          }
+          lastTop = top;
+        });
+
+        moduleFilter.adjustHeight();
+      });
+    }
+  }
+};
+
+Drupal.ModuleFilter.Tab = function(element, id) {
+  var self = this;
+
+  this.id = id;
+  this.hash = id.substring(0, id.length - 4);
+  this.element = element;
+
+  $('a', this.element).click(function() {
+    if (!Drupal.settings.moduleFilter.useURLFragment) {
+      var hash = (!self.element.hasClass('selected')) ? self.hash : 'all';
+      Drupal.ModuleFilter.selectTab(hash);
+      return false;
+    }
+
+    if (self.element.hasClass('selected')) {
+      // Clear the active tab.
+      window.location.hash = 'all';
+      return false;
+    }
+  });
+
+  $('tr.' + this.id, $('#system-modules')).hover(
+    function() {
+      self.element.addClass('suggest');
+    },
+    function() {
+      self.element.removeClass('suggest');
+    }
+  );
+};
+
+Drupal.ModuleFilter.selectTab = function(hash) {
+  if (!hash || Drupal.ModuleFilter.tabs[hash + '-tab'] == undefined || Drupal.settings.moduleFilter.enabledCounts[hash].total == 0) {
+    if (Drupal.settings.moduleFilter.rememberActiveTab) {
+      var activeTab = Drupal.ModuleFilter.getState('activeTab');
+      if (activeTab && Drupal.ModuleFilter.tabs[activeTab + '-tab'] != undefined) {
+        hash = activeTab;
       }
-      // Else if no active tab is defined, set it to the all tab.
-      else if (Drupal.ModuleFilter.activeTab == undefined) {
-        Drupal.ModuleFilter.activeTab = Drupal.ModuleFilter.tabs['all-tab'];
-      }
+    }
+
+    if (!hash) {
+      hash = 'all';
     }
   }
 
-  Drupal.ModuleFilter.visible = function(checkbox) {
-    if (checkbox.length > 0) {
-      if (Drupal.ModuleFilter.showEnabled) {
-        if ($(checkbox).is(':checked') && !$(checkbox).is(':disabled')) {
-          return true;
-        }
+  if (Drupal.ModuleFilter.activeTab != undefined) {
+    Drupal.ModuleFilter.activeTab.element.removeClass('selected');
+  }
+
+  Drupal.ModuleFilter.activeTab = Drupal.ModuleFilter.tabs[hash + '-tab'];
+  Drupal.ModuleFilter.activeTab.element.addClass('selected');
+
+  var moduleFilter = $('input[name="module_filter[name]"]').data('moduleFilter');
+  var filter = moduleFilter.applyFilter();
+
+  if (!Drupal.ModuleFilter.modulesTop) {
+    Drupal.ModuleFilter.modulesTop = $('#module-filter-modules').offset().top;
+  }
+  else {
+    // Calculate header offset; this is important in case the site is using
+    // admin_menu module which has fixed positioning and is on top of everything
+    // else.
+    var headerOffset = Drupal.settings.tableHeaderOffset ? eval(Drupal.settings.tableHeaderOffset + '()') : 0;
+    // Scroll back to top of #module-filter-modules.
+    $('html, body').animate({
+      scrollTop: Drupal.ModuleFilter.modulesTop - headerOffset
+    }, 500);
+    // $('html, body').scrollTop(Drupal.ModuleFilter.modulesTop);
+  }
+
+  Drupal.ModuleFilter.setState('activeTab', hash);
+};
+
+Drupal.ModuleFilter.eventHandlerOperateByURLFragment = function(event) {
+  var hash = $.param.fragment();
+  Drupal.ModuleFilter.selectTab(hash);
+};
+
+Drupal.ModuleFilter.countSummary = function(id) {
+  return Drupal.t('@enabled of @total', { '@enabled': Drupal.settings.moduleFilter.enabledCounts[id].enabled, '@total': Drupal.settings.moduleFilter.enabledCounts[id].total });
+};
+
+Drupal.ModuleFilter.Tab.prototype.updateEnabling = function(name, remove) {
+  this.enabling = this.enabling || {};
+  if (!remove) {
+    this.enabling[name] = name;
+  }
+  else {
+    delete this.enabling[name];
+  }
+};
+
+Drupal.ModuleFilter.Tab.prototype.updateDisabling = function(name, remove) {
+  this.disabling = this.disabling || {};
+  if (!remove) {
+    this.disabling[name] = name;
+  }
+  else {
+    delete this.disabling[name];
+  }
+};
+
+Drupal.ModuleFilter.Tab.prototype.updateVisualAid = function() {
+  var visualAid = '';
+  var enabling = new Array();
+  var disabling = new Array();
+
+  if (this.enabling != undefined) {
+    for (var i in this.enabling) {
+      enabling.push(this.enabling[i]);
+    }
+    if (enabling.length > 0) {
+      enabling.sort();
+      visualAid += '<span class="enabling">+' + enabling.join('</span>, <span class="enabling">') + '</span>';
+    }
+  }
+  if (this.disabling != undefined) {
+    for (var i in this.disabling) {
+      disabling.push(this.disabling[i]);
+    }
+    if (disabling.length > 0) {
+      disabling.sort();
+      if (enabling.length > 0) {
+        visualAid += '<br />';
       }
-      if (Drupal.ModuleFilter.showDisabled) {
-        if (!$(checkbox).is(':checked') && !$(checkbox).is(':disabled')) {
-          return true;
-        }
-      }
-      if (Drupal.ModuleFilter.showRequired) {
-        if ($(checkbox).is(':checked') && $(checkbox).is(':disabled')) {
-          return true;
-        }
+      visualAid += '<span class="disabling">-' + disabling.join('</span>, <span class="disabling">') + '</span>';
+    }
+  }
+
+  if (this.visualAid == undefined) {
+    $('a span.summary', this.element).append('<span class="visual-aid"></span>');
+    this.visualAid = $('span.visual-aid', this.element);
+  }
+
+  this.visualAid.empty().append(visualAid);
+};
+
+Drupal.ModuleFilter.getTabID = function($row) {
+  var id = $row.data('moduleFilterTabID');
+  if (!id) {
+    // Find the tab ID.
+    var classes = $row.attr('class').split(' ');
+    for (var i in classes) {
+      if (Drupal.ModuleFilter.tabs[classes[i]] != undefined) {
+        id = classes[i];
+        break;
       }
     }
-    if (Drupal.ModuleFilter.showUnavailable) {
-      if (checkbox.length == 0 || (!$(checkbox).is(':checked') && $(checkbox).is(':disabled'))) {
-        return true;
-      }
-    }
+    $row.data('moduleFilterTabID', id);
+  }
+  return id;
+};
+
+Drupal.ModuleFilter.updateVisualAid = function(type, $row) {
+  var id = Drupal.ModuleFilter.getTabID($row);
+
+  if (!id) {
     return false;
   }
 
-  Drupal.ModuleFilter.filter = function(string) {
-    var stringLowerCase = string.toLowerCase();
-    var flip = 'odd';
-
-    if (Drupal.ModuleFilter.activeTab.id == 'all-tab') {
-      var selector = 'table.package tbody tr td label > strong';
-    }
-    else {
-      var selector = 'table.package tbody tr.' + Drupal.ModuleFilter.activeTab.id + '-content td label > strong';
-    }
-
-    $(selector).each(function(i) {
-      var $row = $(this).parents('tr');
-      var module = $(this).text();
-      var moduleLowerCase = module.toLowerCase();
-
-      if (moduleLowerCase.match(stringLowerCase)) {
-        if (Drupal.ModuleFilter.visible($('td.checkbox :checkbox', $row))) {
-          $row.removeClass('odd even');
-          $row.addClass(flip);
-          $row.show();
-          flip = (flip == 'odd') ? 'even' : 'odd';
-        }
-        else {
-          $row.hide();
-        }
+  var tab = Drupal.ModuleFilter.tabs[id];
+  var name = $('td:nth(1) strong', $row).text();
+  switch (type) {
+    case 'enable':
+      if (Drupal.ModuleFilter.disabling[id + name] != undefined) {
+        delete Drupal.ModuleFilter.disabling[id + name];
+        tab.updateDisabling(name, true);
+        $row.removeClass('disabling');
       }
       else {
-        $row.hide();
+        Drupal.ModuleFilter.enabling[id + name] = name;
+        tab.updateEnabling(name);
+        $row.addClass('enabling');
       }
-    });
-  }
-
-  Drupal.ModuleFilter.Tab = function(element) {
-    this.id = $(element).attr('id');
-    this.element = element;
-
-    $(this.element).click(function() {
-      Drupal.ModuleFilter.tabs[$(this).attr('id')].setActive();
-    });
-  }
-
-  Drupal.ModuleFilter.Tab.prototype.setActive = function() {
-    if (Drupal.ModuleFilter.activeTab) {
-      $(Drupal.ModuleFilter.activeTab.element).parent().removeClass('active');
-    }
-    // Assume the default active tab is #all-tab. Remove its active class.
-    else {
-      $('#all-tab').parent().removeClass('active');
-    }
-
-    Drupal.ModuleFilter.activeTab = this;
-    $(Drupal.ModuleFilter.activeTab.element).parent().addClass('active');
-    Drupal.ModuleFilter.activeTab.displayRows();
-
-    // Clear filter textfield and refocus on it.
-    $('input[name="module_filter[name]"]').val('');
-    $('input[name="module_filter[name]"]').focus();
-  }
-
-  Drupal.ModuleFilter.Tab.prototype.displayRows = function() {
-    var flip = 'odd';
-    var selector = (Drupal.ModuleFilter.activeTab.id == 'all-tab') ? 'table.package tbody tr' : 'table.package tbody tr.' + this.id + '-content';
-    $('table.package tbody tr').hide();
-    $('table.package tbody tr').removeClass('odd even');
-    $(selector).each(function(i) {
-      if (Drupal.ModuleFilter.visible($('td.checkbox input', $(this)))) {
-        $(this).addClass(flip);
-        flip = (flip == 'odd') ? 'even' : 'odd';
-        $(this).show();
+      break;
+    case 'disable':
+      if (Drupal.ModuleFilter.enabling[id + name] != undefined) {
+        delete Drupal.ModuleFilter.enabling[id + name];
+        tab.updateEnabling(name, true);
+        $row.removeClass('enabling');
       }
-    });
-  }
-
-  Drupal.ModuleFilter.Tab.prototype.updateEnabling = function(amount) {
-    this.enabling = this.enabling || 0;
-    this.enabling += amount;
-    if (this.enabling == 0) {
-      delete(this.enabling);
-    }
-  }
-
-  Drupal.ModuleFilter.Tab.prototype.updateDisabling = function(amount) {
-    this.disabling = this.disabling || 0;
-    this.disabling += amount;
-    if (this.disabling == 0) {
-      delete(this.disabling);
-    }
-  }
-
-  Drupal.ModuleFilter.Tab.prototype.updateVisualAid = function() {
-    var visualAid = '';
-    if (this.enabling != undefined) {
-      visualAid += '<span class="enabling">' + Drupal.t('+@count', { '@count': this.enabling }) + '</span>';
-    }
-    if (this.disabling != undefined) {
-      visualAid += '<span class="disabling">' + Drupal.t('-@count', { '@count': this.disabling }) + '</span>';
-    }
-
-    if (!$('span.visual-aid', $(this.element)).size() && visualAid != '') {
-      $(this.element).prepend('<span class="visual-aid"></span>');
-    }
-
-    $('span.visual-aid', $(this.element)).empty().append(visualAid);
-  }
-
-  Drupal.ModuleFilter.updateVisualAid = function(type, row) {
-    // Find row class.
-    var classes = row.attr('class').split(' ');
-    for (var i in classes) {
-      // Remove '-content' so we can use as id.
-      var id = classes[i].substring(0, classes[i].length - 8);
-      if (Drupal.ModuleFilter.tabs[id] != undefined) {
-        break;
+      else {
+        Drupal.ModuleFilter.disabling[id + name] = name;
+        tab.updateDisabling(name);
+        $row.addClass('disabling');
       }
-    }
-
-    if (Drupal.ModuleFilter.activeTab.id == 'all-tab') {
-      var allTab = Drupal.ModuleFilter.activeTab;
-      var projectTab = Drupal.ModuleFilter.tabs[id];
-    }
-    else {
-      var allTab = Drupal.ModuleFilter.tabs['all-tab'];
-      var projectTab = Drupal.ModuleFilter.activeTab;
-    }
-
-    var name = $('td label strong', row).text();
-    switch (type) {
-      case 'enable':
-        if (Drupal.ModuleFilter.disabling[id + name] != undefined) {
-          delete(Drupal.ModuleFilter.disabling[id + name]);
-          allTab.updateDisabling(-1);
-          projectTab.updateDisabling(-1);
-          row.removeClass('disabling');
-        }
-        else {
-          Drupal.ModuleFilter.enabling[id + name] = name;
-          allTab.updateEnabling(1);
-          projectTab.updateEnabling(1);
-          row.addClass('enabling');
-        }
-        break;
-      case 'disable':
-        if (Drupal.ModuleFilter.enabling[id + name] != undefined) {
-          delete(Drupal.ModuleFilter.enabling[id + name]);
-          allTab.updateEnabling(-1);
-          projectTab.updateEnabling(-1);
-          row.removeClass('enabling');
-        }
-        else {
-          Drupal.ModuleFilter.disabling[id + name] = name;
-          allTab.updateDisabling(1);
-          projectTab.updateDisabling(1);
-          row.addClass('disabling');
-        }
-        break;
-    }
-
-    allTab.updateVisualAid();
-    projectTab.updateVisualAid();
+      break;
   }
+
+  tab.updateVisualAid();
+};
+
+Drupal.ModuleFilter.Filter.prototype.adjustHeight = function() {
+  // Hack for adjusting the height of the modules section.
+  var minHeight = $('#module-filter-tabs ul').height() + 10;
+  minHeight += $('#module-filter-tabs #module-filter-submit').height();
+  $('#module-filter-modules').css('min-height', minHeight);
+  this.element.trigger('moduleFilter:adjustHeight');
+}
+
 })(jQuery);

--- a/docroot/sites/all/modules/development/module_filter/js/modules.js
+++ b/docroot/sites/all/modules/development/module_filter/js/modules.js
@@ -1,0 +1,176 @@
+(function($) {
+
+Drupal.behaviors.moduleFilter = {
+  attach: function(context) {
+    $('#system-modules td.description').once('description', function() {
+      $('.inner.expand', $(this)).click(function() {
+        $(this).toggleClass('expanded');
+      });
+    });
+
+    $('.module-filter-inputs-wrapper', context).once('module-filter', function() {
+      var filterInput = $('input[name="module_filter[name]"]', context);
+      var selector = '#system-modules table tbody tr';
+      if (Drupal.settings.moduleFilter.tabs) {
+        selector += '.module';
+      }
+
+      filterInput.moduleFilter(selector, {
+        wrapper: $('#module-filter-modules'),
+        delay: 500,
+        striping: true,
+        childSelector: 'td:nth(1)',
+        rules: [
+          function(moduleFilter, item) {
+            if (!item.unavailable) {
+              if (moduleFilter.options.showEnabled) {
+                if (item.status && !item.disabled) {
+                  return true;
+                }
+              }
+              if (moduleFilter.options.showDisabled) {
+                if (!item.status && !item.disabled) {
+                  return true;
+                }
+              }
+              if (moduleFilter.options.showRequired) {
+                if (item.status && item.disabled) {
+                  return true;
+                }
+              }
+            }
+            if (moduleFilter.options.showUnavailable) {
+              if (item.unavailable || (!item.status && item.disabled)) {
+                return true;
+              }
+            }
+            return false;
+          }
+        ],
+        buildIndex: [
+          function(moduleFilter, item) {
+            var $checkbox = $('td.checkbox :checkbox', item.element);
+            if ($checkbox.size() > 0) {
+              item.status = $checkbox.is(':checked');
+              item.disabled = $checkbox.is(':disabled');
+            }
+            else {
+              item.status = false;
+              item.disabled = true;
+              item.unavailable = true;
+            }
+            return item;
+          }
+        ],
+        showEnabled: $('#edit-module-filter-show-enabled').is(':checked'),
+        showDisabled: $('#edit-module-filter-show-disabled').is(':checked'),
+        showRequired: $('#edit-module-filter-show-required').is(':checked'),
+        showUnavailable: $('#edit-module-filter-show-unavailable').is(':checked')
+      });
+
+      var moduleFilter = filterInput.data('moduleFilter');
+
+      moduleFilter.operators = {
+        description: function(string, moduleFilter, item) {
+          if (item.description == undefined) {
+            var description = $('.description', item.element).clone();
+            $('.admin-requirements', description).remove();
+            $('.admin-operations', description).remove();
+            item.description = description.text().toLowerCase();
+          }
+
+          if (item.description.indexOf(string) >= 0) {
+            return true;
+          }
+        },
+        requiredBy: function(string, moduleFilter, item) {
+          if (item.requiredBy == undefined) {
+            var requirements = Drupal.ModuleFilter.getRequirements(item.element);
+            item.requires = requirements.requires;
+            item.requiredBy = requirements.requiredBy;
+          }
+
+          for (var i in item.requiredBy) {
+            if (item.requiredBy[i].indexOf(string) >= 0) {
+              return true;
+            }
+          }
+        },
+        requires: function(string, moduleFilter, item) {
+          if (item.requires == undefined) {
+            var requirements = Drupal.ModuleFilter.getRequirements(item.element);
+            item.requires = requirements.requires;
+            item.requiredBy = requirements.requiredBy;
+          }
+
+          for (var i in item.requires) {
+            if (item.requires[i].indexOf(string) >= 0) {
+              return true;
+            }
+          }
+        }
+      };
+
+      $('#edit-module-filter-show-enabled', context).change(function() {
+        moduleFilter.options.showEnabled = $(this).is(':checked');
+        moduleFilter.applyFilter();
+      });
+      $('#edit-module-filter-show-disabled', context).change(function() {
+        moduleFilter.options.showDisabled = $(this).is(':checked');
+        moduleFilter.applyFilter();
+      });
+      $('#edit-module-filter-show-required', context).change(function() {
+        moduleFilter.options.showRequired = $(this).is(':checked');
+        moduleFilter.applyFilter();
+      });
+      $('#edit-module-filter-show-unavailable', context).change(function() {
+        moduleFilter.options.showUnavailable = $(this).is(':checked');
+        moduleFilter.applyFilter();
+      });
+
+      if (!Drupal.settings.moduleFilter.tabs) {
+        moduleFilter.element.bind('moduleFilter:start', function() {
+          $('#system-modules fieldset').show();
+        });
+
+        moduleFilter.element.bind('moduleFilter:finish', function(e, data) {
+          $('#system-modules fieldset').each(function(i) {
+            $fieldset = $(this);
+            if ($('tbody tr', $fieldset).filter(':visible').length == 0) {
+              $fieldset.hide();
+            }
+          });
+        });
+
+        moduleFilter.applyFilter();
+      }
+    });
+  }
+};
+
+Drupal.ModuleFilter.getRequirements = function(element) {
+  var requires = new Array();
+  var requiredBy = new Array();
+  $('.admin-requirements', element).each(function() {
+    var text = $(this).text();
+    if (text.substr(0, 9) == 'Requires:') {
+      // Requires element.
+      requiresString = text.substr(9);
+      requires = requiresString.replace(/\([a-z]*\)/g, '').split(',');
+    }
+    else if (text.substr(0, 12) == 'Required by:') {
+      // Required by element.
+      requiredByString = text.substr(12);
+      requiredBy = requiredByString.replace(/\([a-z]*\)/g, '').split(',');
+    }
+  });
+  for (var i in requires) {
+    requires[i] = $.trim(requires[i].toLowerCase());
+  }
+  for (var i in requiredBy) {
+    requiredBy[i] = $.trim(requiredBy[i].toLowerCase());
+  }
+  return { requires: requires, requiredBy: requiredBy };
+};
+
+})(jQuery);

--- a/docroot/sites/all/modules/development/module_filter/js/permissions.js
+++ b/docroot/sites/all/modules/development/module_filter/js/permissions.js
@@ -1,0 +1,67 @@
+(function($) {
+
+var lastModuleItem;
+
+Drupal.behaviors.moduleFilterPermissions = {
+  attach: function(context) {
+    $('.module-filter-inputs-wrapper', context).once('module-filter', function() {
+      var filterInput = $('input[name="module_filter[name]"]', context);
+      var selector = '#permissions tbody tr';
+
+      // Move location of filter input.
+      $('#permissions').parent().prepend(filterInput.parent().parent());
+
+      filterInput.moduleFilter(selector, {
+        wrapper: $('#permissions').parent(),
+        childSelector: 'td.module',
+        buildIndex: [
+          function(moduleFilter, item) {
+            item.isModule = (item.text != '') ? true : false;
+            if (item.isModule) {
+              item.children = new Array();
+              lastModuleItem = item;
+            }
+            else {
+              item.parent = lastModuleItem;
+              lastModuleItem.children.push(item);
+            }
+            return item;
+          }
+        ]
+      });
+
+      var moduleFilter = filterInput.data('moduleFilter');
+
+      moduleFilter.operators = {
+        perm: function(string, moduleFilter, item) {
+          if (!item.isModule) {
+            if (item.name == undefined) {
+              var $name = $('td.permission', item.element).clone();
+              $('.description', $name).remove();
+              item.name = $name.text().trim().toLowerCase();
+            }
+
+            if (item.name.indexOf(string) >= 0) {
+              return true;
+            }
+          }
+        }
+      };
+
+      moduleFilter.element.bind('moduleFilter:finish', function(e, data) {
+        for (var i in moduleFilter.results) {
+          if (moduleFilter.results[i].isModule) {
+            for (var k in moduleFilter.results[i].children) {
+              moduleFilter.results[i].children[k].element.removeClass('js-hide');
+            }
+          }
+          else {
+            moduleFilter.results[i].parent.element.removeClass('js-hide');
+          }
+        }
+      });
+    });
+  }
+};
+
+})(jQuery);

--- a/docroot/sites/all/modules/development/module_filter/js/update_status.js
+++ b/docroot/sites/all/modules/development/module_filter/js/update_status.js
@@ -1,0 +1,117 @@
+(function($) {
+
+Drupal.behaviors.moduleFilterUpdateStatus = {
+  attach: function(context) {
+    $('#module-filter-update-status-form').once('update-status', function() {
+      var filterInput = $('input[name="module_filter[name]"]', context);
+      filterInput.moduleFilter('table.update > tbody > tr', {
+        wrapper: $('table.update:first').parent(),
+        delay: 300,
+        childSelector: 'div.project a',
+        rules: [
+          function(moduleFilter, item) {
+            switch (moduleFilter.options.show) {
+              case 'all':
+                return true;
+              case 'updates':
+                if (item.state == 'warning' || item.state == 'error') {
+                  return true;
+                }
+                break;
+              case 'security':
+                if (item.state == 'error') {
+                  return true;
+                }
+                break;
+              case 'ignore':
+                if (item.state == 'ignored') {
+                  return true;
+                }
+                break;
+              case 'unknown':
+                if (item.state == 'unknown') {
+                  return true;
+                }
+                break;
+            }
+            return false;
+          }
+        ],
+        buildIndex: [
+          function(moduleFilter, item) {
+            if ($('.version-status', item.element).text() == Drupal.t('Ignored from settings')) {
+              item.state = 'ignored';
+              return item;
+            }
+            if (item.element.is('.ok')) {
+              item.state = 'ok';
+            }
+            else if (item.element.is('.warning')) {
+              item.state = 'warning';
+            }
+            else if (item.element.is('.error')) {
+              item.state = 'error';
+            }
+            else if (item.element.is('.unknown')) {
+              item.state = 'unknown';
+            }
+            return item;
+          }
+        ],
+        show: $('#edit-module-filter-show input[name="module_filter[show]"]', context).val()
+      });
+
+      var moduleFilter = filterInput.data('moduleFilter');
+
+      if (Drupal.settings.moduleFilter.rememberUpdateState) {
+        var updateShow = Drupal.ModuleFilter.getState('updateShow');
+        if (updateShow) {
+          moduleFilter.options.show = updateShow;
+          $('#edit-module-filter-show input[name="module_filter[show]"][value="' + updateShow + '"]', context).click();
+        }
+      }
+
+      $('#edit-module-filter-show input[name="module_filter[show]"]', context).change(function() {
+        moduleFilter.options.show = $(this).val();
+        Drupal.ModuleFilter.setState('updateShow', moduleFilter.options.show);
+        moduleFilter.applyFilter();
+      });
+
+      moduleFilter.element.bind('moduleFilter:start', function() {
+        $('table.update').each(function() {
+          $(this).show().prev('h3').show();
+        });
+      });
+
+      moduleFilter.element.bind('moduleFilter:finish', function(e, data) {
+        $('table.update').each(function() {
+          var $table = $(this);
+          if ($('tbody tr', $(this)).filter(':visible').length == 0) {
+            $table.hide().prev('h3').hide();
+          }
+        });
+      });
+
+      moduleFilter.element.bind('moduleFilter:keyup', function() {
+        if (moduleFilter.clearOffset == undefined) {
+          moduleFilter.inputWidth = filterInput.width();
+          moduleFilter.clearOffset = moduleFilter.element.parent().find('.module-filter-clear a').width();
+        }
+        if (moduleFilter.text) {
+          filterInput.width(moduleFilter.inputWidth - moduleFilter.clearOffset - 5).parent().css('margin-right', moduleFilter.clearOffset + 5);
+        }
+        else {
+          filterInput.width(moduleFilter.inputWidth).parent().css('margin-right', 0);
+        }
+      });
+
+      moduleFilter.element.parent().find('.module-filter-clear a').click(function() {
+        filterInput.width(moduleFilter.inputWidth).parent().css('margin-right', 0);
+      });
+
+      moduleFilter.applyFilter();
+    });
+  }
+};
+
+})(jQuery);

--- a/docroot/sites/all/modules/development/module_filter/module_filter.admin.inc
+++ b/docroot/sites/all/modules/development/module_filter/module_filter.admin.inc
@@ -14,10 +14,17 @@
  * Settings form for module filter.
  */
 function module_filter_settings() {
+  $form['module_filter_set_focus'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Set focus to filter field on page load'),
+    '#description' => t('Currently has no effect when using Overlay module.'),
+    '#default_value' => variable_get('module_filter_set_focus', 1),
+  );
+
   $form['module_filter_tabs'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Tabs'),
-    '#description' => t('Divide module groups into tabbed list.'),
+    '#title' => t('Enhance the modules page with tabs'),
+    '#description' => t('Alternate tabbed theme that restructures packages into tabs.'),
     '#default_value' => variable_get('module_filter_tabs', 1)
   );
   $form['tabs'] = array(
@@ -35,15 +42,63 @@ function module_filter_settings() {
   );
   $form['tabs']['module_filter_visual_aid'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Visuals for newly enabled and disabled modules'),
-    '#description' => t("Adds a basic count to tabs of modules being enabled/disabled and colors the module row pending it's being enabled or disabled"),
+    '#title' => t('Visual aids'),
+    '#description' => t('When enabling/disabling modules, the module name will display in the tab summary.<br />When filtering, a count of results for each tab will be presented.'),
     '#default_value' => variable_get('module_filter_visual_aid', 1)
+  );
+  $form['tabs']['module_filter_hide_empty_tabs'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Hide tabs with no results'),
+    '#description' => t('When a filter returns no results for a tab, the tab is hidden. This is dependent on visual aids being enabled.'),
+    '#default_value' => variable_get('module_filter_hide_empty_tabs', 0)
   );
   $form['tabs']['module_filter_dynamic_save_position'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Save dynamic positioning'),
-    '#description' => t("DEVELOPMENTAL: For sites with lots of tabs, enable to help keep the 'Save configuration' button more accessible."),
-    '#default_value' => variable_get('module_filter_dynamic_save_position', 0)
+    '#title' => t('Dynamically position Save button'),
+    '#description' => t("For sites with lots of tabs, enable to help keep the 'Save configuration' button more accessible."),
+    '#default_value' => variable_get('module_filter_dynamic_save_position', 1)
   );
+  $form['tabs']['module_filter_use_url_fragment'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use URL fragment'),
+    '#description' => t('Use URL fragment when navigating between tabs. This lets you use the browsers back/forward buttons to navigate through the tabs you selected.') . '<br />' . t('When the Overlay module is enabled this functionality will not be used since overlay relies on the URL fragment.'),
+    '#default_value' => variable_get('module_filter_use_url_fragment', 1)
+  );
+  $form['tabs']['module_filter_use_switch'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use switch instead of checkbox'),
+    '#description' => t('This is purely cosmetic (at least for now). Displays a ON/OFF switch rather than a checkbox to enable/disable modules.<br /><strong>Modules will not actually be enabled/disabled until the form is saved.</strong>'),
+    '#default_value' => variable_get('module_filter_use_switch', 1),
+  );
+  $form['tabs']['module_filter_track_recent_modules'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Track recently enabled/disabled modules'),
+    '#description' => t('Adds a "Recent" tab that displays modules that have been enabled or disabled with the last week.'),
+    '#default_value' => variable_get('module_filter_track_recent_modules', 1),
+  );
+  $form['tabs']['module_filter_remember_active_tab'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Remember active tab.'),
+    '#description' => t('When enabled, the active tab will be remembered.'),
+    '#default_value' => variable_get('module_filter_remember_active_tab', 1),
+  );
+
+  $form['update'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Update status'),
+    '#collapsible' => TRUE,
+    '#collapsed' => (module_exists('update')) ? FALSE : TRUE,
+  );
+  $form['update']['module_filter_remember_update_state'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Remember the last selected filter.'),
+    '#description' => t('When enabled, the last state (All, Update available, Security update, Unknown) will be remembered.'),
+    '#default_value' => variable_get('module_filter_remember_update_state', 0),
+  );
+
+  if (module_exists('page_actions')) {
+    $form['tabs']['module_filter_dynamic_save_position']['#description'] .= '<br />' . t('The module %name is enabled and thus this setting will have no affect.', array('%name' => t('Page actions')));
+  }
+
   return system_settings_form($form);
 }

--- a/docroot/sites/all/modules/development/module_filter/module_filter.info
+++ b/docroot/sites/all/modules/development/module_filter/module_filter.info
@@ -1,6 +1,7 @@
 name = Module filter
 description = "Filter the modules list."
 core = 7.x
+package = Administration
 
 files[] = module_filter.install
 files[] = module_filter.js
@@ -16,9 +17,9 @@ files[] = js/module_filter_tab.js
 
 configure = admin/config/user-interface/modulefilter
 
-; Information added by drupal.org packaging script on 2012-07-05
-version = "7.x-1.7"
+; Information added by Drupal.org packaging script on 2015-02-22
+version = "7.x-2.0"
 core = "7.x"
 project = "module_filter"
-datestamp = "1341518501"
+datestamp = "1424631189"
 

--- a/docroot/sites/all/modules/development/module_filter/module_filter.install
+++ b/docroot/sites/all/modules/development/module_filter/module_filter.install
@@ -5,13 +5,20 @@
  */
 
 /**
- * Implementation of hook_uninstall().
+ * Implements hook_uninstall().
  */
 function module_filter_uninstall() {
+  variable_del('module_filter_set_focus');
   variable_del('module_filter_tabs');
   variable_del('module_filter_count_enabled');
   variable_del('module_filter_visual_aid');
+  variable_del('module_filter_hide_empty_tabs');
   variable_del('module_filter_dynamic_save_position');
+  variable_del('module_filter_use_url_fragment');
+  variable_del('module_filter_use_switch');
+  variable_del('module_filter_track_recent_modules');
+  variable_del('module_filter_remember_active_tab');
+  variable_del('module_filter_remember_update_state');
 }
 
 /**
@@ -19,4 +26,22 @@ function module_filter_uninstall() {
  */
 function module_filter_update_7100() {
   variable_del('module_filter_autocomplete');
+}
+
+/**
+ * Rebuild the menu and theme registry.
+ */
+function module_filter_update_7200() {
+  menu_rebuild();
+  system_rebuild_theme_data();
+  drupal_theme_rebuild();
+}
+
+/**
+ * Old update that use to remove the module_filter_dynamic_save_position variable.
+ */
+function module_filter_update_7201() {
+  // We don't want to remove this update hook but at the same time we no
+  // longer want to lose the variable setting, so we just comment it out.
+  // variable_del('module_filter_dynamic_save_position');
 }

--- a/docroot/sites/all/modules/development/module_filter/module_filter.module
+++ b/docroot/sites/all/modules/development/module_filter/module_filter.module
@@ -12,7 +12,7 @@
  */
 
 /**
- * Implementation of hook_perm().
+ * Implements hook_perm().
  */
 function module_filter_permission() {
   return array(
@@ -24,12 +24,12 @@ function module_filter_permission() {
 }
 
 /**
- * Implementation of hook_menu().
+ * Implements hook_menu().
  */
 function module_filter_menu() {
   $items['admin/config/user-interface/modulefilter'] = array(
     'title' => 'Module filter',
-    'description' => 'Configure settings for Module Filter.',
+    'description' => 'Configure how the modules page looks and acts.',
     'access arguments' => array('administer module filter'),
     'page callback' => 'drupal_get_form',
     'page arguments' => array('module_filter_settings'),
@@ -39,7 +39,19 @@ function module_filter_menu() {
 }
 
 /**
- * Implementation of hook_form_FORM_ID_alter().
+ * Implements hook_menu_alter().
+ */
+function module_filter_menu_alter(&$items) {
+  if (isset($items['admin/reports/updates'])) {
+    // We route the updates report page through us.
+    $items['admin/reports/updates']['page callback'] = 'module_filter_update_status';
+    $items['admin/reports/updates']['file'] = 'module_filter.pages.inc';
+    $items['admin/reports/updates']['module'] = 'module_filter';
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
  */
 function module_filter_form_system_modules_alter(&$form, &$form_state, $form_id) {
   // Don't alter the form when confirming.
@@ -48,102 +60,201 @@ function module_filter_form_system_modules_alter(&$form, &$form_state, $form_id)
   }
 
   $form['module_filter'] = array(
-    '#tree' => TRUE,
-    '#weight' => -1
+    '#type' => 'module_filter',
+    '#attached' => array(
+      'js' => array(
+        drupal_get_path('module', 'module_filter') . '/js/modules.js'
+      )
+    )
   );
-  $form['module_filter']['name'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Filter list')
+  $checkbox_defaults = array(
+    ((isset($_GET['enabled'])) ? $_GET['enabled'] : 1) ? 'enabled' : '',
+    ((isset($_GET['disabled'])) ? $_GET['disabled'] : 1) ? 'disabled' : '',
+    ((isset($_GET['required'])) ? $_GET['required'] : 1) ? 'required' : '',
+    ((isset($_GET['unavailable'])) ? $_GET['unavailable'] : 1) ? 'unavailable' : ''
   );
-
   $form['module_filter']['show'] = array(
     '#type' => 'checkboxes',
-    '#default_value' => array('enabled', 'disabled', 'required', 'unavailable'),
+    '#default_value' => array_filter($checkbox_defaults),
     '#options' => array('enabled' => t('Enabled'), 'disabled' => t('Disabled'), 'required' => t('Required'), 'unavailable' => t('Unavailable')),
     '#prefix' => '<div id="module-filter-show-wrapper">',
     '#suffix' => '</div>'
   );
 
   if (variable_get('module_filter_tabs', 1)) {
-    // Remove the fieldsets for each package since we will be using tabs
-    // instead. Put all modules into one array.
-    $modules = array(
-      '#theme' => 'module_filter_modules_table',
-      '#header' => array(
-        array('data' => t('Enabled'), 'class' => 'checkbox'),
-        t('Name'),
-        t('Version'),
-        t('Description'),
-        array('data' => t('Operations'), 'colspan' => 3)
-      )
-    );
+    $form['module_filter']['#attached']['css'][] = drupal_get_path('module', 'module_filter') .'/css/module_filter_tab.css';
+    $form['module_filter']['#attached']['library'][] = array('system', 'jquery.bbq');
+    $form['module_filter']['#attached']['js'][] = drupal_get_path('module', 'module_filter') .'/js/module_filter_tab.js';
 
-    $all = t('All');
-    $tab_counts = array($all => array('id' => 'all', 'enabled' => 0, 'total' => 0));
-    $form['#packages'] = array();
-    foreach (element_children($form['modules']) as $package) {
-      // Add the package to $form['#packages']. Tabs are built from this.
-      $form['#packages'][$package] = $package;
-
-      if (!isset($tab_counts[$package])) {
-        $tab_counts[$package] = array('enabled' => 0, 'total' => 0);
-      }
-
-      foreach (element_children($form['modules'][$package]) as $module) {
-        $tab_counts[$all]['total']++;
-        $tab_counts[$package]['total']++;
-        if (!empty($form['modules'][$package][$module]['enable']['#default_value'])) {
-          $tab_counts[$all]['enabled']++;
-          $tab_counts[$package]['enabled']++;
-        }
-
-        $modules[$module] = $form['modules'][$package][$module];
-        $modules[$module]['#package'] = $package;
-        $modules[$module]['#parents'] = array('modules', $package, $module);
-      }
+    if (!module_exists('page_actions') && variable_get('module_filter_dynamic_save_position', 1)) {
+      $form['module_filter']['#attached']['css'][] = drupal_get_path('module', 'module_filter') .'/css/dynamic_position.css';
+      $form['module_filter']['#attached']['js'][] = drupal_get_path('module', 'module_filter') .'/js/dynamic_position.js';
     }
 
-    // Sort the array of modules alphabetically.
-    uasort($modules, 'module_filter_sort_modules_by_display_name');
+    $form['#attached']['css'][] = drupal_get_path('module', 'module_filter') . '/css/modules.css';
 
-    // Replace the $form['modules'] with our $modules array.
-    $form['modules'] = $modules;
-
-    // Add our $tab_counts array to the form.
-    $form['#tab_counts'] = $tab_counts;
+    $form['#theme'] = 'module_filter_system_modules_tabs';
   }
 
-  $form['#theme'] = 'module_filter_system_modules';
+  $form['#submit'][] = 'module_filter_system_modules_submit_redirect';
+
+  if (variable_get('module_filter_track_recent_modules', 1)) {
+    $form['#submit'][] = 'module_filter_system_modules_submit_recent';
+  }
 }
 
 /**
- * Implementation of hook_theme().
+ * Implements hook_form_FORM_ID_alter().
+ */
+function module_filter_form_user_admin_permissions_alter(&$form, &$form_state) {
+  $form['module_filter'] = array(
+    '#type' => 'module_filter',
+    '#description' => t('Filter list by module. Use the query operator "perm" to filter by permission, e.g., perm:access.'),
+    '#attached' => array(
+      'js' => array(
+        drupal_get_path('module', 'module_filter') . '/js/permissions.js',
+      ),
+    ),
+    '#weight' => -100,
+  );
+}
+
+/**
+ * Implements hook_element_info().
+ */
+function module_filter_element_info() {
+  $types['module_filter'] = array(
+    '#input' => TRUE,
+    '#process' => array('form_process_module_filter', 'ajax_process_form'),
+    '#weight' => -1,
+    '#tree' => TRUE,
+    '#theme' => 'module_filter'
+  );
+  return $types;
+}
+
+/**
+ * Implements hook_theme().
  */
 function module_filter_theme() {
   return array(
-    'module_filter_system_modules' => array(
-      'render element' => 'form',
-      'file' => 'module_filter.theme.inc'
-    ),
-    'module_filter_modules_table' => array(
-      'render element' => 'form',
+    'module_filter' => array(
+      'render element' => 'element',
       'file' => 'module_filter.theme.inc',
     ),
     'module_filter_system_modules_tabs' => array(
       'render element' => 'form',
-      'file' => 'module_filter.theme.inc'
-    )
+      'file' => 'module_filter.theme.inc',
+    ),
+    'module_filter_operations' => array(
+      'variables' => array('links' => array(), 'dropbutton' => FALSE),
+      'file' => 'module_filter.theme.inc',
+    ),
   );
 }
 
-function module_filter_sort_modules_by_display_name($a, $b) {
-  if (is_array($a) && is_array($b) && isset($a['#package'], $b['#package'])) {
-    return strcasecmp($a['name']['#markup'], $b['name']['#markup']);
+function form_process_module_filter($element, &$form_state) {
+  $element['name'] = array(
+    '#type' => 'textfield',
+    '#title' => (isset($element['#title'])) ? $element['#title'] : t('Filter list'),
+    '#default_value' => (isset($element['#default_value'])) ? $element['#default_value'] : ((isset($_GET['filter'])) ? $_GET['filter'] : ''),
+    '#size' => (isset($element['#size'])) ? $element['#size'] : 45,
+    '#weight' => (isset($element['#weight'])) ? $element['#weight'] : -10,
+    '#attributes' => ((isset($element['#attributes'])) ? $element['#attributes'] : array()) + array('autocomplete' => 'off'),
+    '#attached' => array(
+      'css' => array(
+        drupal_get_path('module', 'module_filter') . '/css/module_filter.css'
+      ),
+      'js' => array(
+        'misc/jquery.cookie.js',
+        drupal_get_path('module', 'module_filter') . '/js/module_filter.js',
+        array(
+          'data' => array(
+            'moduleFilter' => array(
+              'setFocus' => variable_get('module_filter_set_focus', 1),
+              'tabs' => variable_get('module_filter_tabs', 1),
+              'countEnabled' => variable_get('module_filter_count_enabled', 1),
+              'visualAid' => variable_get('module_filter_visual_aid', 1),
+              'hideEmptyTabs' => variable_get('module_filter_hide_empty_tabs', 0),
+              'dynamicPosition' => (!module_exists('page_actions')) ? variable_get('module_filter_dynamic_save_position', 1) : FALSE,
+              'useURLFragment' => variable_get('module_filter_use_url_fragment', 1),
+              'useSwitch' => variable_get('module_filter_use_switch', 1),
+              'trackRecent' => variable_get('module_filter_track_recent_modules', 1),
+              'rememberActiveTab' => variable_get('module_filter_remember_active_tab', 1),
+              'rememberUpdateState' => variable_get('module_filter_remember_update_state', 0),
+            )
+          ),
+          'type' => 'setting'
+        )
+      )
+    )
+  );
+  if (isset($element['#description'])) {
+    $element['name']['#description'] = $element['#description'];
   }
-  return 0;
+  return $element;
+}
+
+function module_filter_system_modules_submit_redirect($form, &$form_state) {
+  $query = array();
+  if (!empty($form_state['values']['module_filter']['name'])) {
+    $query['filter'] = $form_state['values']['module_filter']['name'];
+  }
+  $query['enabled'] = (int)(!empty($form_state['values']['module_filter']['show']['enabled']));
+  $query['disabled'] = (int)(!empty($form_state['values']['module_filter']['show']['disabled']));
+  $query['required'] = (int)(!empty($form_state['values']['module_filter']['show']['required']));
+  $query['unavailable'] = (int)(!empty($form_state['values']['module_filter']['show']['unavailable']));
+
+  $form_state['redirect'] = array(
+    'admin/modules',
+    array('query' => $query),
+  );
+}
+
+function module_filter_system_modules_submit_recent($form, &$form_state) {
+  $recent_modules = variable_get('module_filter_recent_modules', array());
+
+  foreach ($form_state['values']['modules'] as $package => $modules) {
+    foreach ($modules as $key => $module) {
+      if ($form['modules'][$package][$key]['enable']['#default_value'] != $module['enable']) {
+        $recent_modules[$key] = REQUEST_TIME;
+      }
+    }
+  }
+
+  variable_set('module_filter_recent_modules', $recent_modules);
+}
+
+function module_filter_new_modules() {
+  // Get current list of modules.
+  $files = system_rebuild_module_data();
+
+  // Remove hidden modules from display list.
+  $visible_files = $files;
+  foreach ($visible_files as $filename => $file) {
+    if (!empty($file->info['hidden'])) {
+      unset($visible_files[$filename]);
+    }
+  }
+
+  uasort($visible_files, 'system_sort_modules_by_info_name');
+
+  $new_modules = array();
+  foreach ($visible_files as $filename => $module) {
+    $ctime = filectime(dirname($module->uri) . '/' . $module->name . '.info');
+    if (($ctime - strtotime('-1 week')) > 0) {
+      $new_modules[$filename] = module_filter_get_id($filename);
+    }
+  }
+  return $new_modules;
 }
 
 function module_filter_get_id($text) {
   $id = strtolower($text);
-  return preg_replace('/([^a-z])([\/(  )])*/', '-', $id);
+  $id = preg_replace('/([^a-z0-9]+)/', '-', $id);
+  return trim($id, '-');
+}
+
+function module_filter_recent_filter($var) {
+  return (!($var < REQUEST_TIME - 60*60*24*7));
 }

--- a/docroot/sites/all/modules/development/module_filter/module_filter.pages.inc
+++ b/docroot/sites/all/modules/development/module_filter/module_filter.pages.inc
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Wrapper function for update_status().
+ *
+ * @see update_status().
+ */
+function module_filter_update_status() {
+  module_load_include('inc', 'update', 'update.report');
+  $update_report = update_status();
+
+  return array(
+    'module_filter' => drupal_get_form('module_filter_update_status_form'),
+    'update_report' => array(
+      '#markup' => $update_report
+    )
+  );
+}
+
+function module_filter_update_status_form($form, &$form_state) {
+  $form['module_filter'] = array(
+    '#type' => 'module_filter',
+    '#attached' => array(
+      'css' => array(
+        drupal_get_path('module', 'module_filter') . '/css/update_status.css'
+      ),
+      'js' => array(
+        drupal_get_path('module', 'module_filter') . '/js/update_status.js'
+      ),
+    ),
+  );
+  $form['module_filter']['show'] = array(
+    '#type' => 'radios',
+    '#default_value' => (isset($_GET['show']) && in_array($_GET['show'], array('all', 'updates', 'security', 'unknown'))) ? $_GET['show'] : 'all',
+    '#options' => array('all' => t('All'), 'updates' => t('Update available'), 'security' => t('Security update'), 'unknown' => t('Unknown')),
+    '#prefix' => '<div id="module-filter-show-wrapper">',
+    '#suffix' => '</div>'
+  );
+  if (module_exists('update_advanced')) {
+    $options = $form['module_filter']['show']['#options'];
+    $form['module_filter']['show']['#options'] = array_slice($options, 0, 2);
+    $form['module_filter']['show']['#options']['ignore'] = t('Ignored from settings');
+    $form['module_filter']['show']['#options'] = array_merge($form['module_filter']['show']['#options'], array_slice($options, 2));
+  }
+  return $form;
+}

--- a/docroot/sites/all/modules/development/module_filter/module_filter.theme.inc
+++ b/docroot/sites/all/modules/development/module_filter/module_filter.theme.inc
@@ -6,119 +6,191 @@
  * @author greenSkin
  */
 
-/**
- * A router theme function.
- *
- * Appropriately themes the system modules page with alterations and based on
- * set variables
- *
- * @param $form
- *   An associative array containing the structure of the form.
- *
- * @return
- *   An output string.
- */
-function theme_module_filter_system_modules($variables) {
-  $form = $variables['form'];
-
-  drupal_add_css(drupal_get_path('module', 'module_filter') .'/css/module_filter.css');
-
-  $output = '';
-  if (variable_get('module_filter_tabs', 1)) {
-    drupal_add_css(drupal_get_path('module', 'module_filter') .'/css/module_filter_tab.css');
-    drupal_add_js(drupal_get_path('module', 'module_filter') .'/js/module_filter_tab.js');
-
-    drupal_add_js(array('moduleFilter' => array('visualAid' => variable_get('module_filter_visual_aid', 1))), 'setting');
-
-    if (variable_get('module_filter_dynamic_save_position', 0)) {
-      drupal_add_js(drupal_get_path('module', 'module_filter') .'/js/dynamic_position.js');
-    }
-
-    $form['module_filter']['#size'] = 45;
-    $output .= theme('module_filter_system_modules_tabs', $form);
-  }
-  else {
-    drupal_add_js(drupal_get_path('module', 'module_filter') .'/js/module_filter.js');
-    $form['module_filter']['#prefix'] = '<div id="module-filter-wrapper" style="display: none;">';
-    $form['module_filter']['#suffix'] = '</div>';
-    $output = drupal_render($form['module_filter']);
-    $form['#theme'] = 'system_modules';
-    $output .= drupal_render($form['modules']);
-    $output .= drupal_render($form['actions']);
-  }
-  return $output;
-}
-
-function theme_module_filter_modules_table($variables) {
-  $form = $variables['form'];
-
-  // Individual table headers.
-  $rows = array();
-  // Iterate through all the modules, which are
-  // children of this fieldset.
-  foreach (element_children($form) as $key) {
-    // Stick it into $module for easier accessing.
-    $module = $form[$key];
-    $row = array();
-    unset($module['enable']['#title']);
-    $row[] = array('class' => array('checkbox'), 'data' => drupal_render($module['enable']));
-    $label = '<label';
-    if (isset($module['enable']['#id'])) {
-      $label .= ' for="'. $module['enable']['#id'] .'"';
-    }
-    $row[] = $label .'><strong>' . drupal_render($module['name']) . '</strong></label>';
-    $row[] = drupal_render($module['version']);
-    // Add the description, along with any modules it requires.
-    $description = drupal_render($module['description']);
-    if ($module['#requires']) {
-      $description .= '<div class="admin-requirements">' . t('Requires: !module-list', array('!module-list' => implode(', ', $module['#requires']))) . '</div>';
-    }
-    if ($module['#required_by']) {
-      $description .= '<div class="admin-requirements">' . t('Required by: !module-list', array('!module-list' => implode(', ', $module['#required_by']))) . '</div>';
-    }
-    $row[] = array('data' => $description, 'class' => array('description'));
-    // Display links (such as help or permissions) in their own columns.
-    foreach (array('help', 'permissions', 'configure') as $key) {
-      $row[] = array('data' => drupal_render($module['links'][$key]), 'class' => array($key));
-    }
-
-    $id = module_filter_get_id($module['#package']);
-    $rows[] = array(
-      'data' => $row,
-      'class' => array($id .'-tab-content')
-    );
-  }
-
-  return theme('table', array('header' => $form['#header'], 'rows' => $rows, 'attributes' => array('class' => array('package'))));
+function theme_module_filter($variables) {
+  $element = $variables['element'];
+  return '<div class="module-filter-inputs-wrapper">' . drupal_render_children($element) . '</div>';
 }
 
 /**
  * Theme callback for the modules tabbed form.
  */
 function theme_module_filter_system_modules_tabs($variables) {
-  $form = $variables['form'];
-
-  $count_enabled = variable_get('module_filter_count_enabled', 1);
-
-  // Display packages.
-  $all = t('All');
-  $all_count = ($count_enabled) ? '<span class="counts">' . t('!enabled of !total', array('!enabled' => $form['#tab_counts'][$all]['enabled'], '!total' => $form['#tab_counts'][$all]['total'])) . '</span>' : '';
-  $tabs = array('all' => '<li class="active"><a id="all-tab" class="project-tab overlay-exclude" href="#all">' . $all . $all_count . '</a></li>');
-  foreach ($form['#packages'] as $package) {
-    $id = module_filter_get_id($package);
-
-    $count = ($count_enabled) ? '<span class="counts">' . t('!enabled of !total', array('!enabled' => $form['#tab_counts'][$package]['enabled'], '!total' => $form['#tab_counts'][$package]['total'])) . '</span>' : '';
-    $tabs[$id] = '<li><a id="' . $id . '-tab" class="project-tab overlay-exclude" href="#' . str_replace('-', '_', $id) . '">' . $package . $count . '</a></li>';
+  if (module_exists('views_ui')) {
+    // Hack to get consistent style with views ctools dropbutton.
+    if (module_load_include('inc', 'views_ui', 'includes/admin')) {
+      foreach (views_ui_get_admin_css() as $file => $options) {
+        drupal_add_css($file, $options);
+      }
+    }
   }
 
+  $form = $variables['form'];
+
+  if (!module_exists('page_actions')) {
+    $form['actions']['#prefix'] = '<div id="module-filter-submit">';
+    $form['actions']['#suffix'] = '</div>';
+  }
+
+  $header = array(
+    array('data' => '', 'class' => array('checkbox')),
+    array('data' => t('Name'), 'class' => array('name')),
+    array('data' => t('Description'), 'class' => array('description')),
+    array('data' => t('Links'), 'class' => array('links')),
+  );
+  $package_ids = array('all');
+  $enabled['all'] = array();
+
+  if (variable_get('module_filter_track_recent_modules', 1)) {
+    $recent_modules = array_filter(variable_get('module_filter_recent_modules', array()), 'module_filter_recent_filter');
+    // Save the filtered results.
+    variable_set('module_filter_recent_modules', $recent_modules);
+
+    $package_ids[] = 'recent';
+    $enabled['recent'] = array();
+  }
+
+  // Determine what modules are new (within a week).
+  $new_modules = module_filter_new_modules();
+  $package_ids[] = 'new';
+  $enabled['new'] = array();
+
+  $rows = array();
+  $flip = array('even' => 'odd', 'odd' => 'even');
+  foreach (element_children($form['modules']) as $package) {
+    $package_id = module_filter_get_id($package);
+    $package_ids[] = $package_id;
+
+    // Package title and header.
+    $rows[] = array('data' => array(array('data' => '<h3>' . $form['modules'][$package]['#title'] . '</h3>', 'colspan' => 4)), 'id' => $package_id . '-package', 'class' => array('admin-package-title'));
+    $rows[] = array('data' => $header, 'class' => array('admin-package-header'));
+
+    $stripe = 'odd';
+    $enabled[$package_id] = array();
+    foreach (element_children($form['modules'][$package]) as $key) {
+      $module = &$form['modules'][$package][$key];
+
+      $is_enabled = isset($module['enable']['#default_value']) ? $module['enable']['#default_value'] : '';
+      $enabled['all'][] = $enabled[$package_id][] = $is_enabled;
+      if (isset($recent_modules[$key])) {
+        $enabled['recent'][] = $is_enabled;
+      }
+      if (isset($new_modules[$key])) {
+        $enabled['new'][] = $is_enabled;
+      }
+
+      $row = array();
+
+      $version = !empty($module['version']['#markup']);
+      $requires = !empty($module['#requires']);
+      $required_by = !empty($module['#required_by']);
+
+      $toggle_enable = '';
+      if (isset($module['enable']['#type']) && $module['enable']['#type'] == 'checkbox') {
+        unset($module['enable']['#title']);
+        $class = ($is_enabled ? 'enabled' : 'off');
+        if (!empty($module['enable']['#disabled'])) {
+          $class .= ' disabled';
+        }
+        $toggle_enable = '<div class="js-hide toggle-enable ' . $class . '"><div>&nbsp;</div></div>';
+      }
+      $row[] = array('class' => array('checkbox'), 'data' => $toggle_enable . drupal_render($module['enable']));
+
+      $label = '<label';
+      if (isset($module['enable']['#id'])) {
+        $label .= ' for="' . $module['enable']['#id'] . '"';
+      }
+      $row[] = array('class' => array('name'), 'data' => $label . '><strong>' . drupal_render($module['name']) . '</strong> <span class="module-machine-name">(' . $key . ')</span></label>');
+
+      // Add the description, along with any modules it requires.
+      $description = '<span class="details"><span class="text">' . drupal_render($module['description']) . '</span></span>';
+      if ($version || $requires || $required_by) {
+        $description .= '<div class="requirements">';
+        if ($version) {
+          $description .= '<div class="admin-requirements">' . t('Version: !module-version', array('!module-version' => drupal_render($module['version']))) . '</div>';
+        }
+        if ($requires) {
+          $description .= '<div class="admin-requirements">' . t('Requires: !module-list', array('!module-list' => implode(', ', $module['#requires']))) . '</div>';
+        }
+        if ($required_by) {
+          $description .= '<div class="admin-requirements">' . t('Required by: !module-list', array('!module-list' => implode(', ', $module['#required_by']))) . '</div>';
+        }
+        $description .= '</div>';
+      }
+      $row[] = array('data' => '<div class="inner expand" role="button">' . $description . '</div>', 'class' => array('description'));
+
+      $operations = (module_exists('ctools')) ? theme('module_filter_operations', array('links' => $module['links'], 'dropbutton' => TRUE)) : theme('module_filter_operations', array('links' => $module['links']));
+      $row[] = array('data' => '<div class="links">' . $operations . '</div>', 'class' => array('links'));
+
+      $class = array(module_filter_get_id($package) . '-tab', 'module', $stripe);
+      if (isset($recent_modules[$key])) {
+        $class[] = 'recent-module';
+      }
+      if (isset($new_modules[$key])) {
+        $class[] = 'new-module';
+      }
+      $rows[] = array('data' => $row, 'no_striping' => TRUE, 'class' => $class);
+      $stripe = $flip[$stripe];
+    }
+
+    // Set the package as printed.
+    $form['modules'][$package]['#printed'] = TRUE;
+  }
+
+  if (variable_get('module_filter_count_enabled', 1)) {
+    $enabled_counts = array();
+    foreach ($enabled as $package_id => $value) {
+      $enabled_counts[$package_id] = array(
+        'enabled' => count(array_filter($value)),
+        'total' => count($value),
+      );
+    }
+    drupal_add_js(array(
+      'moduleFilter' => array(
+        'packageIDs' => $package_ids,
+        'enabledCounts' => $enabled_counts,
+      )
+    ), 'setting');
+  }
+
+  // Add first and last class to rows.
+  $rows[0]['class'][] = 'first';
+  $rows[count($rows) - 1]['class'][] = 'last';
+
   $output = '<div id="module-filter-wrapper">';
-  $output .= '<div id="module-filter-left">';
-  $output .= '<div id="module-filter-tabs"><ul>'. implode($tabs) . '</ul></div>';
-  $output .= '<div id="module-filter-submit">' . drupal_render($form['actions']) . '</div></div>';
-  $output .= '<div id="module-filter-right"><div id="module-filter-squeeze">' . drupal_render($form['module_filter']);
-  $output .= drupal_render($form['modules']) . '</div></div>';
-  $output .= '<div class="clear-block"></div>';
-  $output .= '</div>';
+  $output .= '<div id="module-filter-modules">' . drupal_render($form['module_filter']);
+  $output .= theme('table', array('header' => $header, 'rows' => $rows));
   $output .= drupal_render_children($form);
+  $output .= '</div>';
+  $output .= '</div>';
   return $output;
+}
+
+function theme_module_filter_operations(&$vars) {
+  $links = &$vars['links'];
+  $dropbutton = $vars['dropbutton'];
+
+  $operations = array();
+  foreach (element_children($links) as $key) {
+    if ($dropbutton) {
+      hide($links[$key]);
+      if (!empty($links[$key]['#href'])) {
+        $operations[] = array(
+          'title' => $links[$key]['#title'],
+          'href' => $links[$key]['#href'],
+        );
+      }
+    }
+    else {
+      $data = drupal_render($links[$key]);
+      if (!empty($data)) {
+        $operations[] = array('data' => $data);
+      }
+    }
+  }
+  if (!empty($operations)) {
+    if ($dropbutton) {
+      return '<div class="admin-operations">' . theme('links__ctools_dropbutton', array('title' => t('Operations'), 'links' => $operations, 'attributes' => array('class' => array('links')))) . '</div>';
+    }
+    return '<div class="admin-operations">' . theme('item_list', array('items' => $operations, 'attributes' => array('class' => array('links', 'inline')))) . '</div>';
+  }
 }


### PR DESCRIPTION
Upgraded the Module Filter module to the latest version - **7.x-2.0**.

Database schema updates
-----------------------
The following database updates are required:

* 7200 - Rebuild the menu and theme registry.
* 7201 - Old update that use to remove the module_filter_dynamic_save_position variable.

Remember to run `drush updb --y` as part of the deployment process.

[ Fixes [#10337](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=835) ]