### PR TITLE
Patch the Hierarchical select module

### DIFF
--- a/docroot/sites/all/modules/contrib/hierarchical_select/hierarchical_select.info
+++ b/docroot/sites/all/modules/contrib/hierarchical_select/hierarchical_select.info
@@ -1,4 +1,4 @@
-name = Hierarchical Select
+name = Hierarchical Select - PATCHED
 description = Simplifies the selection of one or multiple items in a hierarchical tree.
 package = Form Elements
 

--- a/docroot/sites/all/modules/contrib/hierarchical_select/hierarchical_select.module
+++ b/docroot/sites/all/modules/contrib/hierarchical_select/hierarchical_select.module
@@ -366,6 +366,7 @@ function _hs_process_attach_css_js($element, $hsid, &$form_state, $complete_form
   global $language;
   // Set up Javascript and add settings specifically for the current
   // hierarchical select.
+  $element['#attached']['library'][] = array('system', 'ui');
   $element['#attached']['library'][] = array('system', 'drupal.ajax');
   $element['#attached']['library'][] = array('system', 'jquery.form');
   $element['#attached']['library'][] = array('system', 'effects');

--- a/docroot/sites/all/modules/patches/PATCHED.txt
+++ b/docroot/sites/all/modules/patches/PATCHED.txt
@@ -156,3 +156,11 @@ Footer is default.
 See #10248
 
 
+=============================================
+
+HierarchicalSelect
+
+Always load JQuery UI library. This fixes FSA issue #10336, as well as issue
+#2656040 on Drupal.org: https://www.drupal.org/node/2656040
+Patch file for Drupal.org: hierarchical_select-require_jquery_ui-2656040-1.patch
+

--- a/docroot/sites/all/modules/patches/hierarchical_select-require_jquery_ui-2656040-1.patch
+++ b/docroot/sites/all/modules/patches/hierarchical_select-require_jquery_ui-2656040-1.patch
@@ -1,0 +1,24 @@
+From f3142bf87c8e4fb0f5cf9ef963fd914344a9a2c2 Mon Sep 17 00:00:00 2001
+From: Matt Farrow <matt.farrow@siriusopensource.com>
+Date: Mon, 25 Jan 2016 11:15:55 +0000
+Subject: [PATCH] Issue #2656040 by mattfarrow: Require JQuery UI
+
+---
+ hierarchical_select.module | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hierarchical_select.module b/hierarchical_select.module
+index b7e8a87..02f663f 100644
+--- a/hierarchical_select.module
++++ b/hierarchical_select.module
+@@ -366,6 +366,7 @@ function _hs_process_attach_css_js($element, $hsid, &$form_state, $complete_form
+   global $language;
+   // Set up Javascript and add settings specifically for the current
+   // hierarchical select.
++  $element['#attached']['library'][] = array('system', 'ui');
+   $element['#attached']['library'][] = array('system', 'drupal.ajax');
+   $element['#attached']['library'][] = array('system', 'jquery.form');
+   $element['#attached']['library'][] = array('system', 'effects');
+-- 
+2.5.4 (Apple Git-61)
+


### PR DESCRIPTION
Due to the JQuery UI library not always being loaded, the hierarchical select module was not working properly on file edit pages.

This has been patched on Drupal.org - issue #2656040.

https://www.drupal.org/node/2656040

The patch has been applied to this branch.

[ Fixes #10336 ]