### PR TITLE
Upgrade Display Suite to version 7.x-2.12

### DIFF
--- a/docroot/sites/all/modules/contrib/ds/css/ds.admin.css
+++ b/docroot/sites/all/modules/contrib/ds/css/ds.admin.css
@@ -7,8 +7,19 @@
   margin-bottom: 1em;
 }
 
+#field-display-overview .field-formatter-settings-edit-form .ft-group {
+  border-top: 1px solid #aaa;
+  padding: 5px 0;
+  overflow: auto;
+}
+
+#field-display-overview .field-formatter-settings-edit-form .ft-group.lb {
+  border-top: none;
+}
+
 #field-display-overview .field-formatter-settings-edit-form .ft-group .form-item {
   margin: 0;
+  white-space: normal;
 }
 
 .ds-layout-preview-title {
@@ -164,7 +175,7 @@ a.section-link {
 .vertical-tabs fieldset#edit-additional-settings-ds-page-title-options-page-option-contexts {
   margin: 1em 0;
   padding: 2.5em 0 0;
-  border: 1px solid #CCCCCC;
+  border: 1px solid #ccc;
 }
 
 #edit-additional-settings-ds-page-title-options-page-option-contexts legend {

--- a/docroot/sites/all/modules/contrib/ds/ds.api.php
+++ b/docroot/sites/all/modules/contrib/ds/ds.api.php
@@ -196,10 +196,13 @@ function hook_ds_fields_info($entity_type) {
       'use_token' => TRUE, // or FALSE,
 
       // block: the module and delta of the block, only for block fields.
-      'block' => 'user-menu',
+      //
+      // @note: Display Suite uses a "|" token to split the module from
+      // the delta.
+      'block' => 'user|menu',
 
       // block_render: block render type, only for block fields.
-      // - DS_BLOCK_CONTENT       : render through block template file.
+      // - DS_BLOCK_TEMPLATE      : render through block template file.
       // - DS_BLOCK_TITLE_CONTENT : render only title and content.
       // - DS_BLOCK_CONTENT       : render only content.
       'block_render' => DS_BLOCK_CONTENT,
@@ -238,7 +241,7 @@ function hook_ds_custom_fields_info() {
   );
   $ds_field->properties = array(
     'code' => array(
-      'value' => '<? print "this is a custom field"; ?>',
+      'value' => '<?php print "this is a custom field"; ?>',
       'format' => 'ds_code',
     ),
     'use_token' => 0,
@@ -268,7 +271,9 @@ function hook_ds_vd_info() {
 }
 
 /**
- * Alter fields defined by Display Suite
+ * Alter fields defined by Display Suite.
+ *
+ * This function is called for each entity type.
  *
  * @param $fields
  *   An array with fields which can be altered just before they get cached.
@@ -420,9 +425,12 @@ function hook_ds_layout_info() {
  *   - entity_type
  *   - bundle
  *   - view_mode
+ * @param array $vars
+ *   All variables available for render. You can use this to add css classes.
  */
-function hook_ds_pre_render_alter(&$layout_render_array, $context) {
+function hook_ds_pre_render_alter(&$layout_render_array, $context, &$vars) {
   $layout_render_array['left'][] = array('#markup' => 'cool!', '#weight' => 20);
+  $vars['attributes_array']['class'][] = 'custom';
 }
 
 /**
@@ -591,6 +599,21 @@ function hook_ds_classes_alter(&$classes, $name) {
   if ('ds_classes_regions' === $name) {
     $classes['css-class-name'] = t('Custom Styling');
   }
+}
+
+/**
+ * Alter the field template settings form
+ *
+ * @param array $form
+ *   The form containing the field settings
+ * @param array $field_settings
+ *   The settings of the field
+ */
+function hook_ds_field_theme_functions_settings_alter(&$form, $field_settings) {
+  $form['something'] = array(
+    '#type' => 'textfield',
+    '#title' => 'test',
+  );
 }
 
 /*

--- a/docroot/sites/all/modules/contrib/ds/ds.ds_fields_info.inc
+++ b/docroot/sites/all/modules/contrib/ds/ds.ds_fields_info.inc
@@ -24,12 +24,8 @@ function ds_ds_fields_info($entity_type) {
         'properties' => $field->properties,
       );
       if (!empty($field->ui_limit)) {
-        $fields[$entity_type][$key]['ui_limit'] = explode("\n", $field->ui_limit);
-        // Ensure that all strings are trimmed, eg. don't have
-        // extra spaces, \r chars etc.
-        foreach ($fields[$entity_type][$key]['ui_limit'] as $k => $v) {
-          $fields[$entity_type][$key]['ui_limit'][$k] = trim($v);
-        }
+        $lines = explode("\n", $field->ui_limit);
+        $fields[$entity_type][$key]['ui_limit'] = $lines;
       }
     }
   }
@@ -79,10 +75,11 @@ function ds_ds_fields_info($entity_type) {
     'properties' => array(
       'settings' => array(
         'link text' => array('type' => 'textfield'),
+        'link class' => array('type' => 'textfield', 'description' => t('Put a class on the link. Eg: btn btn-default')),
         'wrapper' => array('type' => 'textfield', 'description' => t('Eg: h1, h2, p')),
         'class' => array('type' => 'textfield', 'description' => t('Put a class on the wrapper. Eg: block-title')),
       ),
-      'default' => array('link text' => 'Read more', 'wrapper' => '', 'class' => '', 'link' => 1),
+      'default' => array('link text' => 'Read more', 'link class' => '', 'wrapper' => '', 'class' => '', 'link' => 1),
     )
   );
 

--- a/docroot/sites/all/modules/contrib/ds/ds.info
+++ b/docroot/sites/all/modules/contrib/ds/ds.info
@@ -13,9 +13,9 @@ files[] = tests/ds.views.test
 files[] = tests/ds.forms.test
 configure = admin/structure/ds
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/ds.install
+++ b/docroot/sites/all/modules/contrib/ds/ds.install
@@ -69,7 +69,7 @@ function ds_schema() {
       'view_mode' => array(
         'description' => 'The name of the view_mode.',
         'type' => 'varchar',
-        'length' => 32,
+        'length' => 64,
         'not null' => TRUE,
         'default' => '',
       ),
@@ -131,7 +131,7 @@ function ds_schema() {
       'view_mode' => array(
         'description' => 'The name of the view_mode.',
         'type' => 'varchar',
-        'length' => 32,
+        'length' => 64,
         'not null' => TRUE,
         'default' => '',
       ),
@@ -179,7 +179,7 @@ function ds_schema() {
       'view_mode' => array(
         'description' => 'The machine name of the view mode.',
         'type' => 'varchar',
-        'length' => 32,
+        'length' => 64,
         'not null' => TRUE,
         'default' => '',
       ),
@@ -229,7 +229,7 @@ function ds_schema() {
       'label' => array(
         'description' => 'The label of the field.',
         'type' => 'varchar',
-        'length' => 32,
+        'length' => 128,
         'not null' => TRUE,
         'default' => '',
       ),
@@ -276,4 +276,52 @@ function ds_update_7201() {
   if (!db_field_exists('ds_fields', 'ui_limit')) {
     db_add_field('ds_fields', 'ui_limit', $schema['ds_fields']['fields']['ui_limit']);
   }
+}
+
+/**
+ * Increase the label storage length to 128.
+ */
+function ds_update_7202() {
+  db_change_field('ds_fields', 'label', 'label',
+    array(
+      'description' => 'The label of the field.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => TRUE,
+      'default' => '',
+    ));
+}
+
+
+/**
+ * Increase the view_mode storage length to 64
+ */
+function ds_update_7203() {
+  db_change_field('ds_field_settings', 'view_mode', 'view_mode',
+    array(
+      'description' => 'The name of the view_mode.',
+      'type' => 'varchar',
+      'length' => 64,
+      'not null' => TRUE,
+      'default' => '',
+    )
+  );
+  db_change_field('ds_layout_settings', 'view_mode', 'view_mode',
+    array(
+      'description' => 'The name of the view_mode.',
+      'type' => 'varchar',
+      'length' => 64,
+      'not null' => TRUE,
+      'default' => '',
+    )
+  );
+  db_change_field('ds_view_modes', 'view_mode', 'view_mode',
+    array(
+      'description' => 'The machine name of the view mode.',
+      'type' => 'varchar',
+      'length' => 64,
+      'not null' => TRUE,
+      'default' => '',
+    )
+  );
 }

--- a/docroot/sites/all/modules/contrib/ds/ds.module
+++ b/docroot/sites/all/modules/contrib/ds/ds.module
@@ -302,6 +302,9 @@ function ds_get_fields($entity_type, $cache = TRUE) {
 
   static $static_fields, $fields_cached = array();
   static $loaded = FALSE;
+  // Load the ds file that handles ds call of hook_ds_fields_info, otherwise it
+  // doesn't get loaded
+  module_load_include('inc', 'ds', 'ds.ds_fields_info');
 
   // Get fields from cache.
   if (!$loaded) {
@@ -571,8 +574,13 @@ function ds_field_attach_view_alter(&$build, $context) {
     }
   }
 
+  $disable_css = FALSE;
+  if (!empty($layout['settings']['layout_disable_css'])) {
+    $disable_css = TRUE;
+  }
+
   // Add path to css file for this layout and disable block regions if necessary.
-  if (isset($layout['css']) && !isset($loaded_css[$layout['path'] . '/' . $layout['layout'] . '.css'])) {
+  if (!$disable_css && isset($layout['css']) && !isset($loaded_css[$layout['path'] . '/' . $layout['layout'] . '.css'])) {
     // Register css file.
     $loaded_css[$layout['path'] . '/' . $layout['layout'] . '.css'] = TRUE;
     // Add css file.
@@ -605,6 +613,10 @@ function ds_entity_variables(&$vars) {
     if ($vars['elements']['#entity_type'] == 'taxonomy_term') {
       $object = 'term';
     }
+
+    // Get entity id and bundle
+    list($id,, $bundle) = entity_extract_ids($vars['elements']['#entity_type'], $vars[$object]);
+
     if (isset($vars[$object]->preprocess_fields)) {
       foreach ($vars[$object]->preprocess_fields as $field) {
 
@@ -649,11 +661,13 @@ function ds_entity_variables(&$vars) {
         $layout['layout'] = $layout['panels']['theme'];
       }
 
+      $bundle = strtr($bundle, '-', '_');
       $vars['theme_hook_suggestions'][] = $layout['layout'];
       $vars['theme_hook_suggestions'][] = $layout['layout'] . '__' . $vars['elements']['#entity_type'];
       $vars['theme_hook_suggestions'][] = $layout['layout'] . '__' . $vars['elements']['#entity_type'] . '_' . $vars['elements']['#view_mode'];
-      $vars['theme_hook_suggestions'][] = $layout['layout'] . '__' . $vars['elements']['#entity_type'] . '_' . $vars['elements']['#bundle'];
-      $vars['theme_hook_suggestions'][] = $layout['layout'] . '__' . $vars['elements']['#entity_type'] . '_' . $vars['elements']['#bundle'] . '_' . $vars['elements']['#view_mode'];
+      $vars['theme_hook_suggestions'][] = $layout['layout'] . '__' . $vars['elements']['#entity_type'] . '_' . $bundle;
+      $vars['theme_hook_suggestions'][] = $layout['layout'] . '__' . $vars['elements']['#entity_type'] . '_' . $bundle . '_' . $vars['elements']['#view_mode'];
+      $vars['theme_hook_suggestions'][] = $layout['layout'] . '__' . $vars['elements']['#entity_type'] . '__' . $id;
     }
 
     // If the layout has wrapper class lets add it.
@@ -684,6 +698,11 @@ function ds_entity_variables(&$vars) {
       // Add extras classes to the region.
       if (empty($layout['flexible'])) {
         $vars[$region_name . '_classes'] = !empty($layout['settings']['classes'][$region_name]) ? ' ' . implode(' ', $layout['settings']['classes'][$region_name]) : '';
+
+        // Token support for region classes.
+        if (module_exists('token') && isset($vars[$object])) {
+          $vars[$region_name . '_classes'] = token_replace($vars[$region_name . '_classes'], array($object => $vars[$object]), array('clear' => TRUE, 'sanitize' => TRUE));
+        }
       }
       // Add a wrapper to the region.
       if (empty($layout['flexible'])) {
@@ -700,7 +719,12 @@ function ds_entity_variables(&$vars) {
     // Add layout attributes if any.
     $vars['layout_attributes'] = '';
     if (!empty($layout['settings']['layout_attributes'])) {
-      $vars['layout_attributes'] .= ' ' . $layout['settings']['layout_attributes'];
+      if (isset($vars[$object])) {
+        $vars['layout_attributes'] .= ' ' . token_replace($layout['settings']['layout_attributes'], array($object => $vars[$object]), array('clear' => TRUE, 'sanitize' => TRUE));
+      }
+      else {
+        $vars['layout_attributes'] .= ' ' . $layout['settings']['layout_attributes'];
+      }
     }
     // Merge in other attributes which were passed to the template.
     if (!empty($layout['settings']['layout_attributes_merge'])) {
@@ -712,12 +736,24 @@ function ds_entity_variables(&$vars) {
       $vars['layout_attributes'] .= ' ' . drupal_attributes($vars['attributes_array']);
     }
 
+    // Token support for layout classes.
+    if (module_exists('token') && isset($vars[$object])) {
+      foreach ($vars['classes_array'] as &$class) {
+        $class = token_replace($class, array($object => $vars[$object]), array('clear' => TRUE, 'sanitize' => TRUE));
+      }
+    }
+
     // Add an onclick attribute on the wrapper.
     if (!empty($layout['settings']['layout_link_attribute'])) {
       $url = '';
       switch ($layout['settings']['layout_link_attribute']) {
         case 'content':
-          $uri = entity_uri($vars['elements']['#entity_type'], $vars[$object]);
+          if ($object == 'user') {
+            $uri = entity_uri($vars['elements']['#entity_type'], $vars['elements']['#account']);
+          }
+          else {
+            $uri = entity_uri($vars['elements']['#entity_type'], $vars[$object]);
+          }
           if (!empty($uri)) {
             $url = $uri['path'];
           }
@@ -726,7 +762,7 @@ function ds_entity_variables(&$vars) {
           $url = $layout['settings']['layout_link_custom'];
           break;
         case 'tokens':
-          $url = token_replace($layout['settings']['layout_link_custom'], array($vars['elements']['#entity_type'] => $vars[$object]));
+          $url = token_replace($layout['settings']['layout_link_custom'], array($vars['elements']['#entity_type'] => $vars[$object]), array('clear' => TRUE));
           break;
       }
 
@@ -735,9 +771,16 @@ function ds_entity_variables(&$vars) {
       }
     }
 
+    // Set field weights for all fields, including pre-process.
+    foreach($layout_render_array as $region => &$fields) {
+      foreach ($fields as $field_key => &$field) {
+        $field['#weight'] = $field_key;
+      }
+    }
+
     // Let other modules alter the ds array before creating the region variables.
     $context = array('entity' => isset($vars[$object]) ? $vars[$object] : (isset($vars['elements']['#' . $object]) ? $vars['elements']['#' . $object] : ''), 'entity_type' => $vars['elements']['#entity_type'], 'bundle' => $vars['elements']['#bundle'], 'view_mode' => $vars['elements']['#view_mode']);
-    drupal_alter('ds_pre_render', $layout_render_array, $context);
+    drupal_alter('ds_pre_render', $layout_render_array, $context, $vars);
     foreach ($layout_render_array as $region_name => $content) {
       // In case this is a panels layout, add the region to the $content variable.
       if (isset($layout['module']) && $layout['module'] == 'panels') {
@@ -772,16 +815,17 @@ function ds_create_entity_context($entity_type, $entity, &$contexts, $context_ar
  */
 function ds_render_code_field($field) {
   if (isset($field['properties']['code'])) {
+    $value = $field['properties']['code']['value'];
+    // Token support - check on token property so we don't run every single field through token.
+    if (isset($field['properties']['use_token']) && $field['properties']['use_token']) {
+      $value = token_replace($value, array($field['entity_type'] => $field['entity']), array('clear' => TRUE));
+    }
     $format = (isset($field['properties']['code']['format'])) ? $field['properties']['code']['format'] : 'plain_text';
     if ($format == 'ds_code' && module_exists('ds_format')) {
-      $value = ds_format_php_eval($field['properties']['code']['value'], $field['entity'], isset($field['build']) ? $field['build'] : array());
+      $value = ds_format_php_eval($value, $field['entity'], isset($field['build']) ? $field['build'] : array());
     }
     else {
-      $value = check_markup($field['properties']['code']['value'], $format);
-    }
-    // Token support - check on token property so we don't run every single field through token.
-    if (isset($field['properties']['use_token']) && $field['properties']['use_token'] == TRUE) {
-      $value = token_replace($value, array($field['entity_type'] => $field['entity']), array('clear' => TRUE));
+      $value = check_markup($value, $format);
     }
     return $value;
   }
@@ -802,7 +846,12 @@ function ds_render_ctools_field($field) {
     // 3) embed a view with the 2 taxonomies as fields.
     if (isset($field['formatter_settings']['load_terms']) && $field['formatter_settings']['load_terms']) {
       static $terms_loaded = array();
-      $language = $field['entity']->language;
+      if (isset($field['entity']->language)) {
+        $language = $field['entity']->language;
+      }
+      else {
+        $language = LANGUAGE_NONE;
+      }
       $instances = field_info_instances($field['entity_type'], $field['bundle']);
       foreach ($instances as $key => $instance) {
         $info = field_info_field($key);
@@ -816,7 +865,12 @@ function ds_render_ctools_field($field) {
           foreach ($field['entity']->{$key}[$language] as $tkey => $item) {
             if (isset($item['tid']) && !isset($item['taxonomy_term'])) {
               if (!isset($terms_loaded[$item['tid']])) {
-                $terms_loaded[$item['tid']] = taxonomy_term_load($item['tid']);
+                $term = taxonomy_term_load($item['tid']);
+                if (!is_object($term)) {
+                  // This term is missing in the database.
+                  continue;
+                }
+                $terms_loaded[$item['tid']] = $term;
               }
               $field['entity']->{$key}[$language][$tkey]['taxonomy_term'] = $terms_loaded[$item['tid']];
             }
@@ -848,7 +902,7 @@ function ds_render_ctools_field($field) {
       $content = '';
       if ($show_title) {
         if (empty($title_wrapper)) $title_wrapper = 'div';
-        $content .= '<' . check_plain($title_wrapper) . '>' . $data->title . '</' . check_plain($title_wrapper) . '>';
+        $content .= '<' . check_plain($title_wrapper) . ' class="title">' . $data->title . '</' . check_plain($title_wrapper) . '>';
       }
       if (is_array($data->content)) {
         $content .= drupal_render($data->content);
@@ -873,7 +927,7 @@ function ds_render_block_field($field) {
   $contextual_links = array();
   $contextual = module_exists('contextual') && user_access('access contextual links');
   if ($contextual) {
-    if (is_array($block['content']) && isset($block['content']['#contextual_links'])) {
+    if (isset($block['content']) && is_array($block['content']) && isset($block['content']['#contextual_links'])) {
       $contextual_links = $block['content']['#contextual_links'];
     }
   }
@@ -892,7 +946,9 @@ function ds_render_block_field($field) {
     }
 
     global $theme_key;
-    $full_block = db_query("SELECT * FROM {block} WHERE module = :module AND delta = :delta AND theme = :theme", array(':module' => $module, ':delta' => $delta, ':theme' => $theme_key))->fetchObject();
+    if (module_exists('block')) {
+      $full_block = db_query("SELECT * FROM {block} WHERE module = :module AND delta = :delta AND theme = :theme", array(':module' => $module, ':delta' => $delta, ':theme' => $theme_key))->fetchObject();
+    }
     if (!empty($full_block)) {
       if ($full_block->title == '<none>') {
         $block['subject'] = '';
@@ -955,7 +1011,6 @@ function ds_render_block_field($field) {
  * Render a field.
  */
 function ds_render_field($field) {
-
   $title_field = FALSE;
 
   $output = '';
@@ -982,14 +1037,16 @@ function ds_render_field($field) {
 
   // Link.
   if ($settings['link']) {
-    if (isset($field['entity']->uri['path'])) {
-      $path = $field['entity']->uri['path'];
+    if (isset($field['entity']->uri)) {
+      $uri_info = $field['entity']->uri;
     }
     else {
       $uri_info = entity_uri($field['entity_type'], $field['entity']);
-      $path = $uri_info['path'];
     }
-    $output = l($output, $path);
+    if (isset($settings['link class'])) {
+      $uri_info['options']['attributes']['class'][] = $settings['link class'];
+    }
+    $output = l($output, $uri_info['path'], $uri_info['options']);
     if ($title_field) {
       $output = ds_edit_support('title', $output, $field);
     }
@@ -1098,9 +1155,8 @@ function ds_render_user_picture($field) {
   $picture = ds_return_picture($field['entity']);
 
   if (!empty($picture)) {
-    $vars = array();
     $filepath = (isset($picture->uri)) ? $picture->uri : $picture;
-    $name = !empty($field['entity']->name) ? $field['entity']->name : variable_get('anonymous', t('Anonymous'));
+    $name = format_username($field['entity']);
     $alt = t("@user's picture", array('@user' => $name));
     $vars = array('path' => $filepath, 'alt' => $alt, 'title' => $alt);
 
@@ -1157,7 +1213,10 @@ function ds_field_formatter_info() {
       'label'       => t('Rendered taxonomy term'),
       'description' => t('Display the referenced term in a specific view mode'),
       'field types' => array('taxonomy_term_reference'),
-      'settings'    => array('taxonomy_term_reference_view_mode' => 'full'),
+      'settings'    => array(
+        'taxonomy_term_reference_view_mode' => 'full',
+        'use_content_language' => TRUE,
+      ),
     );
     $formatters['ds_taxonomy_separator'] = array(
       'label'       => t('Separated'),
@@ -1203,6 +1262,17 @@ function ds_field_formatter_view($entity_type, $entity, $field, $instance, $lang
       }
       else {
         $term = taxonomy_term_load($item['tid']);
+        if (module_exists('i18n_taxonomy')) {
+          $term = i18n_taxonomy_localize_terms($term);
+        }
+        if (!is_object($term)) {
+          // This term is missing in the database.
+          continue;
+        }
+        $settings = $display['settings'];
+        if ($settings['use_content_language'] && !empty($GLOBALS['language_content']->language)) {
+          $langcode = $GLOBALS['language_content']->language;
+        }
         if (!empty($term)) {
           $build = taxonomy_term_view($term, $view_mode, $langcode);
         }
@@ -1227,13 +1297,20 @@ function ds_field_formatter_view($entity_type, $entity, $field, $instance, $lang
       }
       else {
         $term = taxonomy_term_load($item['tid']);
+        if (module_exists('i18n_taxonomy')) {
+          $term = i18n_taxonomy_localize_terms($term);
+        }
+        if (!is_object($term)) {
+          // This term is missing in the database.
+          continue;
+        }
         if ($display['type'] == 'ds_taxonomy_separator_localized' && function_exists('i18n_taxonomy_term_name')) {
           $term->name = i18n_taxonomy_term_name($term, $language->language);
         }
         $item_display = check_plain($term->name);
         if ($linked) {
           $uri = entity_uri('taxonomy_term', $term);
-          $item_display = l($term->name, $uri['path']);
+          $item_display = l($term->name, $uri['path'], $uri['options']);
         }
       }
       $terms[] = $item_display;

--- a/docroot/sites/all/modules/contrib/ds/includes/ds.displays.inc
+++ b/docroot/sites/all/modules/contrib/ds/includes/ds.displays.inc
@@ -144,12 +144,14 @@ function ds_emergency_region_to_block_submit($form, &$form_state) {
     $region_blocks = variable_get('ds_extras_region_blocks', array());
     $remove = $form_state['values']['remove_block_region'];
     foreach ($remove as $key => $value) {
-      if ($key === $value) {
+      if ($value !== 0 && $key == $value) {
         $variable_set = TRUE;
-        db_delete('block')
-          ->condition('delta', $key)
-          ->condition('module', 'ds_extras')
-          ->execute();
+        if (module_exists('block')) {
+          db_delete('block')
+            ->condition('delta', $key)
+            ->condition('module', 'ds_extras')
+            ->execute();
+        }
         unset($region_blocks[$key]);
       }
     }

--- a/docroot/sites/all/modules/contrib/ds/includes/ds.field_ui.inc
+++ b/docroot/sites/all/modules/contrib/ds/includes/ds.field_ui.inc
@@ -770,6 +770,14 @@ function ds_field_ui_layouts_save($form, &$form_state) {
     $record->settings['layout_link_attribute'] = $form_state['values']['additional_settings']['region_wrapper']['layout_link_attribute'];
     $record->settings['layout_link_custom'] = $form_state['values']['additional_settings']['region_wrapper']['layout_link_custom'];
 
+    // Additional settings
+    if (isset($form_state['values']['additional_settings']['preview']['info']['settings']['disable_css'])) {
+      $record->settings['layout_disable_css'] = $form_state['values']['additional_settings']['preview']['info']['settings']['disable_css'];
+    }
+    else {
+      $record->settings['layout_disable_css'] = FALSE;
+    }
+
     $record->settings = $record->settings;
 
     // Let other modules alter the layout settings.
@@ -982,6 +990,11 @@ function ds_field_formatter_settings_form($field, $instance, $view_mode, $form, 
       '#options' => $options,
       '#default_value' => $settings['taxonomy_term_reference_view_mode'],
     );
+    $element['use_content_language'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Use current content language'),
+      '#default_value' => $settings['use_content_language'],
+    );
     return $element;
   }
 
@@ -1027,7 +1040,8 @@ function ds_field_formatter_settings_summary($field, $instance, $view_mode) {
     $entity_info = entity_get_info('taxonomy_term');
     $modes = $entity_info['view modes'];
     $mode = $modes[$settings['taxonomy_term_reference_view_mode']]['label'];
-    $summary = t('View mode: %mode', array('%mode' => $mode));
+    $summary .= t('View mode: %mode', array('%mode' => $mode)) . '<br />';;
+    $summary .= !empty($settings['use_content_language']) ? t('Use current content language') : t('Use field language');
   }
 
   if ($display['type'] === 'ds_taxonomy_separator' || $display['type'] == 'ds_taxonomy_separator_localized') {
@@ -1613,7 +1627,16 @@ function _ds_field_ui_table_layouts($entity_type, $bundle, $view_mode, &$form, $
   if (!empty($layout) && isset($layout->regions)) {
 
     // Add wrappers
-    $wrapper_options = array('div' => 'Div', 'span' => 'Span', 'section' => 'Section', 'article' => 'Article', 'header' => 'Header', 'footer' => 'Footer', 'aside' => 'Aside');
+    $wrapper_options = array(
+      'div' => 'Div',
+      'span' => 'Span',
+      'section' => 'Section',
+      'article' => 'Article',
+      'header' => 'Header',
+      'footer' => 'Footer',
+      'aside' => 'Aside',
+      'figure' => 'Figure'
+    );
     $form['additional_settings']['region_wrapper'] = array(
       '#type' => 'fieldset',
       '#title' => t('Custom wrappers'),
@@ -1738,6 +1761,9 @@ function _ds_field_ui_table_layouts($entity_type, $bundle, $view_mode, &$form, $
       }
       if ($classes_access) {
         $form['additional_settings']['ds_classes']['info'] = array('#markup' => l(t('Manage region  and field CSS classes'), 'admin/structure/ds/classes', array('query' => drupal_get_destination())));
+      }
+      elseif (user_access('admin_classes')) {
+        $form['additional_settings']['ds_classes']['info'] = array('#markup' => l(t('To manage region and field CSS classes, the Display Suite UI module should be enabled.'), 'admin/modules', array('query' => drupal_get_destination(), 'fragment' => 'edit-modules-display-suite')));
       }
     }
     else {
@@ -1874,13 +1900,14 @@ function _ds_field_ui_table_layouts_preview(&$form, &$form_state, $ds_layouts, $
 
       $suggestions_array[0] = $layout_string . '--' . $entity_type;
       $suggestions_array[2] = $layout_string . '--' . $entity_type . '-' . $bundle;
+      $suggestions_array[4] = $layout_string . '--' . $entity_type . '--{id}';
       if (!isset($form_state['no_view_mode_suggestions']) && $view_mode != 'default') {
         $suggestions_array[1] = $layout_string . '--' . $entity_type . '-' . $view_mode;
         $suggestions_array[3] = $layout_string . '--' . $entity_type . '-' . $bundle . '-' . $view_mode;
       }
 
       ksort($suggestions_array);
-      $suggestions = '<ul><li>' . implode('.tpl.php</li><li>', $suggestions_array) . '.tpl.php</li></ul>';
+      $suggestions .= '<ul><li>' . implode('.tpl.php</li><li>', $suggestions_array) . '.tpl.php</li></ul>';
     }
     else {
       $suggestions = '';
@@ -1901,9 +1928,28 @@ function _ds_field_ui_table_layouts_preview(&$form, &$form_state, $ds_layouts, $
       $form['additional_settings']['ds_layouts']['preview'] ['image'] = array(
         '#markup' => '<div class="ds-layout-preview-image"><img src="' . base_path() . $image . '"/></div>',
       );
-      $form['additional_settings']['ds_layouts']['preview'] ['suggestions'] = array(
-        '#markup' => '<div class="ds-layout-preview-suggestion"><p>' . $selected . '</p><p>' . t('!suggestions', array('!suggestions' => strtr($suggestions, '_', '-'))) . '</p></div>',
+      $form['additional_settings']['ds_layouts']['preview']['info'] = array(
+        '#type' => 'container',
+        '#attributes' => array(
+          'class' => array('ds-layout-preview-suggestion'),
+        ),
       );
+      $form['additional_settings']['ds_layouts']['preview']['info']['suggestions'] = array(
+        '#markup' => '<p>' . $selected . '</p><p>' . t('!suggestions', array('!suggestions' => strtr($suggestions, '_', '-'))) . '</p>',
+      );
+
+      if (!empty($chosen_layout['css'])) {
+        $disable_css = FALSE;
+        if (isset($layout->settings['layout_disable_css'])) {
+          $disable_css = $layout->settings['layout_disable_css'];
+        }
+
+        $form['additional_settings']['ds_layouts']['preview']['info']['settings']['disable_css'] = array(
+          '#type' => 'checkbox',
+          '#title' => t('Disable layout CSS styles'),
+          '#default_value' => $disable_css,
+        );
+      }
     }
 
     if (isset($form_state['values']['additional_settings']['layout']) && (!isset($layout->layout) || $form_state['values']['additional_settings']['layout'] != $layout->layout)) {
@@ -1961,9 +2007,30 @@ function ds_field_ui_change_layout_validate(&$form, &$form_state) {
  * Form submission handler for _ds_field_ui_table_layouts_preview().
  */
 function ds_field_ui_change_layout_submit($form, &$form_state) {
+  $values = $form_state['values'];
+  if (isset($values['additional_settings']['preview']['info']['settings']['disable_css'])) {
+    $disable_css = $values['additional_settings']['preview']['info']['settings']['disable_css'];
+  }
+  else {
+    $disable_css = FALSE;
+  }
+
+  $record = db_select('ds_layout_settings')
+    ->fields('ds_layout_settings')
+    ->condition('entity_type', $values['ds_entity_type'])
+    ->condition('bundle', $values['ds_bundle'])
+    ->condition('view_mode', $values['ds_view_mode'])
+    ->execute()
+    ->fetchObject();
+
+  $record->settings = unserialize($record->settings);
+  $record->settings['layout_disable_css'] = $disable_css;
+
+  drupal_write_record('ds_layout_settings', $record, array('id'));
+
   unset($_GET['destination']);
   global $base_url;
-  $url = $base_url . '/' . $form_state['values']['layout_changed_url'];
+  $url = $base_url . '/' . $values['layout_changed_url'];
   $form_state['redirect'] = $url;
 }
 
@@ -2027,7 +2094,7 @@ function _ds_field_ui_fields($entity_type, $bundle, $view_mode, &$form, &$form_s
   foreach ($fields as $key => $field) {
 
     // Check on ui_limit.
-    if (isset($field['ui_limit'])) {
+    if (!empty($field['ui_limit'])) {
 
       $continue = TRUE;
       foreach ($field['ui_limit'] as $limitation) {
@@ -2252,6 +2319,7 @@ function _ds_field_ui_core_fields($entity_type, $bundle, $view_mode, &$form, &$f
 
         // Load the form
         module_load_include('inc', 'ds_extras', 'includes/ds_extras.admin');
+        if (!is_array($settings_form)) $settings_form = array();
         ds_extras_field_template_settings_form($settings_form, $form_state, $context);
       }
 
@@ -2470,9 +2538,7 @@ function _ds_field_ui_custom_fields($entity_type, $bundle, $view_mode, &$form, $
     'custom_field' => t('Add a code field'),
     'manage_ctools' => t('Add a dynamic field'),
   );
-  if (module_exists('block')) {
-    $field_types['manage_block'] = t('Add a block field');
-  }
+  $field_types['manage_block'] = t('Add a block field');
   $field_types['manage_preprocess'] = t('Add a preprocess field');
 
   foreach ($field_types as $field_key => $field_title) {

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_devel/ds_devel.info
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_devel/ds_devel.info
@@ -5,9 +5,9 @@ package = "Display Suite"
 dependencies[] = ds
 dependencies[] = devel
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_extras/ds_extras.info
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_extras/ds_extras.info
@@ -5,9 +5,9 @@ package = "Display Suite"
 dependencies[] = ds
 configure = admin/structure/ds/list/extras
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_extras/ds_extras.module
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_extras/ds_extras.module
@@ -236,7 +236,7 @@ function ds_extras_form_field_ui_field_edit_form_alter(&$form, &$form_state, $fo
 }
 
 /**
- * Utility funtion to return the view mode for the current entity.
+ * Utility function to return the view mode for the current entity.
  *
  * The drupal_static is called in ds_extras_node_show to set
  * the current view mode. Through this technique, the hide page
@@ -338,33 +338,59 @@ function ds_extras_switch_view_mode_field($field) {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function ds_extras_form_node_type_form_alter(&$form, $form_state, $form_id) {
+  $node_type = $form['#node_type']->type;
+
+  // Get the view modes.
+  $options = ds_extras_get_bundle_view_modes('node', $node_type);
+
+  // Only fire if we have more than 1 option.
+  if (count($options) > 1) {
+    if (!isset($form['ds_extras'])) {
+      $form['ds_extras'] = array(
+        '#type' => 'fieldset',
+        '#title' => t('Display Suite: Extras'), // There's already a 'Display settings' fieldset
+        '#collapsible' => TRUE,
+        '#collapsed' => TRUE,
+        '#group' => 'additional_settings',
+        '#weight' => 100,
+      );
+    }
+
+    $form['ds_extras']['ds_extras_view_modes'] = array(
+      '#type' => 'checkboxes',
+      '#title' => t('View modes'),
+      '#options' => $options,
+      '#default_value' => variable_get('ds_extras_view_modes_' . $node_type, array_keys($options)),
+      '#description' => t('Select which view modes will be available to switch to on node edit forms.'),
+    );
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function ds_extras_form_node_form_alter(&$form, $form_state, $form_id) {
+  $node = $form['#node'];
 
   // Switch full view mode.
-  if (user_access('ds_switch ' . $form['#node']->type)) {
-
-    $view_mode_settings = field_view_mode_settings('node', $form['#node']->type);
+  if (user_access('ds_switch ' . $node->type)) {
 
     // Get the view modes.
-    $ds_vm = ds_entity_view_modes('node');
+    $view_modes = ds_extras_get_bundle_view_modes('node', $node->type);
+    $enabled_vm = variable_get('ds_extras_view_modes_' . $node->type, array_keys($view_modes));
     $layouts = array();
-    $options = array('' => t('Default'));
-    foreach ($ds_vm as $key => $item) {
-      $overriden = (!empty($view_mode_settings[$key]['custom_settings']) ? TRUE : FALSE);
-      if ($overriden) {
-        $layout = ds_get_layout('node', $form['#node']->type, $key, FALSE);
+    $options = array();
+    foreach ($view_modes as $key => $label) {
+      if (in_array($key, $enabled_vm)) {
+        $layout = ds_get_layout('node', $node->type, $key, FALSE);
         $layouts[$key] = $layout;
-        $options[$key] = $item['label'];
+        $options[$key] = $label;
       }
     }
 
-    // Add default layout settings
-    $layouts[''] = ds_get_layout('node', $form['#node']->type, 'default', FALSE);
-
     // Only fire if we have more than 1 option.
     if (count($options) > 1) {
-      $node = $form['#node'];
-
       if (!isset($form['ds_extras'])) {
         $form['ds_extras'] = array(
           '#type' => 'fieldset',
@@ -380,7 +406,7 @@ function ds_extras_form_node_form_alter(&$form, $form_state, $form_id) {
         '#type' => 'select',
         '#title' => t('View mode'),
         '#options' => $options,
-        '#default_value' => isset($node->ds_switch) ? $node->ds_switch : '',
+        '#default_value' => isset($node->ds_switch) ? $node->ds_switch : 'default',
         '#description' => t('Switch to a different view mode to display the full page view of this node.'),
         '#weight' => -1,
         '#ajax' => array(
@@ -395,13 +421,17 @@ function ds_extras_form_node_form_alter(&$form, $form_state, $form_id) {
         '#suffix' => '</div>',
       );
 
-      $mode = isset($form_state['input']['ds_switch']) ? $form_state['input']['ds_switch'] : (isset($node->ds_switch) ? $node->ds_switch : '');
-      $chosen_layout = $layouts[$mode];
-
       $fallback_image = drupal_get_path('module', 'ds') . '/images/preview.png';
-      $image = (isset($chosen_layout['image']) && !empty($chosen_layout['image'])) ? $chosen_layout['path'] . '/' . $chosen_layout['layout'] . '.png' : $fallback_image;
-      if (isset($chosen_layout['panels']) && !empty($chosen_layout['panels']['icon'])) {
-        $image = $chosen_layout['panels']['path'] . '/' . $chosen_layout['panels']['icon'];
+      $mode = isset($form_state['input']['ds_switch']) ? $form_state['input']['ds_switch'] : (isset($node->ds_switch) ? $node->ds_switch : 'default');
+      if (isset($layouts[$mode])) {
+        $chosen_layout = $layouts[$mode];
+        $image = (isset($chosen_layout['image']) && !empty($chosen_layout['image'])) ? $chosen_layout['path'] . '/' . $chosen_layout['layout'] . '.png' : $fallback_image;
+        if (isset($chosen_layout['panels']) && !empty($chosen_layout['panels']['icon'])) {
+          $image = $chosen_layout['panels']['path'] . '/' . $chosen_layout['panels']['icon'];
+        }
+      }
+      else {
+        $image = $fallback_image;
       }
 
       $form['ds_extras']['preview']['image'] = array(
@@ -409,6 +439,25 @@ function ds_extras_form_node_form_alter(&$form, $form_state, $form_id) {
       );
     }
   }
+}
+
+/**
+ * Get view modes for an entity bundle.
+ */
+function ds_extras_get_bundle_view_modes($type, $bundle) {
+  $view_modes = array('default' => t('Default'));
+
+  $view_mode_settings = field_view_mode_settings($type, $bundle);
+  $ds_vm = ds_entity_view_modes($type);
+
+  foreach ($ds_vm as $key => $item) {
+    $overriden = (!empty($view_mode_settings[$key]['custom_settings']) ? TRUE : FALSE);
+    if ($overriden) {
+      $view_modes[$key] = $item['label'];
+    }
+  }
+
+  return $view_modes;
 }
 
 /**
@@ -606,11 +655,13 @@ function ds_extras_entity_view_alter(&$build, $entity_type) {
       $contexts = array();
       $id = (arg(0) == 'taxonomy') ? arg(2) : arg(1);
       $entity = entity_load($entity_type, array($id));
-      ds_create_entity_context($entity_type, $entity[$id], $contexts);
-      $title = $layout['settings']['page_option_title'];
-      $title = filter_xss_admin(ctools_context_keyword_substitute($title, array(), $contexts));
-      $page_title['title'] = $title;
-      $page_title['head_title'] = $title;
+      if (isset($entity[$id])) {
+        ds_create_entity_context($entity_type, $entity[$id], $contexts);
+        $title = $layout['settings']['page_option_title'];
+        $title = filter_xss_admin(ctools_context_keyword_substitute($title, array(), $contexts));
+        $page_title['title'] = t($title);
+        $page_title['head_title'] = t($title);
+      }
     }
   }
 
@@ -729,8 +780,17 @@ function theme_ds_field_expert($variables) {
 
   $config = $variables['ds-config'];
 
+  // Set prefix
+  if (!empty($config['prefix'])) {
+    $output .= $config['prefix'];
+  }
+
   // Render the label if it's not hidden.
   if (!$variables['label_hidden']) {
+    $styled_label = $variables['label'];
+    if (!isset($config['lb-col'])) $styled_label .= ':&nbsp;';
+
+    // Style the label it self
     $label_wrapper = isset($config['lb-el']) ? $config['lb-el'] : 'div';
     $class = array('label-' . $variables['element']['#label_display']);
     if (!empty($config['lb-cl'])) $class[] = $config['lb-cl'];
@@ -739,33 +799,48 @@ function theme_ds_field_expert($variables) {
     if (!empty($config['lb-at'])) $attributes[] = $config['lb-at'];
     if (!empty($config['lb-def-at'])) $attributes[] = $variables['title_attributes'];
     $attributes = (!empty($attributes)) ? ' ' . implode(' ', $attributes) : '';
-    $output .= '<' . $label_wrapper . $class . $attributes . '>' . $variables['label'];
-    if (!isset($config['lb-col'])) $output .= ':&nbsp;';
-    $output .= '</' . $label_wrapper . '>';
+    $styled_label = '<' . $label_wrapper . $class . $attributes . '>' . $styled_label . '</' . $label_wrapper . '>';
+
+    // Place it inside a wrapper
+    if (isset($config['lbw'])) {
+      $class = !empty($config['lbw-cl']) ? ' class="' . $config['lbw-cl'] . '"' : '';
+      $attributes = !empty($config['lbw-at']) ?  ' ' . $config['lbw-at'] : '';
+      $styled_label = '<' . $config['lbw-el'] . $class . $attributes . '>' . $styled_label . '</' . $config['lbw-el'] . '>';
+    }
+
+    $output .= $styled_label;
   }
 
   // Field items wrapper
   if (isset($config['fis'])) {
-    $class = (!empty($config['fis-cl'])) ? ' class="' . $config['fis-cl'] . '"' : '';
+    $class = (!empty($config['fis-cl'])) ? ' class="' . token_replace($config['fis-cl'], array($variables['element']['#entity_type'] => $variables['element']['#object']), array('clear' => TRUE)) . '"' : '';
     $attributes = array();
-    if (!empty($config['fis-at'])) $attributes[] = $config['fis-at'];
+    if (!empty($config['fis-at'])) $attributes[] = token_replace($config['fis-at'], array($variables['element']['#entity_type'] => $variables['element']['#object']), array('clear' => TRUE));;
     if (!empty($config['fis-def-at'])) $attributes[] = $variables['content_attributes'];
     $attributes = (!empty($attributes)) ? ' ' . implode(' ', $attributes) : '';
     $output .= '<' . $config['fis-el'] . $class . $attributes . '>';
   }
 
   // Render items.
+  $item_count = count($variables['items']);
+  $item_index = 0;
   foreach ($variables['items'] as $delta => $item) {
     // Field item wrapper.
     if (isset($config['fi'])) {
       $class = array();
       if (!empty($config['fi-odd-even'])) {
-        $class[] = $delta % 2 ? 'odd' : 'even';
+        $class[] = $delta % 2 ? 'even' : 'odd';
       }
       if (!empty($config['fi-cl'])) {
         $class[] = $config['fi-cl'];
       }
-      $class = !empty($class) ? ' class="'. implode(' ', $class)  .'"' : '';
+      if(!empty($config['fi-first-last']) && $item_index == 0) {
+        $class[] = "first";
+      }
+      if(!empty($config['fi-first-last']) && $item_index == $item_count - 1) {
+        $class[] = "last";
+      }
+      $class = !empty($class) ? ' class="'. token_replace(implode(' ', $class), array($variables['element']['#entity_type'] => $variables['element']['#object']), array('clear' => TRUE)) .'"' : '';
       $attributes = array();
       if (!empty($config['fi-at'])) {
         $attributes[] = token_replace($config['fi-at'], array($variables['element']['#entity_type'] => $variables['element']['#object']), array('clear' => TRUE));
@@ -784,6 +859,7 @@ function theme_ds_field_expert($variables) {
     if (isset($config['fi'])) {
       $output .= '</' . $config['fi-el'] . '>';
     }
+    ++$item_index;
   }
 
   // Closing field items wrapper.
@@ -794,14 +870,19 @@ function theme_ds_field_expert($variables) {
   // Outer wrapper.
   if (isset($config['ow'])) {
     $class = array();
-    if (!empty($config['ow-cl'])) $class[] = $config['ow-cl'];
+    if (!empty($config['ow-cl'])) $class[] = token_replace($config['ow-cl'], array($variables['element']['#entity_type'] => $variables['element']['#object']), array('clear' => TRUE));
     if (!empty($config['ow-def-cl'])) $class[] = $variables['classes'];
     $class = (!empty($class)) ? ' class="' . implode(' ', $class) . '"' : '';
     $attributes = array();
-    if (!empty($config['ow-at'])) $attributes[] = $config['ow-at'];
+    if (!empty($config['ow-at'])) $attributes[] = token_replace($config['ow-at'], array($variables['element']['#entity_type'] => $variables['element']['#object']), array('clear' => TRUE));;
     if (!empty($config['ow-def-at'])) $attributes[] = $variables['attributes'];
     $attributes = (!empty($attributes)) ? ' ' . implode(' ', $attributes) : '';
     $output = '<' . $config['ow-el'] . $class . $attributes . '>' . $output . '</' . $config['ow-el'] . '>';
+  }
+
+  // Set suffix
+  if (!empty($config['suffix'])) {
+    $output .= $config['suffix'];
   }
 
   return $output;
@@ -850,7 +931,7 @@ function ds_extras_ds_field_settings_alter(&$field_settings, $form, &$form_state
     }
 
     // Label.
-    if (isset($form_state['values']['fields'][$key]['label']) && $form_state['values']['fields'][$key]['label'] != 'hidden') {
+    if (isset($form_state['values']['fields'][$key]['label'])) {
       if (!empty($values['lb'])) {
         $field_settings[$key]['formatter_settings']['ft']['lb'] = $values['lb'];
       }
@@ -869,6 +950,27 @@ function ds_extras_ds_field_settings_alter(&$field_settings, $form, &$form_state
       if (!(empty($values['lb-col']))) {
         $field_settings[$key]['formatter_settings']['ft']['lb-col'] = TRUE;
       }
+
+      // label wrapper
+      if (!empty($values['lbw'])) {
+        $field_settings[$key]['formatter_settings']['ft']['lbw'] = $values['lbw'];
+      }
+      if (!(empty($values['lbw-el'])) && $function == 'theme_ds_field_expert') {
+        $field_settings[$key]['formatter_settings']['ft']['lbw-el'] = check_plain($values['lbw-el']);
+      }
+      if (!(empty($values['lbw-cl'])) && $function == 'theme_ds_field_expert') {
+        $field_settings[$key]['formatter_settings']['ft']['lbw-cl'] = check_plain($values['lbw-cl']);
+      }
+      if (!(empty($values['lbw-at'])) && $function == 'theme_ds_field_expert') {
+       $field_settings[$key]['formatter_settings']['ft']['lbw-at'] = filter_xss($values['lbw-at']);
+      }
+    }
+
+    if (!(empty($values['prefix']))) {
+      $field_settings[$key]['formatter_settings']['ft']['prefix'] = $values['prefix'];
+    }
+    if (!(empty($values['suffix']))) {
+      $field_settings[$key]['formatter_settings']['ft']['suffix'] = $values['suffix'];
     }
 
     // Custom field configuration.
@@ -892,6 +994,7 @@ function ds_extras_ds_field_settings_alter(&$field_settings, $form, &$form_state
           // Odd even class.
           if ($wrapper_key == 'fi') {
             $field_settings[$key]['formatter_settings']['ft'][$wrapper_key . '-odd-even'] = !(empty($values[$wrapper_key . '-odd-even'])) ? TRUE : FALSE;
+            $field_settings[$key]['formatter_settings']['ft'][$wrapper_key . '-first-last'] = !(empty($values[$wrapper_key . '-first-last'])) ? TRUE : FALSE;
           }
         }
       }
@@ -949,6 +1052,7 @@ function ds_extras_preprocess_field(&$variables) {
     $variables['ds-config'] = $config;
     $variables['theme_hook_suggestions'] = array();
     // Either it uses the function.
+    $variables['theme_hook_suggestions'][] = str_replace('theme_', '', $config['func']);
     $variables['theme_hook_suggestions'][] = $config['func'];
     // Or the template file(s).
     $suggestion = 'field__' . str_replace('theme_ds_field_', '', $config['func']);
@@ -961,6 +1065,7 @@ function ds_extras_preprocess_field(&$variables) {
   elseif (isset($field_instance_info['ds_extras_field_template']) && !empty($field_instance_info['ds_extras_field_template']) && $field_instance_info['ds_extras_field_template'] != 'theme_field') {
     $variables['theme_hook_suggestions'] = array();
     // Either it uses the function.
+    $variables['theme_hook_suggestions'][] = str_replace('theme_', '', $field_instance_info['ds_extras_field_template']);
     $variables['theme_hook_suggestions'][] = $field_instance_info['ds_extras_field_template'];
     // Or the template file(s).
     $suggestion = 'field__' . str_replace('theme_ds_field_', '', $field_instance_info['ds_extras_field_template']);
@@ -976,6 +1081,7 @@ function ds_extras_preprocess_field(&$variables) {
       $variables['theme_hook_suggestions'] = array();
       $variables['ds-config'] = $config;
       // Either it uses the function.
+      $variables['theme_hook_suggestions'][] = str_replace('theme_', '', $field_theme_function);
       $variables['theme_hook_suggestions'][] = $field_theme_function;
       // Or the template file(s).
       $suggestion = 'field__' . str_replace('theme_ds_field_', '', $field_theme_function);
@@ -983,6 +1089,18 @@ function ds_extras_preprocess_field(&$variables) {
       $variables['theme_hook_suggestions'][] = $suggestion . '__' . $field_name;
       $variables['theme_hook_suggestions'][] = $suggestion . '__' . $variables['element']['#bundle'];
       $variables['theme_hook_suggestions'][] = $suggestion . '__' . $field_name . '__' . $variables['element']['#bundle'];
+    }
+  }
+
+  // Sanitize the output of field templates
+  $fields = array(
+    'prefix',
+    'suffix',
+  );
+
+  foreach ($fields as $field) {
+    if (isset($variables['ds-config'][$field])) {
+      $variables['ds-config'][$field] = filter_xss_admin($variables['ds-config'][$field]);
     }
   }
 }

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_extras/includes/ds_extras.admin.inc
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_extras/includes/ds_extras.admin.inc
@@ -114,14 +114,12 @@ function ds_extras_settings($form) {
     '#default_value' => variable_get('ds_extras_field_permissions', FALSE),
   );
 
-  if (module_exists('block')) {
-    $form['additional_settings']['fs4']['ds_extras_region_to_block'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Region to block'),
-      '#description' => t('Create additional regions exposed as block. Note: this will not work on the default view mode.'),
-      '#default_value' => variable_get('ds_extras_region_to_block', FALSE),
-    );
-  }
+  $form['additional_settings']['fs4']['ds_extras_region_to_block'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Region to block'),
+    '#description' => t('Create additional regions exposed as block. Note: this will not work on the default view mode.'),
+    '#default_value' => variable_get('ds_extras_region_to_block', FALSE),
+  );
 
   if (module_exists('views')) {
     $form['additional_settings']['fs4']['ds_extras_vd'] = array(
@@ -144,7 +142,7 @@ function ds_extras_settings($form) {
   $form['additional_settings']['fs4']['ds_extras_switch_field'] = array(
     '#type' => 'checkbox',
     '#title' => t('View mode switcher'),
-    '#description' => t('Adds a field with links to switch view modes inline with Ajax. Only works for nodes at this time.'),
+    '#description' => t('Adds a field with links to switch view modes inline with Ajax. Only works for nodes at this time. It does not work in combination with the reset layout.'),
     '#default_value' => variable_get('ds_extras_switch_field', FALSE),
   );
 
@@ -327,9 +325,21 @@ function ds_extras_field_template_settings_form(array &$form, array &$form_state
     );
   }
 
+  // Add prefix
+  $form['ft']['prefix'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Prefix'),
+    '#size' => '100',
+    '#description' => t('You can enter any html in here.'),
+    '#default_value' => isset($field_settings['prefix']) ? $field_settings['prefix'] : '',
+    '#prefix' => '<div class="field-prefix">',
+    '#suffix' => '</div>',
+  );
+
   // Wrappers and label.
   $wrappers = array(
     'lb' => array('title' => t('Label')),
+    'lbw' => array('title' => t('Label wrapper')),
     'ow' => array('title' => t('Outer wrapper')),
     'fis' => array('title' => t('Field items')),
     'fi' => array('title' => t('Field item')),
@@ -352,6 +362,11 @@ function ds_extras_field_template_settings_form(array &$form, array &$form_state
       '#size' => '10',
       '#description' => t('E.g. div, span, h2 etc.'),
       '#default_value' => isset($field_settings[$wrapper_key . '-el']) ? $field_settings[$wrapper_key . '-el'] : '',
+      '#states' => array(
+        'visible' => array(
+          ':input[name$="[ft][' . $wrapper_key . ']"]' => array('checked' => TRUE),
+        ),
+      ),
     );
     $form['ft'][$wrapper_key . '-cl'] = array(
       '#type' => 'textfield',
@@ -359,6 +374,11 @@ function ds_extras_field_template_settings_form(array &$form, array &$form_state
       '#size' => '10',
       '#default_value' => isset($field_settings[$wrapper_key . '-cl']) ? $field_settings[$wrapper_key . '-cl'] : '',
       '#description' => t('E.g.') .' ' . implode(', ', $classes),
+      '#states' => array(
+        'visible' => array(
+          ':input[name$="[ft][' . $wrapper_key . ']"]' => array('checked' => TRUE),
+        ),
+      ),
     );
     $form['ft'][$wrapper_key . '-at'] = array(
       '#type' => 'textfield',
@@ -366,6 +386,11 @@ function ds_extras_field_template_settings_form(array &$form, array &$form_state
       '#size' => '20',
       '#default_value' => isset($field_settings[$wrapper_key . '-at']) ? $field_settings[$wrapper_key . '-at'] : '',
       '#description' => t('E.g. name="anchor"'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name$="[ft][' . $wrapper_key . ']"]' => array('checked' => TRUE),
+        ),
+      ),
     );
 
     // Hide colon.
@@ -384,14 +409,41 @@ function ds_extras_field_template_settings_form(array &$form, array &$form_state
         '#type' => 'checkbox',
         '#title' => t('Add odd/even classes'),
         '#default_value' => isset($field_settings['fi-odd-even']) ? $field_settings['fi-odd-even'] : FALSE,
+        '#states' => array(
+          'visible' => array(
+            ':input[name$="[ft][' . $wrapper_key . ']"]' => array('checked' => TRUE),
+          ),
+        ),
+      );
+      $form['ft']['fi-first-last'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Add first/last classes'),
+        '#default_value' => isset($field_settings['fi-first-last']) ? $field_settings['fi-first-last'] : FALSE,
+        '#states' => array(
+          'visible' => array(
+            ':input[name$="[ft][' . $wrapper_key . ']"]' => array('checked' => TRUE),
+          ),
+        ),
       );
     }
-    $form['ft'][$wrapper_key . '-def-at'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Add default attributes'),
-      '#default_value' => isset($field_settings[$wrapper_key . '-def-at']) ? $field_settings[$wrapper_key . '-def-at'] : FALSE,
-      '#suffix' => ($wrapper_key == 'ow') ? '' : '</div><div class="clearfix"></div>',
-    );
+    if ($wrapper_key != 'lbw') {
+      $form['ft'][$wrapper_key . '-def-at'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Add default attributes'),
+        '#default_value' => isset($field_settings[$wrapper_key . '-def-at']) ? $field_settings[$wrapper_key . '-def-at'] : FALSE,
+        '#suffix' => ($wrapper_key == 'ow') ? '' : '</div>',
+        '#states' => array(
+          'visible' => array(
+            ':input[name$="[ft][' . $wrapper_key . ']"]' => array('checked' => TRUE),
+          ),
+        ),
+      );
+    }
+    else {
+      $form['ft'][$wrapper_key . '-def-at'] = array(
+        '#markup' => '</div><div class="clearfix"></div>',
+      );
+    }
 
     // Default classes for outer wrapper.
     if ($wrapper_key == 'ow') {
@@ -399,10 +451,26 @@ function ds_extras_field_template_settings_form(array &$form, array &$form_state
         '#type' => 'checkbox',
         '#title' => t('Add default classes'),
         '#default_value' => isset($field_settings[$wrapper_key . '-def-cl']) ? $field_settings[$wrapper_key . '-def-cl'] : FALSE,
-        '#suffix' => '</div><div class="clearfix"></div>',
+        '#suffix' => '</div>',
+        '#states' => array(
+          'visible' => array(
+            ':input[name$="[ft][' . $wrapper_key . ']"]' => array('checked' => TRUE),
+          ),
+        ),
       );
     }
   }
+
+  // Add suffix
+  $form['ft']['suffix'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Suffix'),
+    '#size' => '100',
+    '#description' => t('You can enter any html in here.'),
+    '#default_value' => isset($field_settings['suffix']) ? $field_settings['suffix'] : '',
+    '#prefix' => '<div class="field-prefix">',
+    '#suffix' => '</div>',
+  );
 
   // Another label needs some other stuff.
   unset($form['ft']['lb']['#description']);
@@ -410,6 +478,9 @@ function ds_extras_field_template_settings_form(array &$form, array &$form_state
   $form['ft']['lb']['#size'] = '10';
   $form['ft']['lb']['#attributes'] = array('class' => array('label-change'));
   $form['ft']['lb']['#default_value'] = isset($field_settings['lb']) ? $field_settings['lb'] : '';
+
+  // Let other modules make modifications to the settings form as needed.
+  drupal_alter('ds_field_theme_functions_settings_form_alter', $form, $field_settings);
 }
 
 /**
@@ -502,12 +573,14 @@ function ds_extras_block_submit($form, &$form_state) {
     $region_blocks = variable_get('ds_extras_region_blocks', array());
     $remove = $form_state['values']['additional_settings']['region_to_block']['remove_block_region'];
     foreach ($remove as $key => $value) {
-      if ($key === $value) {
+      if ($value !== 0 && $key == $value) {
         $variable_set = TRUE;
-        db_delete('block')
-          ->condition('delta', $key)
-          ->condition('module', 'ds_extras')
-          ->execute();
+        if (module_exists('block')) {
+          db_delete('block')
+            ->condition('delta', $key)
+            ->condition('module', 'ds_extras')
+            ->execute();
+        }
         unset($region_blocks[$key]);
       }
     }

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_extras/includes/ds_extras.pages.inc
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_extras/includes/ds_extras.pages.inc
@@ -23,14 +23,25 @@ function ds_extras_node_page_view($node) {
   // Update the history table, stating that this user viewed this node.
   node_tag_new($node);
 
-  // For markup consistency with other pages, use node_view_multiple() rather than node_view().
-  $view_mode = (!empty($node->ds_switch)) ? $node->ds_switch : 'full';
+  if (empty($node->ds_switch)) {
+    // When not set fall back to full
+    $view_mode = 'full';
+  }
+  elseif ($node->ds_switch == 'default') {
+    // When default set fall back to full
+    $view_mode = 'full';
+  }
+  else {
+    $view_mode = $node->ds_switch;
+  }
 
   // It's also possible to use $_GET['v'] to switch view modes.
   if (isset($_GET['v']) && !empty($_GET['v'])) {
     $view_mode = $_GET['v'];
   }
   drupal_static('ds_extras_view_mode', $view_mode);
+
+  // For markup consistency with other pages, use node_view_multiple() rather than node_view().
   return node_view_multiple(array($node->nid => $node), $view_mode);
 }
 

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_extras/includes/ds_extras.registry.inc
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_extras/includes/ds_extras.registry.inc
@@ -83,7 +83,7 @@ function _ds_extras_theme_registry_alter(&$theme_registry) {
   }
 
   // Remove ds_preprocess_field in case field templates is not enabled.
-  if (!variable_get('ds_extras_field_template', FALSE)) {
+  if (!variable_get('ds_extras_field_template', FALSE) && isset($theme_registry['field']['preprocess functions'])) {
     $key = array_search('ds_extras_preprocess_field', $theme_registry['field']['preprocess functions']);
     if (!empty($key)) {
       unset($theme_registry['field']['preprocess functions'][$key]);

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_extras/js/ds_extras.admin.js
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_extras/js/ds_extras.admin.js
@@ -77,7 +77,10 @@ Drupal.behaviors.settingsToggle = {
         // Remove margin from update button.
         $('.ft-update', field).css({'margin-top': '-10px'});
         // Show wrappers.
-        $('.ow, .fis, .fi', field).show();
+        $('.lbw, .ow, .fis, .fi', field).show();
+        // Show prefix and suffix
+        $('.field-prefix', field).show();
+        $('.field-suffix', field).show();
       }
       else {
         // Hide second, third, fourth, fifth and sixth  label.
@@ -85,7 +88,10 @@ Drupal.behaviors.settingsToggle = {
         // Add margin on update button.
         $('.ft-update', field).css({'margin-top': '10px'});
         // Hide wrappers.
-        $('.ow, .fis, .fi', field).hide();
+        $('.lbw, .ow, .fis, .fi', field).hide();
+        // Hide prefix and suffix
+        $('.field-prefix', field).hide();
+        $('.field-suffix', field).hide();
       }
 
       // Colon.

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_format/ds_format.info
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_format/ds_format.info
@@ -5,9 +5,9 @@ package = "Display Suite"
 dependencies[] = ds
 configure = admin/structure/ds/list/extras
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_forms/ds_forms.info
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_forms/ds_forms.info
@@ -4,9 +4,9 @@ core = "7.x"
 package = "Display Suite"
 dependencies[] = ds
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_forms/ds_forms.module
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_forms/ds_forms.module
@@ -89,6 +89,25 @@ function ds_forms_form_alter(&$form, &$form_state, $form_id) {
 }
 
 /**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ */
+function ds_forms_field_widget_field_collection_embed_form_alter(&$element, &$form_state, $context){
+  if ($ds_form = ds_build_load($element, 'field_collection_embed')) {
+    if ($layout = ds_get_layout($ds_form->entity_type, $ds_form->bundle, 'form', FALSE)) {
+      // Add the theming function and add the layout as a class.
+      $element['#theme'] = array('ds_forms_custom_form');
+      $element['#form_id'] = 'field_collection_embed';
+      $class = strtr($layout['layout'], '_', '-');
+      if ((isset($element['#attributes']['class']) && is_array($element['#attributes']['class'])) || !(isset($element['#attributes']['class']))) {
+        $element['#attributes']['class'][] = $class;
+      }
+      elseif (isset($element['#attributes']['class']) && is_string($element['#attributes']['class'])) {
+        $element['#attributes']['class'] .= ' ' . $class . ' ';
+      }
+    }
+  }
+}
+/**
  * Helper function to determine if this form can be loaded.
  */
 function ds_build_load($form, $form_id) {
@@ -162,8 +181,17 @@ function ds_forms_preprocess_ds_forms_custom_form(&$vars) {
       $vars['layout_attributes'] = '';
     }
 
+    if (isset($layout['settings']['classes']['layout_class'])) {
+      foreach ($layout['settings']['classes']['layout_class'] as $layout_class) {
+        $vars['classes_array'][] = $layout_class;
+      }
+    }
+
     // Ensure there is a class
-    $vars['classes'] = 'ds-form';
+    $vars['classes_array'][] = 'ds-form';
+
+    // Merge the classes into a string
+    $vars['classes'] = implode(' ', $vars['classes_array']);
 
     // Add a layout wrapper
     $vars['layout_wrapper'] = isset($layout['settings']['layout_wrapper']) ? $layout['settings']['layout_wrapper'] : 'div';

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_forms/js/ds_forms.admin.js
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_forms/js/ds_forms.admin.js
@@ -58,7 +58,7 @@ Drupal.fieldUIFieldOverview.ds.prototype = {
   regionChange: function (region, recurse) {
 	  	  	  
      // Replace dashes with underscores.
-     region = region.replace('-', '_');
+     region = region.replace(/-/g, '_');
 
      // Set the region of the select list.
      this.$regionSelect.val(region);

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_search/ds_search.info
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_search/ds_search.info
@@ -5,9 +5,9 @@ package = "Display Suite"
 dependencies[] = ds
 configure = admin/structure/ds/list/search
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_search/ds_search.module
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_search/ds_search.module
@@ -54,6 +54,10 @@ function ds_search_theme() {
  * Search page theming.
  */
 function theme_ds_search_page($build) {
+  // fix for Drupal 7.33+
+  if(isset($build['theme_hook_original'])) {
+    unset($build['theme_hook_original']);
+  }
 
   // Check on empty search results.
   if (empty($build['search_results'])) {
@@ -496,7 +500,7 @@ function node_ds_search_execute($keys = NULL, $conditions = NULL) {
       // Render the node.
       $rendered = drupal_render($build);
       // Attach extra information to the rendered output.
-      $rendered .= ' ' . $node->search_extra;
+      $rendered .= ' ' . implode('', $node->search_extra);
       // Generate the snippet based on rendered content.
       $node->snippet = search_excerpt($keys, $rendered);
     }
@@ -704,6 +708,10 @@ function ds_search_process_results($results) {
 
       $load = entity_load($result['fields']['entity_type'], array($result['fields']['entity_id']));
       $entity = reset($load);
+      if (!$entity) {
+        watchdog('ds_search', "Empty entity loaded from results, possibly corrupt solr index? (@entity_type, @id)", array('@entity_type' => $result['fields']['entity_type'], '@id' => $result['fields']['entity_id']), WATCHDOG_DEBUG);
+        continue;
+      }
 
       // Add the snippet, url and extra info on the object.
       $entity->search_snippet = $result['snippet'];

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_search/includes/ds_search.admin.inc
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_search/includes/ds_search.admin.inc
@@ -126,6 +126,10 @@ function ds_search_settings($form, $form_state) {
 
   $node_types = node_type_get_names();
   $ds_search_group_by_type_settings = variable_get('ds_search_group_by_type_settings');
+  $wrapper_options = array(
+    'fieldset' => t('Fieldset'),
+    'markup' => t('Div with H3 headline'),
+  );
   foreach ($node_types as $name => $label) {
 
     $form['ds_search_group_by_type_settings'][$name]['name'] = array(
@@ -150,10 +154,6 @@ function ds_search_settings($form, $form_state) {
       '#parents' => array('ds_search_group_by_type_settings', $name, 'label'),
     );
 
-    $wrapper_options = array(
-      'fieldset' => t('Fieldset'),
-      'markup' => t('Div with H3 headline'),
-    );
     $form['ds_search_group_by_type_settings'][$name]['wrapper'] = array(
       '#type' => 'select',
       '#options' => $wrapper_options,

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_ui/ds_ui.info
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_ui/ds_ui.info
@@ -4,9 +4,9 @@ core = "7.x"
 package = "Display Suite"
 dependencies[] = ds
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_ui/ds_ui.module
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_ui/ds_ui.module
@@ -145,19 +145,16 @@ function ds_ui_menu() {
     'access arguments' => array('admin_fields'),
     'type' => MENU_VISIBLE_IN_BREADCRUMB,
   );
-  // Block can be disabled.
-  if (module_exists('block')) {
-    $items['admin/structure/ds/fields/manage_block'] = array(
-      'title' => 'Add a block field',
-      'description' => 'Manage a block field',
-      'page callback' => 'drupal_get_form',
-      'page arguments' => array('ds_edit_block_field_form'),
-      'file' => 'includes/ds.fields.inc',
-      'access arguments' => array('admin_fields'),
-      'type' => MENU_LOCAL_ACTION,
-      'weight' => 2,
-    );
-  }
+  $items['admin/structure/ds/fields/manage_block'] = array(
+    'title' => 'Add a block field',
+    'description' => 'Manage a block field',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ds_edit_block_field_form'),
+    'file' => 'includes/ds.fields.inc',
+    'access arguments' => array('admin_fields'),
+    'type' => MENU_LOCAL_ACTION,
+    'weight' => 2,
+  );
 
   // CTools Modal add field.
   $items['admin/structure/ds/%ctools_js/add_field/%'] = array(

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_ui/includes/ds.classes.inc
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_ui/includes/ds.classes.inc
@@ -18,12 +18,29 @@ function ds_classes_form($form, $form_state) {
     '#description' => t('Configure CSS classes which you can add to regions on the "manage display" screens. Add multiple CSS classes line by line.<br />If you want to have a friendly name, separate class and friendly name by |, but this is not required. eg:<br /><em>class_name_1<br />class_name_2|Friendly name<br />class_name_3</em>')
   );
 
-  $form['ds_classes_fields'] = array(
-    '#type' => 'textarea',
-    '#title' => t('CSS classes for fields'),
-    '#default_value' => variable_get('ds_classes_fields', ''),
-    '#description' => t('Configure CSS classes which you can add to fields on the "manage display" screens. Add multiple CSS classes line by line.<br />If you want to have a friendly name, separate class and friendly name by |, but this is not required. eg:<br /><em>class_name_1<br />class_name_2|Friendly name<br />class_name_3</em>')
-  );
+  if (module_exists('token')) {
+    $tokens_mapping = token_get_entity_mapping();
+    $tokens_list = array();
+    foreach($tokens_mapping as $token_map => $entity_map) {
+      $tokens_list[] = $token_map;
+    }
+    $form['token'] = array(
+      '#type' => 'container',
+      '#theme' => 'token_tree',
+      '#token_types' => $tokens_list,
+      '#dialog' => TRUE,
+    );
+  }
+
+  // Only show field classes if DS extras module is enabled
+  if (module_exists('ds_extras')) {
+    $form['ds_classes_fields'] = array(
+      '#type' => 'textarea',
+      '#title' => t('CSS classes for fields'),
+      '#default_value' => variable_get('ds_classes_fields', ''),
+      '#description' => t('Configure CSS classes which you can add to fields on the "manage display" screens. Add multiple CSS classes line by line.<br />If you want to have a friendly name, separate class and friendly name by |, but this is not required. eg:<br /><em>class_name_1<br />class_name_2|Friendly name<br />class_name_3</em>')
+    );
+  }
 
   return system_settings_form($form);
 }

--- a/docroot/sites/all/modules/contrib/ds/modules/ds_ui/includes/ds.fields.inc
+++ b/docroot/sites/all/modules/contrib/ds/modules/ds_ui/includes/ds.fields.inc
@@ -114,7 +114,7 @@ function ds_custom_manage($field_key = '') {
 }
 
 /**
- * Shared form for all all fields.
+ * Shared form for all fields.
  */
 function ds_shared_form(&$form, $field) {
   ctools_include('export');
@@ -176,6 +176,7 @@ function ds_shared_form(&$form, $field) {
     '#description' => t('Limit this field on field UI per bundles and/or view modes. The values are in the form of $bundle|$view_mode, where $view_mode may be either a view mode set to use custom settings, or \'default\'. You may use * to select all, e.g article|*, *|full or *|*. Enter one value per line.'),
     '#type' => 'textarea',
     '#default_value' => $field->ui_limit,
+    '#element_validate' => array('ds_ui_limit_validate'),
   );
 
   $form['submit'] = array(
@@ -189,6 +190,73 @@ function ds_shared_form(&$form, $field) {
   $form['#submit'][] = 'ds_shared_form_submit';
 
   return $field;
+}
+
+/**
+ * Element validation function for ui limit field.
+ */
+function ds_ui_limit_validate($element, &$form_state, $form) {
+  // Get all enabled entity types.
+  $entity_types = array_filter($form_state['values']['entities']);
+
+  if (!empty($element['#value'])) {
+    $ui_limit = $element['#value'];
+
+    $lines = explode("\n", str_replace("\r", "\n", $ui_limit));
+    // Ensure that all strings are trimmed and filter out empty lines.
+    $lines = array_filter(array_map('trim', $lines));
+
+    $error = FALSE;
+    foreach ($lines as $line) {
+      // Each line should hold a pipe character to seperate bundle and view_mode.
+      if (strpos($line, '|') === FALSE) {
+        $error = TRUE;
+        continue;
+      }
+
+      list($bundle, $view_mode) = explode('|', $line);
+
+      if (empty($bundle) || empty($view_mode) || !_ds_check_existing_ui_limit($entity_types, $bundle, $view_mode)) {
+        $error = TRUE;
+      }
+    }
+    if ($error) {
+      form_error($element, t('The values are in the form of $bundle|$view_mode, where $view_mode may be either a view mode set to use custom settings, or \'default\'.'));
+    }
+
+    // Set trimmed and validated entry back as value.
+    form_set_value($element, implode("\n", $lines), $form_state);
+  }
+}
+
+/**
+ * Helper function to check if bundle + view_mode combination exists.
+ */
+function _ds_check_existing_ui_limit($entity_types, $bundle, $view_mode) {
+  $exists = FALSE;
+  foreach ($entity_types as $entity_type) {
+    $info = entity_get_info($entity_type);
+
+    // Combine allowed bundles and entity specific ones.
+    $bundle_allowed = array('*');
+    $bundles = array_merge($bundle_allowed, array_keys($info['bundles']));
+
+    // Combine allowed view_modes and entity specific ones.
+    $view_mode_allowed = array('*', 'default');
+    $view_modes = array_merge($view_mode_allowed, array_keys($info['view modes']));
+
+    if (in_array($bundle, $bundles) &&
+      in_array($view_mode, $view_modes)) {
+
+      $exists = TRUE;
+      break;
+    }
+  }
+  if (!$exists) {
+    drupal_set_message(t('Incorrect field limit combination: @bundle|@view_mode', array('@bundle' => $bundle, '@view_mode' => $view_mode)), 'error');
+  }
+
+  return $exists;
 }
 
 /**
@@ -209,7 +277,7 @@ function ds_shared_form_validate($form, &$form_state) {
   $field->properties = array();
   $field->field = $form_state['values']['field'];
   $field->label = $form_state['values']['name'];
-  $field->ui_limit = str_replace("\r", '', $form_state['values']['ui_limit']);
+  $field->ui_limit = $form_state['values']['ui_limit'];
 
   $entities = $form_state['values']['entities'];
   foreach ($entities as $key => $value) {

--- a/docroot/sites/all/modules/contrib/ds/tests/ds.entities.test
+++ b/docroot/sites/all/modules/contrib/ds/tests/ds.entities.test
@@ -114,7 +114,7 @@ class dsNodeTests extends dsBaseTest {
     $this->assertRaw('group-footer', 'Template found (region footer)');
     $this->assertRaw('group-left', 'Template found (region left)');
     $this->assertRaw('group-right', 'Template found (region right)');
-    $this->assertPattern('/<div[^>]*>Submitted[^<]*<a[^>]+href="\/user\/' . $node_author->uid . '"[^>]*>' . check_plain($node_author->name) . '<\/a>.<\/div>/', t('Submitted by line found'));
+    $this->assertPattern('/<div[^>]*>Submitted[^<]*<a[^>]+href="' . preg_quote(base_path(), '/') . 'user\/' . $node_author->uid . '"[^>]*>' . check_plain($node_author->name) . '<\/a>.<\/div>/', t('Submitted by line found'));
 
     // Configure teaser layout.
     $teaser = array(
@@ -521,6 +521,7 @@ class dsNodeTests extends dsBaseTest {
       'fields[body][settings_edit_form][settings][ft][fi-el]' => 'span',
       'fields[body][settings_edit_form][settings][ft][fi-cl]' => 'fi-class',
       'fields[body][settings_edit_form][settings][ft][fi-odd-even]' => '1',
+      'fields[body][settings_edit_form][settings][ft][fi-first-last]' => '1',
     );
     $this->dsEditFormatterSettings($edit);
     $this->drupalGet('node/' . $node->nid);
@@ -537,6 +538,7 @@ class dsNodeTests extends dsBaseTest {
       'fields[body][settings_edit_form][settings][ft][fi-el]' => 'div',
       'fields[body][settings_edit_form][settings][ft][fi-cl]' => 'fi-class',
       'fields[body][settings_edit_form][settings][ft][fi-odd-even]' => '1',
+      'fields[body][settings_edit_form][settings][ft][fi-first-last]' => '1',
     );
     $this->dsEditFormatterSettings($edit);
     $this->drupalGet('node/' . $node->nid);
@@ -555,6 +557,7 @@ class dsNodeTests extends dsBaseTest {
       'fields[body][settings_edit_form][settings][ft][fi-el]' => 'span',
       'fields[body][settings_edit_form][settings][ft][fi-cl]' => 'fi-class',
       'fields[body][settings_edit_form][settings][ft][fi-odd-even]' => '1',
+      'fields[body][settings_edit_form][settings][ft][fi-first-last]' => '1',
     );
     $this->dsEditFormatterSettings($edit);
     $this->drupalGet('node/' . $node->nid);

--- a/docroot/sites/all/modules/contrib/ds/tests/ds_exportables_test/ds_exportables_test.info
+++ b/docroot/sites/all/modules/contrib/ds/tests/ds_exportables_test/ds_exportables_test.info
@@ -4,9 +4,9 @@ package = "Display Suite"
 core = 7.x
 hidden = TRUE
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/tests/ds_test.info
+++ b/docroot/sites/all/modules/contrib/ds/tests/ds_test.info
@@ -5,9 +5,9 @@ package = "Display Suite"
 dependencies[] = ds_extras
 hidden = TRUE
 
-; Information added by drupal.org packaging script on 2013-09-04
-version = "7.x-2.6"
+; Information added by Drupal.org packaging script on 2016-01-16
+version = "7.x-2.12"
 core = "7.x"
 project = "ds"
-datestamp = "1378305390"
+datestamp = "1452953681"
 

--- a/docroot/sites/all/modules/contrib/ds/views/views_plugin_ds_entity_view.inc
+++ b/docroot/sites/all/modules/contrib/ds/views/views_plugin_ds_entity_view.inc
@@ -10,6 +10,8 @@
  */
 class views_plugin_ds_entity_view extends views_plugin_row {
 
+  protected $group_count;
+
   function init(&$view, &$display, $options = NULL) {
     parent::init($view, $display, $options);
     $this->base_table = $view->base_table;
@@ -18,6 +20,8 @@ class views_plugin_ds_entity_view extends views_plugin_row {
       $this->base_table = 'node';
     }
     $this->base_field = $this->ds_views_3_support();
+
+    $this->group_count = 0;
   }
 
   // Return base_field based on base_table. It might not be
@@ -59,6 +63,7 @@ class views_plugin_ds_entity_view extends views_plugin_row {
     $options['grouping_fieldset'] = array(
       'contains' => array(
         'grouping' => array('default' => FALSE, 'bool' => TRUE),
+        'group_odd_even' => array('default' => FALSE, 'bool' => TRUE),
         'group_field' => array('default' => ''),
         'group_field_function' => array('default' => ''),
       ),
@@ -241,6 +246,12 @@ class views_plugin_ds_entity_view extends views_plugin_row {
       $form['grouping_fieldset']['grouping']['#description'] = t('Grouping is disabled because you do not have any sort fields.');
     }
 
+    $form['grouping_fieldset']['group_odd_even'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Add odd/even group classes to the individual group elements'),
+      '#default_value' => FALSE,
+    );
+
     // Advanced function.
     $delta_fields = array();
     $field_api_fields = field_info_instances($this->entity_type);
@@ -362,7 +373,6 @@ class views_plugin_ds_entity_view extends views_plugin_row {
    * Render each $row.
    */
   function render($row) {
-
     // Set a variable to indicate if comments need to be loaded or not.
     $load_comments = isset($this->options['load_comments']) ? $this->options['load_comments'] : FALSE;
 
@@ -440,6 +450,7 @@ class views_plugin_ds_entity_view extends views_plugin_row {
       if (!isset($grouping[$view_name][$group_value])) {
         $group_value_content = '<h2 class="grouping-title">' . $group_value . '</h2>';
         $grouping[$view_name][$group_value] = $group_value;
+        $this->group_count++;
       }
     }
 
@@ -448,7 +459,17 @@ class views_plugin_ds_entity_view extends views_plugin_row {
       if (!empty($group_value_content)) {
         $content = $group_value_content . $content;
       }
-      $content = '<div class="grouping-content">' . $content . '</div>';
+      $classes = array('grouping-content');
+      if ($this->options['grouping_fieldset']['group_odd_even']) {
+        if ($this->group_count % 2 == 0) {
+          $classes[] = 'even';
+        }
+        else {
+          $classes[] = 'odd';
+        }
+      }
+
+      $content = '<div class="' . implode(' ', $classes) . '">' . $content . '</div>';
     }
 
     // Return the content.

--- a/docroot/sites/all/modules/contrib/ds/views/views_plugin_ds_fields_view.inc
+++ b/docroot/sites/all/modules/contrib/ds/views/views_plugin_ds_fields_view.inc
@@ -41,6 +41,7 @@ class views_plugin_ds_fields_view extends views_plugin_row {
       'commerce_product' => 'product_id',
       'commerce_line_item' => 'line_item_id',
       'civicrm_event' => 'id',
+      'field_collection_item' => 'item_id',
     );
     return isset($base_table_fields[$this->base_table]) ? $base_table_fields[$this->base_table] : 'nid';
   }


### PR DESCRIPTION
Upgraded the Display Suite contributed module to version **7.x-2.12**

This is a security release.

Database schema updates
-----------------------
The following updates are required as part of this upgrade:

* 7202 -   Increase the label storage length to 128.
* 7203 -   Increase the view_mode storage length to 64

Be sure to run `drush updb --y` as part of the deployment process.

Testing
-------
Display suite is used across the site to provide layouts and rendering of pages. I have tested this upgrade on my local install and have been through the code to review the changes. No problems were found, and the majority of the code changes were minor and unlikely to cause problems.

When testing this module upgrade, it is important to view pages of various different content types to ensure that the layout appears unaffected.

[ Fixes [#1082](https://support.siriusopensource.com/index.pl?Action=AgentTicketZoom;TicketID=580) ]
