### PR TITLE
Develop: Create custom site maintenance page

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.info
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.info
@@ -1,0 +1,4 @@
+name = FSA maintenance page
+description = "Provides additional functionality for the site maintenance page."
+core = 7.x
+package = System

--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -1,0 +1,216 @@
+<?php
+/**
+ * @file
+ * Module file for the FSA maintenance page module
+ */
+
+
+/**
+ * CSS file for the maintenance page
+ */
+define('FSA_MAINTENANCE_PAGE_CSS_FILE', 'maintenance-page.css');
+
+/**
+ * Default maintenance page title
+ */
+define('FSA_MAINTENANCE_PAGE_DEFAULT_PAGE_TITLE', t('Site under maintenance'));
+
+/**
+ * Implements hook_menu().
+ */
+function fsa_maintenance_page_menu() {
+  $items = array();
+
+  // Creates a link for external systems to use as a maintenance page.
+  $items['site-maintenance'] = array(
+    'title' => 'Site under maintenance',
+    'page callback' => '_fsa_maintenance_page_render_page',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
+  // Creates a link for CloudFlare to use as an error page
+  $items['site-maintenance/cf'] = array(
+    'title' => 'Site under maintenance',
+    'page callback' => '_fsa_maintenance_page_render_page',
+    'page arguments' => array(TRUE),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+
+/**
+ * Implements template_preprocess_maintenance_page().
+ *
+ * @param array $variables
+ *   Template variables - passed by reference.
+ */
+function fsa_maintenance_page_preprocess_maintenance_page(&$variables) {
+
+  // Render array for the maintenance page CSS file.
+  $css_file = array(
+    '#type' => 'html_tag',
+    '#tag' => 'link',
+    '#attributes' => array(
+      'rel' => 'stylesheet',
+      'media' => 'screen',
+      'href' => '/' . drupal_get_path('theme', 'site_frontend') . '/css/' . FSA_MAINTENANCE_PAGE_CSS_FILE,
+    ),
+  );
+
+  // Set the page title
+  $variables['title'] = variable_get('maintenance_mode_title', FSA_MAINTENANCE_PAGE_DEFAULT_PAGE_TITLE);
+  drupal_set_title($variables['title']);
+
+  // Make sure $head_title reflects the page title
+  if (drupal_get_title()) {
+    $head_title_array = array(
+      'title' => strip_tags(drupal_get_title()),
+      'name' => check_plain(variable_get('site_slogan', t('Food Standards Agency'))),
+    );
+  }
+  else {
+    $head_title_array = array(
+      'title' => strip_tags($variables['title']),
+      'name' => t('Food Standards Agency'),
+    );
+  }
+
+  // Flatten the $head_title array
+  // @todo Move this to a process function
+  $variables['head_title'] = implode(' | ', array_values($head_title_array));
+
+  // Set the 'css_file' variable
+  $variables['css_file'] = $css_file;
+
+  // Render the social media icons block in the header
+  $variables['page']['header_social_media'] = _fsa_maintenance_page_social_media_icons();
+
+  // Make the content variable into an array so we can add to it.
+  $variables['content'] = array(
+    'message' => array(
+      '#type' => 'html_tag',
+      '#value' => $variables['content'],
+      '#tag' => 'p',
+      '#attributes' => array(
+        'class' => array(
+          'views-field-field-summary'
+        ),
+      ),
+      '#weight' => 0,
+    ),
+    // Add the social media icons to the main body content, but hide labels
+    'social_media_icons' => array(
+      'icons' => _fsa_maintenance_page_social_media_icons(array('show_labels' => FALSE)),
+      '#weight' => 100,
+    ),
+  );
+
+  // Add the additional content - if populated
+  $extra_content = variable_get('maintenance_mode_extra');
+  $extra_content = !empty($extra_content['value']) ? $extra_content['value'] : '';
+  if (!empty($extra_content)) {
+    $variables['content']['extra'] = array(
+      '#markup' => $extra_content,
+      '#weight' => 10,
+    );
+  }
+
+  // Add the CloudFlare token if required
+  if (!empty($variables['cf'])) {
+    $variables['content']['cf_token'] = array(
+      '#markup' => '::ALWAYS_ONLINE_NO_COPY_BOX::',
+      '#weight' => 5,
+    );
+  }
+}
+
+
+/**
+ * Renders a 'static' version of the site maintenance page.
+ *
+ * @param boolean $cf
+ *   If set to TRUE, indicates that this is for use by CloudFlare, in which case
+ *   it needs to output the special token.
+ *
+ * This can be used on other systems where a maintenance page may be required.
+ */
+function _fsa_maintenance_page_render_page($cf = FALSE) {
+  $content = variable_get('maintenance_mode_message');
+  $theme = 'site_frontend';
+  $variables = array(
+    'content' => $content,
+    'external' => FALSE,
+    'cf' => $cf,
+  );
+  $rendered_page = theme('maintenance_page', $variables);
+  print $rendered_page;
+  drupal_exit();
+}
+
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * We use this to add fields to the maintenance mode admin form.
+ *
+ * @param array $form
+ *   The form array - passed by reference
+ *
+ * @param array $form_state
+ *   The form state array - passed by reference
+ */
+function fsa_maintenance_page_form_system_site_maintenance_mode_alter(&$form, &$form_state) {
+
+  // We add a field for additional content on the site maintenance page.
+  $extra_content = variable_get('maintenance_mode_extra');
+  $extra_content = !empty($extra_content['value']) ? $extra_content['value'] : '';
+
+  // Set some form element weights so that fields appear in the right order
+  $form['maintenance_mode']['#weight'] = 0;
+  $form['maintenance_mode_message']['#weight'] = 20;
+
+  // Add a field for maintenance page title
+  $form['maintenance_mode_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Maintenance mode page title'),
+    '#description' => t('This is the title that will be displayed at the top of the site maintenance page.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('maintenance_mode_title', FSA_MAINTENANCE_PAGE_DEFAULT_PAGE_TITLE),
+    '#weight' => 10,
+  );
+
+  // Add a WYSIWYG field for additional content such as contact details etc
+  $form['maintenance_mode_extra'] = array(
+    '#type' => 'text_format',
+    '#title' => t('Additional information'),
+    '#description' => t('Use this field to include additional information such as contact details.'),
+    '#format' => 'full_html',
+    '#default_value' => $extra_content,
+    '#weight' => 30,
+  );
+}
+
+
+// Helper function - returns social media icons block render array
+function _fsa_maintenance_page_social_media_icons($options = array()) {
+  $module = 'fsa_social_media';
+  $delta = 'social_media_icons';
+  // Set the maintenance_mode option
+  $options['maintenance_mode'] = TRUE;
+  // Load the block
+  $block = block_load($module, $delta);
+  // If there is no block or it's not an object, return an empty string now.
+  if (empty($block) || !is_object($block)) {
+    return '';
+  }
+  // If we have any options, add them to the block object.
+  if (!empty($options)) {
+    $block->display_options = $options;
+  }
+  // Generate the render array for the block.
+  return _block_get_renderable_array(_block_render_blocks(array($block)));
+}

--- a/docroot/sites/all/modules/custom/fsa_social_media/fsa_social_media.module
+++ b/docroot/sites/all/modules/custom/fsa_social_media/fsa_social_media.module
@@ -132,6 +132,14 @@ function fsa_social_media_preprocess_block(&$variables) {
   if ($delta != 'social_media_icons') {
     return;
   }
+  // By default, show the labels
+  $variables['show_labels'] = TRUE;
+  // Get block display options - if set
+  $display_options = !empty($block->display_options) ? $block->display_options : array();
+  // Add any display options to the $variables array
+  foreach ($display_options as $option => $value) {
+    $variables[$option] = $value;
+  }
   // Preprocess the items
   $variables['items'] = !empty($block->items) ? $block->items : array();
   $last_item = count($variables['items']) > 0 ? count($variables['items']) - 1 : 0;

--- a/docroot/sites/all/modules/custom/fsa_social_media/fsa_social_media.module
+++ b/docroot/sites/all/modules/custom/fsa_social_media/fsa_social_media.module
@@ -180,6 +180,11 @@ function fsa_social_media_preprocess_block(&$variables) {
 
   }
   $variables['classes_array'][] = 'social-media-icons';
+
+  // Are we in maintenance mode?
+  $maintenance_mode = empty($variables['maintenance_mode']) ? variable_get('maintenance_mode', 0) : $variables['maintenance_mode'];
+  // Make sure it's a boolean
+  $variables['maintenance_mode'] = !empty($maintenance_mode);
 }
 
 

--- a/docroot/sites/all/modules/custom/fsa_social_media/theme/block--fsa_social_media--social-media-icons.tpl.php
+++ b/docroot/sites/all/modules/custom/fsa_social_media/theme/block--fsa_social_media--social-media-icons.tpl.php
@@ -66,10 +66,16 @@
     <?php print render($title_suffix); ?>
     <div<?php print $content_attributes; ?>>
       <div class="custom-block-content-inner">
-        <div class="label-wrapper">
-          <span class="left-label"><?php print t('Stay updated'); ?>:</span>
-          <span class="right-label"><?php print t('Keep connected'); ?>:</span>
-        </div>
+        <?php if ($show_labels): ?>
+          <div class="label-wrapper">
+            <?php if (!$maintenance_mode): ?>
+              <span class="left-label"><?php print t('Stay updated'); ?>:</span>
+              <span class="right-label"><?php print t('Keep connected'); ?>:</span>
+            <?php else: ?>
+              <?php print t('Keep connected'); ?>
+            <?php endif; ?>
+          </div>
+        <?php endif; ?>
         <div class="icons-wrapper">
         <ul>
           <li><a href="/subscribe" target="_blank" title="email"><img alt="email" src="/sites/all/themes/site_frontend/images/icons/34x34/email.png" /></a></li>

--- a/docroot/sites/all/modules/custom/fsa_social_media/theme/block--fsa_social_media--social-media-icons.tpl.php
+++ b/docroot/sites/all/modules/custom/fsa_social_media/theme/block--fsa_social_media--social-media-icons.tpl.php
@@ -78,9 +78,11 @@
         <?php endif; ?>
         <div class="icons-wrapper">
         <ul>
-          <li><a href="/subscribe" target="_blank" title="email"><img alt="email" src="/sites/all/themes/site_frontend/images/icons/34x34/email.png" /></a></li>
-          <li><a href="/subscribe" target="_blank" title="phone"><img alt="phone" src="/sites/all/themes/site_frontend/images/icons/34x34/phone.png" /></a></li>
-          <li class="extra-margin"><a href="/about-us/data-and-policies/aboutsite/rss" target="_blank" title="RSS"><img alt="RSS" src="/sites/all/themes/site_frontend/images/icons/34x34/rss.png" /></a></li>
+          <?php if (!$maintenance_mode): ?>
+            <li><a href="/subscribe" target="_blank" title="email"><img alt="email" src="/sites/all/themes/site_frontend/images/icons/34x34/email.png" /></a></li>
+            <li><a href="/subscribe" target="_blank" title="phone"><img alt="phone" src="/sites/all/themes/site_frontend/images/icons/34x34/phone.png" /></a></li>
+            <li class="extra-margin"><a href="/about-us/data-and-policies/aboutsite/rss" target="_blank" title="RSS"><img alt="RSS" src="/sites/all/themes/site_frontend/images/icons/34x34/rss.png" /></a></li>
+          <?php endif; ?>
           <?php foreach($items as $item): ?>
             <li class="<?= $item['classes']; ?>"><a href="<?php print render($item['url']); ?>" target="_blank" title="<?php print render($item['title']); ?>"><?php print render($item['icon']); ?></a></li>
           <?php endforeach; ?>

--- a/docroot/sites/all/themes/site_frontend/css/maintenance-page.css
+++ b/docroot/sites/all/themes/site_frontend/css/maintenance-page.css
@@ -1,0 +1,9083 @@
+@charset "UTF-8";
+*, *:after, *:before {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  *behavior: url('../behaviors/box-sizing/boxsizing.php');
+}
+
+*, *:after, *:before {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  *behavior: url('../behaviors/box-sizing/boxsizing.php');
+}
+
+/* No files to import found in abstractions/**\/* */
+/* default font size for body is set to 62.5% in _typography.scss */
+/**
+ * font scale adjustments 
+ * requires accessibility_links local module to be enabled
+ */
+body.font-plus-1 {
+  font-size: 68%;
+}
+
+body.font-plus-2 {
+  font-size: 73%;
+}
+
+/* hide contextual links - gets in the way when logged in */
+html.js l-region--accessibility .contextual-links-wrapper {
+  display: none !important;
+}
+
+/* for mobile */
+@media (min-width: 0px) and (max-width: 480px) {
+  /* keep fonts the same as default */
+  body.font-plus-1,
+  body.font-plus-2 {
+    font-size: 62.5%;
+  }
+}
+/* hide contextual links - gets in the way when logged in */
+.l-region--accessibility .contextual-links-wrapper,
+.l-region--accessibility .contextual-links-trigger,
+.l-region--accessibility .contextual-links {
+  display: none !important;
+}
+
+html.js .l-region--accessibility .contextual-links-wrapper,
+html.js .l-region--accessibility .contextual-links-region:hover .contextual-links-trigger,
+html.js .l-region--accessibility .contextual-links-active .contextual-links-trigger,
+html.js .l-region--accessibility .contextual-links-active .contextual-links {
+  display: none !important;
+}
+
+/**
+ * Blocks added with blockreference module on landing pages
+ * Note: blockreference blocks ignore block class settings
+ * only pulls in block title and block content
+ */
+.node-type-landing-page .field--type-blockreference .block {
+  overflow: hidden;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+  background: #f5f8f1;
+}
+.node-type-landing-page .field--type-blockreference .block h2.block__title {
+  color: #4B7A0A;
+  margin: 0 0 0.5em 0;
+  font-size: 1.6em;
+  font-weight: normal;
+  padding: .46875em 11px .140625em 11px;
+}
+.node-type-landing-page .field--type-blockreference .block .block__content {
+  padding: .5em 11px .3em 11px;
+  overflow: hidden;
+}
+
+/* mobile view */
+@media (min-width: 0px) and (max-width: 480px) {
+  .node-type-landing-page .field--type-blockreference .block {
+    /* increase the block title size */
+  }
+  .node-type-landing-page .field--type-blockreference .block h2.block__title {
+    font-size: 1.8em;
+  }
+}
+/* print styling overrides */
+@media print {
+  .node-type-landing-page .field--type-blockreference {
+    display: none;
+  }
+  .node-type-landing-page .field--type-blockreference .block {
+    border: 1px solid #000;
+  }
+  .node-type-landing-page .field--type-blockreference .block h2.block__title {
+    color: #000;
+  }
+}
+/* bocks in sidebar second */
+.l-region--sidebar-second .block {
+  margin-bottom: 11px;
+}
+
+/* custom classes in block.tpl.php */
+.block__content,
+.custom-block-inner,
+.custom-block-title-wrapper,
+.custom-block-content-inner,
+.custom-views-footer-inner {
+  overflow: hidden;
+}
+
+.grey-block {
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+}
+.grey-block h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 11px;
+  margin: 0;
+  background: #999;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(6%, #999999), color-stop(100%, #3e3e3e));
+  background: -webkit-linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  background: -o-linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  background: -ms-linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  background: linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#999999',endColorstr='#3e3e3e',GradientType=0);
+  border-bottom: none;
+}
+.grey-block .block__content {
+  padding: 1em 11px .3em 11px;
+  background-color: #fff;
+}
+
+.purple-block {
+  overflow: hidden;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+}
+.purple-block .custom-block-inner {
+  background: #9e218a;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(1%, #9e218a), color-stop(100%, #5d0050));
+  background: -webkit-linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  background: -o-linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  background: -ms-linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  background: linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#9e218a',endColorstr='#5d0050',GradientType=0);
+}
+.purple-block h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .5em 11px .15em 11px;
+  margin: 0;
+}
+.purple-block .block__content {
+  color: #fff;
+  padding: .5em 11px .3em 11px;
+}
+
+.blue-block {
+  overflow: hidden;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+  background: #f9fcfd;
+}
+.blue-block .custom-block-inner {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #f9fcfd 1%, #d2e8f1 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(1%, #f9fcfd), color-stop(100%, #d2e8f1));
+  background: -webkit-linear-gradient(top, #f9fcfd 1%, #d2e8f1 100%);
+  background: -o-linear-gradient(top, #f9fcfd 1%, #d2e8f1 100%);
+  background: -ms-linear-gradient(top, #f9fcfd 1%, #d2e8f1 100%);
+  background: linear-gradient(top, #f9fcfd 1%, #d2e8f1 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f9fcfd',endColorstr='#d2e8f1',GradientType=0);
+}
+.blue-block h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 11px;
+  margin: 0;
+  background: #0781af;
+  background: -moz-linear-gradient(top, #0781af 50%, #027099 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(50%, #0781af), color-stop(100%, #027099));
+  background: -webkit-linear-gradient(top, #0781af 50%, #027099 100%);
+  background: -o-linear-gradient(top, #0781af 50%, #027099 100%);
+  background: -ms-linear-gradient(top, #0781af 50%, #027099 100%);
+  background: linear-gradient(to bottom, #0781af 50%, #027099 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0781af',endColorstr='#027099',GradientType=0);
+  border-bottom: 1px solid #64b1cf;
+}
+.blue-block .block__content {
+  padding: 1em 11px .3em 11px;
+}
+
+.blue-block-white-background {
+  overflow: hidden;
+  background: #fff;
+}
+.blue-block-white-background .custom-block-title-wrapper {
+  -webkit-border-radius: 9px 9px 0 0;
+  -moz-border-radius: 9px 9px 0 0;
+  -o-border-radius: 9px 9px 0 0;
+  -ms-border-radius: 9px 9px 0 0;
+  border-radius: 9px 9px 0 0;
+}
+.blue-block-white-background h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 11px;
+  margin: 0;
+  background: #0781af;
+  background: -moz-linear-gradient(top, #0781af 50%, #027099 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(50%, #0781af), color-stop(100%, #027099));
+  background: -webkit-linear-gradient(top, #0781af 50%, #027099 100%);
+  background: -o-linear-gradient(top, #0781af 50%, #027099 100%);
+  background: -ms-linear-gradient(top, #0781af 50%, #027099 100%);
+  background: linear-gradient(to bottom, #0781af 50%, #027099 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0781af',endColorstr='#027099',GradientType=0);
+  border-bottom: 1px solid #64b1cf;
+}
+.blue-block-white-background .block__content {
+  border: 1px solid #bbddea;
+  -webkit-border-radius: 0 0 9px 9px;
+  -moz-border-radius: 0 0 9px 9px;
+  -o-border-radius: 0 0 9px 9px;
+  -ms-border-radius: 0 0 9px 9px;
+  border-radius: 0 0 9px 9px;
+}
+.blue-block-white-background .block__content .custom-block-content-inner {
+  padding: 1em 11px .3em 11px;
+}
+
+.green-block {
+  overflow: hidden;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+}
+.green-block h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 11px;
+  margin: 0;
+  background: #3b9356;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #3b9356), color-stop(100%, #02684a));
+  background: -webkit-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -o-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -ms-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: linear-gradient(top, #3b9356 0%, #02684a 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#3b9356',endColorstr='#02684a',GradientType=0);
+}
+.green-block .block__content .custom-block-content-inner {
+  padding: 1em 11px .3em 11px;
+  background: #dde9c9;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #f0f5e7 0, #dde9c9 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #f0f5e7), color-stop(100%, #dde9c9));
+  background: -webkit-linear-gradient(top, #f0f5e7 0, #dde9c9 100%);
+  background: -o-linear-gradient(top, #f0f5e7 0, #dde9c9 100%);
+  background: -ms-linear-gradient(top, #f0f5e7 0, #dde9c9 100%);
+  background: linear-gradient(top, #f0f5e7 0%, #dde9c9 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f5e7',endColorstr='#dde9c9',GradientType=0);
+}
+
+.green-block-white-background {
+  overflow: hidden;
+}
+.green-block-white-background .custom-block-title-wrapper {
+  -webkit-border-radius: 9px 9px 0 0;
+  -moz-border-radius: 9px 9px 0 0;
+  -o-border-radius: 9px 9px 0 0;
+  -ms-border-radius: 9px 9px 0 0;
+  border-radius: 9px 9px 0 0;
+}
+.green-block-white-background h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 10px;
+  margin: 0;
+  background: #3b9356;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #3b9356), color-stop(100%, #02684a));
+  background: -webkit-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -o-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -ms-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: linear-gradient(top, #3b9356 0%, #02684a 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#3b9356',endColorstr='#02684a',GradientType=0);
+}
+.green-block-white-background .block__content {
+  border: 1px solid #02684a;
+  -webkit-border-radius: 0 0 9px 9px;
+  -moz-border-radius: 0 0 9px 9px;
+  -o-border-radius: 0 0 9px 9px;
+  -ms-border-radius: 0 0 9px 9px;
+  border-radius: 0 0 9px 9px;
+}
+.green-block-white-background .block__content .custom-block-content-inner {
+  padding: 1em 10px .3em 10px;
+  background-color: #fff;
+}
+
+.light-grey-block {
+  overflow: hidden;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+}
+.light-grey-block .custom-block-inner {
+  background: #f5f8f1;
+}
+.light-grey-block h2.block__title {
+  font-size: 1.5em;
+  color: #4b800d;
+  padding: .5em 11px .15em 11px;
+  margin: 0;
+}
+.light-grey-block .block__content {
+  padding: .5em 11px .3em 11px;
+}
+
+/* blocks in main content area */
+.l-content .green-block,
+.l-content .blue-block {
+  margin-bottom: 11px;
+}
+.l-content .light-grey-block h2.block__title {
+  font-size: 1.6em;
+  font-weight: normal;
+  padding: .46875em 11px .140625em 11px;
+}
+
+/* used for blocks to emulate page section headings */
+.section-block {
+  padding-bottom: 15px;
+  overflow: hidden;
+}
+.section-block .block__title,
+.section-block h2.block__title,
+.section-block h3.block__title {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+  clear: both;
+}
+
+/* print styling overrides */
+@media print {
+  .grey-block,
+  .purple-block,
+  .blue-block,
+  .blue-block-white-background,
+  .green-block,
+  .green-block-white-background,
+  .light-grey-block,
+  .section-block {
+    background: none;
+    background-color: transparent;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    -o-border-radius: 0;
+    -ms-border-radius: 0;
+    border-radius: 0;
+    border: none;
+  }
+  .grey-block .block__title,
+  .grey-block h2.block__title,
+  .grey-block h3.block__title,
+  .purple-block .block__title,
+  .purple-block h2.block__title,
+  .purple-block h3.block__title,
+  .blue-block .block__title,
+  .blue-block h2.block__title,
+  .blue-block h3.block__title,
+  .blue-block-white-background .block__title,
+  .blue-block-white-background h2.block__title,
+  .blue-block-white-background h3.block__title,
+  .green-block .block__title,
+  .green-block h2.block__title,
+  .green-block h3.block__title,
+  .green-block-white-background .block__title,
+  .green-block-white-background h2.block__title,
+  .green-block-white-background h3.block__title,
+  .light-grey-block .block__title,
+  .light-grey-block h2.block__title,
+  .light-grey-block h3.block__title,
+  .section-block .block__title,
+  .section-block h2.block__title,
+  .section-block h3.block__title {
+    color: #000;
+    background: none;
+    background-color: transparent;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    -o-border-radius: 0;
+    -ms-border-radius: 0;
+    border-radius: 0;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+  .grey-block .block__content,
+  .grey-block .custom-block-inner,
+  .grey-block .custom-block-title-wrapper,
+  .grey-block .custom-block-content-inner,
+  .purple-block .block__content,
+  .purple-block .custom-block-inner,
+  .purple-block .custom-block-title-wrapper,
+  .purple-block .custom-block-content-inner,
+  .blue-block .block__content,
+  .blue-block .custom-block-inner,
+  .blue-block .custom-block-title-wrapper,
+  .blue-block .custom-block-content-inner,
+  .blue-block-white-background .block__content,
+  .blue-block-white-background .custom-block-inner,
+  .blue-block-white-background .custom-block-title-wrapper,
+  .blue-block-white-background .custom-block-content-inner,
+  .green-block .block__content,
+  .green-block .custom-block-inner,
+  .green-block .custom-block-title-wrapper,
+  .green-block .custom-block-content-inner,
+  .green-block-white-background .block__content,
+  .green-block-white-background .custom-block-inner,
+  .green-block-white-background .custom-block-title-wrapper,
+  .green-block-white-background .custom-block-content-inner,
+  .light-grey-block .block__content,
+  .light-grey-block .custom-block-inner,
+  .light-grey-block .custom-block-title-wrapper,
+  .light-grey-block .custom-block-content-inner,
+  .section-block .block__content,
+  .section-block .custom-block-inner,
+  .section-block .custom-block-title-wrapper,
+  .section-block .custom-block-content-inner {
+    color: #000;
+    background: none;
+    background-color: transparent;
+    border: none;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    -o-border-radius: 0;
+    -ms-border-radius: 0;
+    border-radius: 0;
+  }
+}
+/* override default styling that comes with field collections module */
+.field-collection-view {
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.field-collection-container {
+  border-bottom: none;
+  margin-bottom: 0px;
+}
+
+/* grey type outer box applied to specific field collections */
+.add-classes-here {
+  overflow: hidden;
+  border: 1px solid #c4c4c4;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+  padding: 12px 10px;
+  background: #fff;
+}
+.add-classes-here .custom-block-content-inner {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjQ2JSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlYWVhZWEiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(46%, white), color-stop(100%, #eaeaea));
+  background: -webkit-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -o-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -ms-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 46%, #eaeaea 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#eaeaea',GradientType=0);
+}
+
+/* grey type outer box applied to specific field collections that have a block-type heading */
+.add-additional-classes-here {
+  overflow: hidden;
+  border: 1px solid #c4c4c4;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+  padding: 0 0 12px 0;
+}
+.add-additional-classes-here .custom-block-content-inner {
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjQ2JSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlYWVhZWEiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(46%, white), color-stop(100%, #eaeaea));
+  background: -webkit-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -o-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -ms-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 46%, #eaeaea 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#eaeaea',GradientType=0);
+}
+
+@media print {
+  .field-collection-view .entity-field-collection-item {
+    float: none;
+  }
+}
+/* fields that need site-wide styling */
+/* research programme fields */
+.field--name-field-contact-name,
+.field--name-field-phone-number,
+.field--name-field-email {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  margin-bottom: 0.3em;
+}
+
+/* files */
+.file-item {
+  font-weight: normal;
+  margin-bottom: 0.5em;
+  font-size: 1.3em;
+}
+.file-item a {
+  text-decoration: none;
+  color: #006f51;
+}
+.file-item a:hover {
+  text-decoration: underline;
+}
+.file-item .filesize {
+  font-size: 0.846em;
+}
+.file-item .file-summary p {
+  margin-bottom: 0;
+  font-size: 1em;
+}
+
+/* print styling overrides */
+@media print {
+  .file-item a {
+    color: #000;
+  }
+
+  .file-item {
+    display: none;
+  }
+}
+/* inline form labels */
+label.element-invisible.compact-form-label {
+  /* override defaults */
+  position: absolute !important;
+  clip: auto;
+  overflow: visible;
+  height: auto;
+  font-weight: normal;
+}
+
+.compact-form-label {
+  font-size: 1em;
+  line-height: 1.4em;
+  top: 1px;
+  left: 6px;
+  letter-spacing: 0.5px;
+  font-weight: normal;
+  color: #333;
+}
+
+.global-search .compact-form-label {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  top: -1px;
+  left: 8px;
+  color: #333;
+}
+
+/* override search facet default labels to apply compact label */
+.search-facet label.compact-form-label,
+.search-facet .views-exposed-form label.compact-form-label,
+.search-facet .form-item label.compact-form-label,
+.search-facet .form-actions label.compact-form-label {
+  padding-bottom: 0;
+  display: block;
+  padding-left: 0;
+  color: #666;
+  font-weight: normal;
+  font-size: 1.2em;
+  line-height: 1.4em;
+  top: 2px;
+  left: 6px;
+  font-family: Arial,Verdana,Helvetica,san-serif;
+}
+
+/* print styling overrides */
+@media print {
+  .compact-form-label,
+  .global-search .compact-form-label,
+  .search-facet label.compact-form-label,
+  .search-facet .views-exposed-form label.compact-form-label,
+  .search-facet .form-item label.compact-form-label,
+  .search-facet .form-actions label.compact-form-label {
+    color: #000;
+  }
+}
+/* default links for site */
+a {
+  color: #006f51;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+a:focus {
+  text-decoration: underline !important;
+}
+
+/* Skip to main content */
+.element-invisible {
+  color: #006f51;
+  text-decoration: underline !important;
+}
+
+/* Skip to main content */
+.element-invisible {
+  color: #006f51;
+  text-decoration: underline !important;
+}
+
+/* links for body and textarea fields */
+.field--type-text-with-summary a,
+.field--type-text-long a,
+.field-type-text-long a,
+.field-type-text-with-summary a {
+  text-decoration: underline !important;
+}
+.field--type-text-with-summary a:hover,
+.field--type-text-long a:hover,
+.field-type-text-long a:hover,
+.field-type-text-with-summary a:hover {
+  text-decorartion: none !important;
+}
+.field--type-text-with-summary a:focus,
+.field--type-text-long a:focus,
+.field-type-text-long a:focus,
+.field-type-text-with-summary a:focus {
+  text-decoration: none !important;
+}
+
+/* external links icon - requires external links module */
+span.ext {
+  background: url("../images/icons/external-link-icon.gif") right center no-repeat;
+  width: 10px;
+  height: 10px;
+  margin-left: 3px;
+  margin-right: 3px;
+  display: inline-block;
+  *display: inline;
+  zoom: 1;
+}
+
+/* apply this class to the block, not to the link itself */
+.green-sidebar-links1 ul {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+.green-sidebar-links1 .li {
+  font-size: 1em;
+  font-weight: normal;
+  display: block;
+  padding-left: 14px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+}
+.green-sidebar-links1 .li a {
+  text-decoration: none;
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  color: #006f51;
+  margin-bottom: 0.35em;
+}
+.green-sidebar-links1 .li a:hover {
+  text-decoration: underline;
+}
+
+/* apply this class to the block, not to the link itself */
+.green-sidebar-links2 ul {
+  margin: 0;
+  padding: 0;
+}
+.green-sidebar-links2 .li {
+  font-size: 1em;
+  font-weight: normal;
+  display: block;
+  padding-left: 14px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+}
+.green-sidebar-links2 .li a {
+  text-decoration: none;
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  color: #006f51;
+  margin-bottom: 0.5em;
+}
+.green-sidebar-links2 .li a:hover {
+  text-decoration: underline;
+}
+.green-sidebar-links2 .field--name-field-subtitle {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  margin-bottom: 0.5em;
+}
+
+/* more link */
+a.fsa-more-link {
+  font-weight: normal;
+  display: block;
+  padding-left: 14px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+  text-decoration: none;
+  color: #006f51;
+}
+
+a.fsa-more-link:hover {
+  text-decoration: underline;
+}
+
+/* alternative more link */
+a.fsa-more-link-orange-arrow {
+  font-weight: normal;
+  display: block;
+  padding-left: 14px;
+  background-image: url("../images/orange-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+  text-decoration: none;
+  color: #006f51;
+}
+
+a.fsa-more-link-orange-arrow:hover {
+  text-decoration: underline;
+}
+
+/* more link with orange icon */
+a.more-link-orange-icon-right {
+  font-weight: normal;
+  padding-right: 15px;
+  background: url("../images/icons/more.png") no-repeat right 1px;
+  text-decoration: none;
+  color: #3d3d3d;
+  white-space: normal;
+  word-wrap: break-word;
+  cursor: pointer;
+  line-height: 1em;
+  font-weight: bold;
+}
+
+a.more-link-orange-icon-right:hover {
+  text-decoration: underline;
+}
+
+/* more button 
+ * requires this html structure:  
+ * <p class="more-button-wrapper"><a href="/science/" title="More about: Science and research" class="more-button"><span class="link-text">More</span></a></p>
+*/
+p.more-button-wrapper {
+  clear: both;
+  float: right;
+  margin: 0 0 6px 0;
+}
+
+p .more-button {
+  font-size: 1em;
+}
+
+.more-button {
+  overflow: hidden;
+  border: 1px solid #fff;
+  line-height: 1em;
+  font-size: 1.2em;
+  font-weight: bold;
+  white-space: normal;
+  word-wrap: break-word;
+  display: block;
+  float: left;
+  cursor: pointer;
+  text-decoration: none;
+  color: #3d3d3d;
+  text-align: left;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSI0NiUiIHN0b3AtY29sb3I9IiNmZmZmZmYiIHN0b3Atb3BhY2l0eT0iMSIvPgogICAgPHN0b3Agb2Zmc2V0PSI5OSUiIHN0b3AtY29sb3I9IiNjZGNkY2QiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(46%, white), color-stop(99%, #cdcdcd));
+  background: -webkit-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -o-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -ms-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: linear-gradient(top, #ffffff 46%, #cdcdcd 99%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#cdcdcd',GradientType=0);
+  padding: 6px;
+}
+
+.more-button:hover {
+  text-decoration: underline;
+}
+
+.more-button .link-text {
+  padding-right: 15px;
+  background: url("../images/icons/more.png") no-repeat right 1px;
+  display: block;
+  text-align: left;
+}
+
+/* print styling overrides */
+@media print {
+  a,
+  a.fsa-more-link,
+  a.fsa-more-link-orange-arrow,
+  a.more-link-orange-icon-right,
+  .more-button {
+    color: #000;
+  }
+
+  .green-sidebar-links1 li a,
+  .green-sidebar-links2 li a {
+    color: #000;
+  }
+}
+img, media {
+  max-width: 100%;
+}
+
+/* files - depends on hook_file_link in template.php and custom formatter "file type size and link" on file in content type display settings */
+.file-item span.filesize {
+  margin-left: 10px;
+}
+
+/* generic classes that are not captured elsewhere */
+/* example usage: to hide RDF content */
+.hidden {
+  display: none;
+}
+
+/* site logo */
+a.site-logo:focus img {
+  border: 1px solid #fff;
+}
+
+/* apply page section title if a parent group has class: page-section  - used mainly in display settings formatting */
+.page-section h2 {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+  clear: both;
+}
+
+/* print styling overrides */
+@media print {
+  .page-section h2 {
+    color: #000;
+    background: none;
+    background-color: transparent;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+}
+/**
+ * requires classes to be added to fields (example: page-section-heading)- done in field preprocess
+ */
+/* example usage: section headings on page section field collection */
+.page-section-heading {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+  clear: both;
+}
+.page-section-heading h1, .page-section-heading h2, .page-section-heading h3, .page-section-heading h4, .page-section-heading h5, .page-section-heading h6 {
+  font-size: 1em;
+  margin-bottom: 0;
+}
+
+/* example usage: related items and child page headings on page section field collection */
+.page-section-subheading {
+  display: block;
+  font-size: 1.4em;
+  color: #5d9711;
+  font-weight: bold;
+  margin-bottom: 0.5em;
+}
+.page-section-subheading h1, .page-section-subheading h2, .page-section-subheading h3, .page-section-subheading h4, .page-section-subheading h5, .page-section-subheading h6 {
+  font-size: 1em;
+  margin-bottom: 0;
+}
+
+/* for files we need a bit more maring on subheading */
+.field--name-field-fc-related-items-heading.page-section-subheading {
+  clear: both;
+  margin-bottom: 0.8em;
+}
+
+/* page section body field */
+.field--name-field-fc-section-body h3 {
+  font-size: 1.4em;
+  margin: 0 0 .5em 0;
+}
+.field--name-field-fc-section-body h4 {
+  font-size: 1.2em;
+  margin-bottom: .6em;
+}
+.field--name-field-fc-section-body li {
+  font-size: 1.2em;
+  line-height: 1.3em;
+  margin-bottom: 0.7em;
+}
+.field--name-field-fc-section-body td li {
+  font-size: 1em;
+}
+.field--name-field-fc-section-body li li {
+  font-size: 1em;
+}
+
+/* example usage: related items and child page teaser listings on page section field collection */
+.page-section-teaser {
+  font-size: 1em;
+  line-height: 1.4em;
+  margin-bottom: 18px;
+  /* node title */
+  /* subtitle */
+  /* teaser updated date */
+  /* teaser summary */
+  /* node links like read more (if enabled) */
+  /* related media files and csv files */
+}
+.page-section-teaser h2.node__title,
+.page-section-teaser h3.node__title {
+  font-size: 1.3em;
+  line-height: 1.4em;
+  margin-bottom: 0;
+  font-weight: bold;
+}
+.page-section-teaser .node__title {
+  font-weight: bold;
+  display: block;
+}
+.page-section-teaser .node__title a {
+  text-decoration: none;
+  color: #006f51;
+}
+.page-section-teaser .node__title a:hover {
+  text-decoration: underline;
+}
+.page-section-teaser .field--name-field-subtitle {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+}
+.page-section-teaser .field--name-field-updated {
+  font-size: 1.1em;
+  margin-bottom: 0.2em;
+}
+.page-section-teaser .field--name-field-summary {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  color: #333;
+  margin-bottom: 0.2em;
+}
+.page-section-teaser .field__item {
+  margin-bottom: 0.5em;
+}
+.page-section-teaser .node__links a {
+  text-decoration: none;
+  color: #006f51;
+}
+.page-section-teaser .node__links a:hover {
+  text-decoration: underline;
+}
+.page-section-teaser .file-item {
+  font-weight: normal;
+  margin-bottom: 0.5em;
+  font-size: 1.2em;
+}
+.page-section-teaser .file-item a {
+  text-decoration: none;
+  color: #006f51;
+}
+.page-section-teaser .file-item a:hover {
+  text-decoration: underline;
+}
+.page-section-teaser .file-item .filesize {
+  font-size: 0.846em;
+}
+.page-section-teaser .file-summary p {
+  margin-bottom: 0;
+  font-size: 1em;
+}
+
+/* child pages normal teaser and child pages micro-teaser */
+.field--name-field-child-page.page-section-teaser .field__item {
+  margin-bottom: 0px;
+}
+
+/* child pages normal teaser */
+.field--name-field-child-page.page-section-teaser .node-teaser {
+  margin-bottom: 13px;
+}
+.field--name-field-child-page.page-section-teaser .node-teaser .field__item {
+  margin-bottom: 0.5em;
+}
+
+/* child pages mirco teaser - more in this section micro teaser variation of default teaser. Note: teaser is toggeled in page section edit mode */
+.field--name-field-child-page.page-section-teaser .node--micro-teaser h2.node__title,
+.field--name-field-child-page.page-section-teaser .node--micro-teaser h3.node__title {
+  font-size: 1em;
+  font-weight: normal;
+}
+.field--name-field-child-page.page-section-teaser .node--micro-teaser .node__title {
+  font-weight: normal;
+}
+.field--name-field-child-page.page-section-teaser .node--micro-teaser .node__title a {
+  font-size: 1.2em;
+  text-decoration: none;
+  color: #333;
+  display: block;
+  padding: 5px 120px 5px 24px;
+  margin-bottom: 1px;
+  background-color: #eee;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: 10px 8px;
+}
+.field--name-field-child-page.page-section-teaser .node--micro-teaser .node__title a:hover {
+  text-decoration: underline;
+}
+
+/* for mobile */
+@media (min-width: 0px) and (max-width: 480px) {
+  /* adjust right padding on child page micro tesser view mode */
+  .field--name-field-child-page.page-section-teaser .node--micro-teaser a {
+    padding: 5px 14px 5px 24px;
+  }
+}
+/* related data wrapper - csv files */
+.csv-files-wrapper {
+  clear: both;
+  overflow: hidden;
+  margin-bottom: 18px;
+  border: 1px solid #c4c4c4;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.csv-files-inner {
+  overflow: hidden;
+  padding: 12px 10px 0px 10px;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjQ2JSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlYWVhZWEiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(46%, white), color-stop(100%, #eaeaea));
+  background: -webkit-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -o-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -ms-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 46%, #eaeaea 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#eaeaea',GradientType=0);
+  /* extra margin for related data heading */
+}
+.csv-files-inner .page-section-subheading {
+  margin-bottom: 0.8em;
+}
+
+/* related items wrapper - files */
+.related-items-wrapper {
+  clear: both;
+  overflow: hidden;
+  margin-bottom: 18px;
+  border: 1px solid #c4c4c4;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.related-items-inner {
+  overflow: hidden;
+  padding: 12px 10px 0px 10px;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjQ2JSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlYWVhZWEiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(46%, white), color-stop(100%, #eaeaea));
+  background: -webkit-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -o-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -ms-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 46%, #eaeaea 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#eaeaea',GradientType=0);
+  /* extra margin for related items heading */
+}
+.related-items-inner .page-section-subheading {
+  margin-bottom: 0.8em;
+}
+
+/* print styling overrides */
+@media print {
+  .page-section-heading {
+    color: #000;
+    background: none;
+    background-color: transparent;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+
+  .page-section-subheading {
+    color: #000;
+  }
+
+  .page-section-teaser .node__title a,
+  .page-section-teaser .field--name-field-summary,
+  .page-section-teaser .node__links a,
+  .page-section-teaser .file-item a {
+    color: #000;
+  }
+
+  .field--name-field-child-page.page-section-teaser .node--micro-teaser .node__title a {
+    color: #000;
+    background-color: transparent;
+  }
+
+  .csv-files-wrapper,
+  .related-items-wrapper {
+    display: none;
+  }
+}
+/* Drupal system output */
+/* print styling overrides */
+@media print {
+  .messages {
+    display: none;
+  }
+
+  /* hide edit tabs */
+  ul.tabs {
+    display: none;
+  }
+}
+html {
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  font-size: 62.5%;
+  line-height: 1.3em;
+  font-family: Arial, Verdana, Helvetica, sans-serif;
+  color: #333;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: Arial, Verdana, Helvetica, sans-serif;
+}
+
+h1 {
+  font-size: 2.8em;
+  line-height: 1.2em;
+  font-weight: normal;
+  color: #4b800d;
+  margin: 0 0 .4642857em 0;
+}
+
+h2 {
+  font-size: 1.5em;
+  line-height: 1.2em;
+  font-weight: bold;
+  margin: 0 0 .867em 0;
+}
+
+h3, h4, h5, h6 {
+  font-size: 1.3em;
+  line-height: 1.2em;
+  font-weight: bold;
+  margin: 0 0 1em 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  text-rendering: optimizeLegibility;
+}
+
+p, li, dt, dd, blockquote, pre, address, label, th, td, code {
+  font-size: 1.2em;
+  line-height: 1.5em;
+}
+
+.field--name-field-fc-section-body li {
+  line-height: 1.5em;
+}
+
+li li {
+  font-size: 1em;
+}
+
+td p, td li {
+  font-size: 1em;
+}
+
+p, ul, ol, dl, address, blockquote {
+  margin: 0 0 1.3em 0;
+}
+
+ol, ul {
+  padding: 0 0 0 16px;
+  margin-left: -3px;
+}
+
+.file-item {
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+
+/* print styling overrides */
+@media print {
+  body, h1 {
+    color: #000;
+  }
+}
+/* views blocks that have a class section-block */
+.section-block .view .node__title,
+.section-block .view h2.node__title,
+.section-block .view h3.node__title {
+  font-size: 1.3em;
+  line-height: 1.4em;
+  margin-bottom: 0;
+  font-weight: bold;
+}
+.section-block .view .field--name-field-summary {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  color: #333;
+  margin-bottom: 0.2em;
+}
+.section-block .view .field--name-field-consultation-summary {
+  margin-bottom: 0.2em;
+}
+.section-block .view .field--name-field-consultation-dates .field__item {
+  margin-bottom: 0;
+}
+.section-block .view .node-teaser {
+  margin-bottom: 0.8em;
+}
+.section-block .view .file-item {
+  font-weight: normal;
+  margin-bottom: 0.5em;
+  font-size: 1.2em;
+}
+.section-block .view .file-item .filesize {
+  font-size: 0.846em;
+}
+.section-block .view .file-summary p {
+  margin-bottom: 0;
+  font-size: 1em;
+}
+.section-block .view .field--type-taxonomy-term-reference {
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+.section-block .view .field__item {
+  margin-bottom: 0.5em;
+}
+.section-block .view .view-empty {
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+.section-block .view .views-row {
+  border-bottom: 1px solid #5d9711;
+  padding: 7px 0 7px 0;
+}
+.section-block .view .views-row.views-row-first {
+  padding: 0 0 7px 0;
+}
+.section-block .view .views-row.views-row-last {
+  border-bottom: none;
+  padding: 7px 0 0 0;
+}
+.section-block .view .views-row.views-row-first.views-row-last {
+  padding: 0 0 0 0;
+  border-bottom: none;
+}
+
+/* views grouped by headings - that are implemented by view template override on specific views */
+.custom-views-grouped-heading {
+  margin: 0 0 1em 0;
+}
+
+/* print styling overrides */
+@media print {
+  .section-block .view .field--name-field-summary {
+    color: #000;
+  }
+  .section-block .view .views-row {
+    border-bottom: none;
+  }
+}
+/* these are styles used with ckeditor - includes backwards compatibility for migrated content too */
+/* highlighted content - guidance - ckeditor style */
+.guidance {
+  clear: both;
+  display: block;
+  background: #F0F4E5;
+  border: 1px solid #5D9711;
+  color: #333;
+  padding: 11px;
+  margin-bottom: 1.3em;
+  /* where <strong> exists outside of a p-tag */
+  /* adjustment for this site */
+}
+.guidance strong {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  font-weight: bold;
+  margin-bottom: 0.5833;
+  display: block;
+}
+.guidance p strong {
+  font-size: 1em;
+  margin-bottom: 0;
+  display: inline;
+}
+
+/* highlighted content - training - ckeditor style */
+.training {
+  clear: both;
+  display: block;
+  background: #f6fcff;
+  border: 1px solid #007FB2;
+  color: #333;
+  padding: 11px;
+  margin-bottom: 1.3em;
+  /* where <strong> exists outside of a p-tag */
+  /* adjustment for this site */
+}
+.training strong {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  font-weight: bold;
+  margin-bottom: 0.5833;
+  display: block;
+}
+.training p strong {
+  font-size: 1em;
+  margin-bottom: 0;
+  display: inline;
+}
+
+/* highlighted content - science - ckeditor style - for science field style, see components/_science_field.scss */
+.science,
+.moreInfo {
+  clear: both;
+  display: block;
+  background: #fff;
+  border: 1px solid #5d9711;
+  color: #333;
+  padding: 9px 10px 6px 10px;
+  margin-bottom: 1.3em;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+  /* where <strong> exists outside of a p-tag */
+  /* adjustment for this site */
+}
+.science h2, .science h3,
+.moreInfo h2,
+.moreInfo h3 {
+  margin: 0 0 0.5em 0;
+  padding: 0;
+  font-size: 1.4em;
+  color: #5d9711;
+  background: none;
+  font-weight: bold;
+}
+.science strong,
+.moreInfo strong {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  font-weight: bold;
+  margin-bottom: 1em;
+  display: block;
+}
+.science p strong,
+.moreInfo p strong {
+  font-size: 1em;
+  margin-bottom: 0;
+  display: inline;
+}
+
+/* section heading - ckeditor style */
+.inline-section-heading,
+h2.inline-section-heading,
+h3.inline-section-heading {
+  clear: both;
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+  clear: both;
+}
+
+/* tables - we restricting this css to only textarea fields so that it does not affect other parts of the site */
+.field--name-field-fc-section-body,
+.field--name-body,
+.field--type-text-with-summary,
+.field--type-text-long {
+  /* override drupal default */
+}
+.field--name-field-fc-section-body table,
+.field--name-body table,
+.field--type-text-with-summary table,
+.field--type-text-long table {
+  clear: both;
+  margin: 0 0 1.3em 0;
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+  border-top: 1px solid #006f51;
+  border-bottom: 1px solid #ebebeb;
+  border-left: none;
+  border-right: none;
+}
+.field--name-field-fc-section-body caption, .field--name-field-fc-section-body th, .field--name-field-fc-section-body td,
+.field--name-body caption,
+.field--name-body th,
+.field--name-body td,
+.field--type-text-with-summary caption,
+.field--type-text-with-summary th,
+.field--type-text-with-summary td,
+.field--type-text-long caption,
+.field--type-text-long th,
+.field--type-text-long td {
+  text-align: left;
+  vertical-align: top;
+  font-weight: normal;
+}
+.field--name-field-fc-section-body caption,
+.field--name-body caption,
+.field--type-text-with-summary caption,
+.field--type-text-long caption {
+  margin: .9em 0;
+  padding: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #333;
+}
+.field--name-field-fc-section-body th, .field--name-field-fc-section-body td,
+.field--name-body th,
+.field--name-body td,
+.field--type-text-with-summary th,
+.field--type-text-with-summary td,
+.field--type-text-long th,
+.field--type-text-long td {
+  padding: .6em 10px .6em 10px;
+  border-left: 1px solid #ebebeb;
+  border-right: none;
+}
+.field--name-field-fc-section-body td:first-child,
+.field--name-body td:first-child,
+.field--type-text-with-summary td:first-child,
+.field--type-text-long td:first-child {
+  border-left: none;
+}
+.field--name-field-fc-section-body th, .field--name-field-fc-section-body thead th, .field--name-field-fc-section-body thead td, .field--name-field-fc-section-body tfoot th, .field--name-field-fc-section-body tfoot td,
+.field--name-body th,
+.field--name-body thead th,
+.field--name-body thead td,
+.field--name-body tfoot th,
+.field--name-body tfoot td,
+.field--type-text-with-summary th,
+.field--type-text-with-summary thead th,
+.field--type-text-with-summary thead td,
+.field--type-text-with-summary tfoot th,
+.field--type-text-with-summary tfoot td,
+.field--type-text-long th,
+.field--type-text-long thead th,
+.field--type-text-long thead td,
+.field--type-text-long tfoot th,
+.field--type-text-long tfoot td {
+  font-weight: bold;
+  color: #006f51;
+}
+.field--name-field-fc-section-body thead th, .field--name-field-fc-section-body thead td,
+.field--name-body thead th,
+.field--name-body thead td,
+.field--type-text-with-summary thead th,
+.field--type-text-with-summary thead td,
+.field--type-text-long thead th,
+.field--type-text-long thead td {
+  background: #f2f2f2;
+}
+.field--name-field-fc-section-body tfoot th, .field--name-field-fc-section-body tfoot td,
+.field--name-body tfoot th,
+.field--name-body tfoot td,
+.field--type-text-with-summary tfoot th,
+.field--type-text-with-summary tfoot td,
+.field--type-text-long tfoot th,
+.field--type-text-long tfoot td {
+  border-top: 1px solid #ebebeb;
+}
+.field--name-field-fc-section-body thead span, .field--name-field-fc-section-body tfoot span,
+.field--name-body thead span,
+.field--name-body tfoot span,
+.field--type-text-with-summary thead span,
+.field--type-text-with-summary tfoot span,
+.field--type-text-long thead span,
+.field--type-text-long tfoot span {
+  display: block;
+  margin: .6em 0 0 0;
+  font-weight: normal;
+}
+.field--name-field-fc-section-body thead .subHead th, .field--name-field-fc-section-body tfoot .subHead th,
+.field--name-body thead .subHead th,
+.field--name-body tfoot .subHead th,
+.field--type-text-with-summary thead .subHead th,
+.field--type-text-with-summary tfoot .subHead th,
+.field--type-text-long thead .subHead th,
+.field--type-text-long tfoot .subHead th {
+  padding-top: 0;
+  margin: 0;
+  font-weight: normal;
+}
+.field--name-field-fc-section-body th.numeric, .field--name-field-fc-section-body td.numeric,
+.field--name-body th.numeric,
+.field--name-body td.numeric,
+.field--type-text-with-summary th.numeric,
+.field--type-text-with-summary td.numeric,
+.field--type-text-long th.numeric,
+.field--type-text-long td.numeric {
+  text-align: right;
+}
+.field--name-field-fc-section-body th.multiCol, .field--name-field-fc-section-body td.multiCol,
+.field--name-body th.multiCol,
+.field--name-body td.multiCol,
+.field--type-text-with-summary th.multiCol,
+.field--type-text-with-summary td.multiCol,
+.field--type-text-long th.multiCol,
+.field--type-text-long td.multiCol {
+  text-align: center;
+}
+.field--name-field-fc-section-body th.first, .field--name-field-fc-section-body td.first, .field--name-field-fc-section-body th.grouped, .field--name-field-fc-section-body td.grouped,
+.field--name-body th.first,
+.field--name-body td.first,
+.field--name-body th.grouped,
+.field--name-body td.grouped,
+.field--type-text-with-summary th.first,
+.field--type-text-with-summary td.first,
+.field--type-text-with-summary th.grouped,
+.field--type-text-with-summary td.grouped,
+.field--type-text-long th.first,
+.field--type-text-long td.first,
+.field--type-text-long th.grouped,
+.field--type-text-long td.grouped {
+  border-left: 0;
+}
+.field--name-field-fc-section-body tbody .alt th, .field--name-field-fc-section-body tbody .alt td,
+.field--name-body tbody .alt th,
+.field--name-body tbody .alt td,
+.field--type-text-with-summary tbody .alt th,
+.field--type-text-with-summary tbody .alt td,
+.field--type-text-long tbody .alt th,
+.field--type-text-long tbody .alt td {
+  background: #f2f2f2;
+}
+.field--name-field-fc-section-body tbody tr:nth-child(even) th, .field--name-field-fc-section-body tbody tr:nth-child(even) td,
+.field--name-body tbody tr:nth-child(even) th,
+.field--name-body tbody tr:nth-child(even) td,
+.field--type-text-with-summary tbody tr:nth-child(even) th,
+.field--type-text-with-summary tbody tr:nth-child(even) td,
+.field--type-text-long tbody tr:nth-child(even) th,
+.field--type-text-long tbody tr:nth-child(even) td {
+  background: #f2f2f2;
+}
+.field--name-field-fc-section-body table.linearTable,
+.field--name-body table.linearTable,
+.field--type-text-with-summary table.linearTable,
+.field--type-text-long table.linearTable {
+  margin-bottom: 2em;
+  border-top: 1px solid #006f51;
+  border-bottom: 0;
+}
+.field--name-field-fc-section-body .linearTable th, .field--name-field-fc-section-body .linearTable td,
+.field--name-body .linearTable th,
+.field--name-body .linearTable td,
+.field--type-text-with-summary .linearTable th,
+.field--type-text-with-summary .linearTable td,
+.field--type-text-long .linearTable th,
+.field--type-text-long .linearTable td {
+  border-bottom: 1px solid #ebebeb;
+}
+.field--name-field-fc-section-body .linearTable tbody th.grouper,
+.field--name-body .linearTable tbody th.grouper,
+.field--type-text-with-summary .linearTable tbody th.grouper,
+.field--type-text-long .linearTable tbody th.grouper {
+  padding-top: 2em;
+  color: #333;
+}
+.field--name-field-fc-section-body th,
+.field--name-body th,
+.field--type-text-with-summary th,
+.field--type-text-long th {
+  background-color: transparent;
+}
+
+/* legacy css for tables from old site */
+.field--name-field-fc-section-body .fsatable,
+.field--name-body .fsatable,
+.field--type-text-with-summary .fsatable,
+.field--type-text-long .fsatable {
+  float: left;
+  width: 100%;
+  margin: 2px 0 20px 0;
+}
+.field--name-field-fc-section-body .fsatable th, .field--name-field-fc-section-body .cottable td,
+.field--name-body .fsatable th,
+.field--name-body .cottable td,
+.field--type-text-with-summary .fsatable th,
+.field--type-text-with-summary .cottable td,
+.field--type-text-long .fsatable th,
+.field--type-text-long .cottable td {
+  font-family: Arial, sans-serif;
+  font-size: 85%;
+  padding: 5px;
+  border-right: 1px solid #fff;
+  border-bottom: 1px solid #fff;
+}
+.field--name-field-fc-section-body .fsatable thead th,
+.field--name-body .fsatable thead th,
+.field--type-text-with-summary .fsatable thead th,
+.field--type-text-long .fsatable thead th {
+  color: #666;
+  border-bottom: 1px solid #99cc99;
+}
+.field--name-field-fc-section-body .fsatable tbody th,
+.field--name-body .fsatable tbody th,
+.field--type-text-with-summary .fsatable tbody th,
+.field--type-text-long .fsatable tbody th {
+  text-align: left;
+  vertical-align: top;
+  background-color: #c4cdd8;
+  color: #666;
+}
+.field--name-field-fc-section-body .fsatable td,
+.field--name-body .fsatable td,
+.field--type-text-with-summary .fsatable td,
+.field--type-text-long .fsatable td {
+  color: #666;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px dotted #99cc99;
+  background: #f5f5f5;
+  border-right: 1px solid #fff;
+  border-bottom: 1px solid #fff;
+}
+.field--name-field-fc-section-body .fsatable td.lastrow,
+.field--name-body .fsatable td.lastrow,
+.field--type-text-with-summary .fsatable td.lastrow,
+.field--type-text-long .fsatable td.lastrow {
+  border-bottom: none;
+}
+.field--name-field-fc-section-body .fsatable td a,
+.field--name-body .fsatable td a,
+.field--type-text-with-summary .fsatable td a,
+.field--type-text-long .fsatable td a {
+  color: #006633;
+  text-decoration: none;
+}
+.field--name-field-fc-section-body .fsatable td a:hover,
+.field--name-body .fsatable td a:hover,
+.field--type-text-with-summary .fsatable td a:hover,
+.field--type-text-long .fsatable td a:hover {
+  color: #003300;
+}
+.field--name-field-fc-section-body .fsatable td ul,
+.field--name-body .fsatable td ul,
+.field--type-text-with-summary .fsatable td ul,
+.field--type-text-long .fsatable td ul {
+  margin: 0 0 0 14px;
+  padding-left: 3px;
+}
+.field--name-field-fc-section-body .fsatable td ul li,
+.field--name-body .fsatable td ul li,
+.field--type-text-with-summary .fsatable td ul li,
+.field--type-text-long .fsatable td ul li {
+  font-size: 130%;
+}
+
+/* print styling overrides */
+@media print {
+  .guidance,
+  .training,
+  .science,
+  .moreInfo {
+    border: 1px solid #000;
+    background: none;
+    background-color: transparent;
+    color: #000;
+    -webkit-border-radius: 0px;
+    -moz-border-radius: 0px;
+    -o-border-radius: 0px;
+    -ms-border-radius: 0px;
+    border-radius: 0px;
+  }
+  .guidance h2, .guidance h3,
+  .training h2,
+  .training h3,
+  .science h2,
+  .science h3,
+  .moreInfo h2,
+  .moreInfo h3 {
+    color: #000;
+  }
+
+  .inline-section-heading,
+  h2.inline-section-heading,
+  h3.inline-section-heading {
+    color: #000;
+    background: transparent;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+
+  .field--name-field-fc-section-body table,
+  .field--name-body table,
+  .field--type-text-with-summary table,
+  .field--type-text-long table {
+    border-top: 1px solid #000;
+  }
+  .field--name-field-fc-section-body caption,
+  .field--name-body caption,
+  .field--type-text-with-summary caption,
+  .field--type-text-long caption {
+    color: #000;
+  }
+  .field--name-field-fc-section-body th, .field--name-field-fc-section-body thead th, .field--name-field-fc-section-body thead td, .field--name-field-fc-section-body tfoot th, .field--name-field-fc-section-body tfoot td,
+  .field--name-body th,
+  .field--name-body thead th,
+  .field--name-body thead td,
+  .field--name-body tfoot th,
+  .field--name-body tfoot td,
+  .field--type-text-with-summary th,
+  .field--type-text-with-summary thead th,
+  .field--type-text-with-summary thead td,
+  .field--type-text-with-summary tfoot th,
+  .field--type-text-with-summary tfoot td,
+  .field--type-text-long th,
+  .field--type-text-long thead th,
+  .field--type-text-long thead td,
+  .field--type-text-long tfoot th,
+  .field--type-text-long tfoot td {
+    color: #000;
+  }
+  .field--name-field-fc-section-body table.linearTable,
+  .field--name-body table.linearTable,
+  .field--type-text-with-summary table.linearTable,
+  .field--type-text-long table.linearTable {
+    border-top: 1px solid #000;
+  }
+  .field--name-field-fc-section-body .linearTable tbody th.grouper,
+  .field--name-body .linearTable tbody th.grouper,
+  .field--type-text-with-summary .linearTable tbody th.grouper,
+  .field--type-text-long .linearTable tbody th.grouper {
+    color: #000;
+  }
+
+  /* legacy css for tables from old site */
+  .field--name-field-fc-section-body .fsatable thead th,
+  .field--name-body .fsatable thead th,
+  .field--type-text-with-summary .fsatable thead th,
+  .field--type-text-long .fsatable thead th {
+    color: #000;
+  }
+  .field--name-field-fc-section-body .fsatable tbody th,
+  .field--name-body .fsatable tbody th,
+  .field--type-text-with-summary .fsatable tbody th,
+  .field--type-text-long .fsatable tbody th {
+    color: #000;
+  }
+  .field--name-field-fc-section-body .fsatable td,
+  .field--name-body .fsatable td,
+  .field--type-text-with-summary .fsatable td,
+  .field--type-text-long .fsatable td {
+    color: #000;
+  }
+  .field--name-field-fc-section-body .fsatable td a,
+  .field--name-body .fsatable td a,
+  .field--type-text-with-summary .fsatable td a,
+  .field--type-text-long .fsatable td a {
+    color: #000;
+  }
+}
+#admin-menu {
+  font-size: 1em;
+  font-family: Arial, Verdana, Helvetica, sans-serif;
+}
+#admin-menu li {
+  font-size: 1em;
+}
+#admin-menu li a {
+  font-size: 1.2em;
+}
+
+/* adobe reader block
+ * requires block class: adobe-reader-block
+ * and requires specific markup - see blow commented out code
+ */
+.adobe-reader-block {
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+  background: #fff;
+  padding: 1em 11px 1em 11px;
+  /* we don't need a bock title, but we theme it just in case */
+}
+.adobe-reader-block h2.block__title {
+  font-size: 1.5em;
+  color: #5d9711;
+  margin: 0 0 .5em 0;
+}
+.adobe-reader-block img {
+  margin: 0;
+  border: none;
+}
+.adobe-reader-block p {
+  margin-top: 0;
+  margin-bottom: 0.5em;
+}
+.adobe-reader-block p.adobe-link {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/*
+<p>You may need the free Acrobat Reader to view a pdf</p>
+<p class="adobe-link">
+<a href="http://get.adobe.com/reader/" target="_blank" title="Opens in a new window">
+<img src="/sites/all/themes/site_frontend/images/adobe-reader.gif" alt="Get Adobe Reader">
+</a>
+</p>
+*/
+/* print styling overrides */
+@media print {
+  .adobe-reader-block {
+    display: none;
+  }
+}
+/**
+ * Alert type field
+ * In display settings, requires prefix: <p class="alert-type"><span class="alert-label">Type: </span> and suffix: </p>
+ * We are not using inline label setting for label because the div around it interferes with floating of text around feature image
+ * Without the p-tag, wrapping of text around feature image breaks. We use a p-tag so that the right font size is pulled through.
+ */
+p.alert-type {
+  margin-bottom: 10px;
+}
+
+.alert-label {
+  font-weight: bold;
+}
+
+/**
+ * Alert type reference
+ * In display settings, requires prefix: <p class="alert-ref"><span class="ref-label">Ref: </span> and suffix: </p>
+ * We are not using inline label setting for label because the div around it interferes with floating of text around feature image
+ * Adding a p-tag around the content aloows the text to be correctky formatted (size) and facilitates correct text wrapping.
+ * We use a p-tag so that the right font size is pulled through.
+ */
+p.alert-ref {
+  margin-bottom: 10px;
+}
+
+.ref-label {
+  font-weight: bold;
+}
+
+.bottom-menu-wrapper {
+  border-top: 1px solid #61873b;
+  background: #565656;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzU2NTY1NiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiMyNDI0MjMiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #565656 0, #242423 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #565656), color-stop(100%, #242423));
+  background: -webkit-linear-gradient(top, #565656 0, #242423 100%);
+  background: -o-linear-gradient(top, #565656 0, #242423 100%);
+  background: -ms-linear-gradient(top, #565656 0, #242423 100%);
+  background: linear-gradient(top, #565656 0%, #242423 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#565656',endColorstr='#242423',GradientType=0);
+}
+
+.bottom-menu {
+  width: 16.6%;
+  float: left;
+  padding-right: 12px;
+  margin-top: 10px;
+  margin-bottom: 20px;
+}
+.bottom-menu ul {
+  padding: 0;
+  margin: 0;
+}
+.bottom-menu ul.menu .leaf {
+  list-style-image: none;
+  list-style-type: none;
+}
+.bottom-menu li {
+  list-style-type: none;
+  font-size: 1em;
+  margin: 0;
+  padding: 0;
+}
+.bottom-menu li.first a {
+  font-size: 1.4em;
+  line-height: 1.4em;
+  font-weight: bold;
+  min-height: 2.5em;
+}
+.bottom-menu li a {
+  font-size: 1.1em;
+  line-height: 1.4em;
+  margin: 0 0 .5em 0;
+}
+.bottom-menu a, .bottom-menu a:visited {
+  color: #ffffff;
+  text-decoration: none;
+  display: block;
+}
+.bottom-menu a:hover {
+  text-decoration: underline;
+}
+
+ul.breadcrumb {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.breadcrumb a {
+  color: #333;
+  text-decoration: none;
+}
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+.breadcrumb li {
+  margin: 0 3px 0 0;
+  padding: 0 3px 0 8px;
+  font-size: 1.2em;
+  color: #00684a;
+  background-image: url("../images/breadcrumb-arrow.png");
+  background-repeat: no-repeat;
+  background-position: left center;
+  float: left;
+}
+.breadcrumb li:first-child {
+  padding: 0;
+  background-image: none;
+}
+
+.breadcrumb-accessibility-wrapper {
+  border-top: 1px solid #348971;
+}
+
+.breadcrumb-accessibility-inner {
+  overflow: hidden;
+  margin: 12px 0;
+  min-height: 17px;
+}
+
+/**
+ * home page carousel 
+ * depends on block class: home-page-carousel and default skin for views slideshow
+*/
+.home-page-carousel {
+  margin-bottom: 20px;
+  /* slideshow size */
+  /* slide image */
+  /* slide content wrapper */
+  /* slide content */
+  /* slide controls and pager - outer wrapper */
+  /* slide controls wrapper */
+  /* previous button */
+  /* pause button */
+  /* play button */
+  /* next button */
+  /* slide pager wrapper */
+  /* pager items */
+  /* active pager item */
+}
+.home-page-carousel .skin-default {
+  width: 699px;
+  height: 230px;
+  overflow: hidden;
+  position: relative;
+}
+.home-page-carousel .views-field-field-slide-image {
+  z-index: 1;
+}
+.home-page-carousel .views-field-field-slide-image img {
+  -webkit-border-radius: 8px 8px 0 0;
+  -moz-border-radius: 8px 8px 0 0;
+  -o-border-radius: 8px 8px 0 0;
+  -ms-border-radius: 8px 8px 0 0;
+  border-radius: 8px 8px 0 0;
+}
+.home-page-carousel .slide-content-wrapper {
+  z-index: 2;
+  width: 400px;
+  max-height: 169px;
+  overflow: hidden;
+  position: absolute;
+  top: 24px;
+  left: 0px;
+  background-color: #000;
+  background-color: rgba(0, 0, 0, 0.65);
+}
+.home-page-carousel .slide-content {
+  padding: 16px;
+  font-size: 1em;
+}
+.home-page-carousel .slide-content h2 {
+  font-size: 2em;
+  margin-bottom: 0.3em;
+  color: #fff;
+}
+.home-page-carousel .slide-content p {
+  font-size: 1.5em;
+  margin-bottom: 0.4em;
+  color: #fff;
+}
+.home-page-carousel .slide-content a {
+  font-size: 1.2em;
+  text-decoration: none;
+  color: #fff;
+  display: block;
+  padding-left: 12px;
+  background-image: url("../images/white-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+}
+.home-page-carousel .slide-content a:hover {
+  text-decoration: underline;
+}
+.home-page-carousel .slide-content a:focus {
+  padding: 2px;
+  border: 1px solid #ff8000;
+}
+.home-page-carousel .views-slideshow-controls-bottom {
+  display: block;
+  width: 699px;
+  height: 27px;
+  position: absolute;
+  left: 0px;
+  bottom: 0px;
+  z-index: 90;
+  background-color: #000;
+  -webkit-border-radius: 0 0 8px 8px;
+  -moz-border-radius: 0 0 8px 8px;
+  -o-border-radius: 0 0 8px 8px;
+  -ms-border-radius: 0 0 8px 8px;
+  border-radius: 0 0 8px 8px;
+}
+.home-page-carousel .views-slideshow-controls-text {
+  z-index: 99;
+  width: 69px;
+  position: absolute;
+  bottom: 0px;
+  left: 16px;
+  padding: 3px;
+  background-color: #000;
+  overflow: hidden;
+}
+.home-page-carousel .views-slideshow-controls-text-previous {
+  display: block;
+  width: 21px;
+  height: 21px;
+  float: left;
+}
+.home-page-carousel .views-slideshow-controls-text-previous a {
+  display: block;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+  background-color: transparent;
+  background-image: url("../images/carousel-controls/slide-previous.jpg");
+  background-repeat: no-repeat;
+  background-position: center center;
+  text-decoration: none;
+  border: 1px solid #000;
+  text-indent: -400px;
+}
+.home-page-carousel .views-slideshow-controls-text-previous a:hover,
+.home-page-carousel .views-slideshow-controls-text-previous a:focus {
+  border: 1px solid #ff8000;
+  text-decoration: none;
+}
+.home-page-carousel .views-slideshow-controls-text-pause.views-slideshow-controls-text-status-play {
+  display: block;
+  width: 21px;
+  height: 21px;
+  float: left;
+}
+.home-page-carousel .views-slideshow-controls-text-pause.views-slideshow-controls-text-status-play a {
+  display: block;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+  background-color: transparent;
+  background-image: url("../images/carousel-controls/slide-pause.jpg");
+  background-repeat: no-repeat;
+  background-position: center center;
+  text-decoration: none;
+  border: 1px solid #000;
+  text-indent: -400px;
+}
+.home-page-carousel .views-slideshow-controls-text-pause.views-slideshow-controls-text-status-play a:hover,
+.home-page-carousel .views-slideshow-controls-text-pause.views-slideshow-controls-text-status-play a:focus {
+  border: 1px solid #ff8000;
+  text-decoration: none;
+}
+.home-page-carousel .views-slideshow-controls-text-pause.views-slideshow-controls-text-status-pause {
+  display: block;
+  width: 21px;
+  height: 21px;
+  float: left;
+}
+.home-page-carousel .views-slideshow-controls-text-pause.views-slideshow-controls-text-status-pause a {
+  display: block;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+  background-color: transparent;
+  background-image: url("../images/carousel-controls/slide-play.jpg");
+  background-repeat: no-repeat;
+  background-position: center center;
+  text-decoration: none;
+  border: 1px solid #000;
+  text-indent: -400px;
+}
+.home-page-carousel .views-slideshow-controls-text-pause.views-slideshow-controls-text-status-pause a:hover,
+.home-page-carousel .views-slideshow-controls-text-pause.views-slideshow-controls-text-status-pause a:focus {
+  border: 1px solid #ff8000;
+  text-decoration: none;
+}
+.home-page-carousel .views-slideshow-controls-text-next {
+  display: block;
+  width: 21px;
+  height: 21px;
+  float: left;
+}
+.home-page-carousel .views-slideshow-controls-text-next a {
+  display: block;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+  background-color: transparent;
+  background-image: url("../images/carousel-controls/slide-next.jpg");
+  background-repeat: no-repeat;
+  background-position: center center;
+  text-decoration: none;
+  border: 1px solid #000;
+  text-indent: -400px;
+}
+.home-page-carousel .views-slideshow-controls-text-next a:hover,
+.home-page-carousel .views-slideshow-controls-text-next a:focus {
+  border: 1px solid #ff8000;
+  text-decoration: none;
+}
+.home-page-carousel .views-slideshow-pager-fields {
+  z-index: 99;
+  width: 500px;
+  position: absolute;
+  bottom: 0px;
+  left: 99px;
+  padding: 3px;
+  overflow: hidden;
+  background-color: #000;
+  text-align: center;
+}
+.home-page-carousel .views-slideshow-pager-field-item {
+  display: block;
+  float: left;
+  width: 21px;
+  height: 21px;
+  margin: 0;
+}
+.home-page-carousel .views-slideshow-pager-field-item a {
+  display: block;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+  background-color: transparent;
+  background-image: url("../images/carousel-controls/slide-pager-bullet-default.jpg");
+  background-repeat: no-repeat;
+  background-position: center center;
+  text-decoration: none;
+  border: 1px solid #000;
+  text-indent: -400px;
+}
+.home-page-carousel .views-slideshow-pager-field-item a:hover,
+.home-page-carousel .views-slideshow-pager-field-item a:focus {
+  border: 1px solid #ff8000;
+  text-decoration: none;
+}
+.home-page-carousel .views-slideshow-pager-field-item.active a {
+  background-image: url("../images/carousel-controls/slide-pager-bullet-active.jpg");
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+
+/* for mobile */
+@media (min-width: 0px) and (max-width: 480px) {
+  .home-page-carousel {
+    display: none;
+  }
+}
+/* print styling overrides */
+@media print {
+  .home-page-carousel {
+    display: none;
+  }
+}
+/* list of committees
+ * requires block class: committee-list
+ */
+.committee-list h2.block__title {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+}
+.committee-list h3.views-field-title {
+  font-size: 1.3em;
+  line-height: 1.4em;
+  margin-bottom: 0;
+  font-weight: bold;
+}
+.committee-list .views-field-field-site-section {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  margin-bottom: 0.2em;
+}
+.committee-list .views-row {
+  padding-top: 0.7em;
+  padding-bottom: 0.7em;
+  border-top: 1px solid #7dac41;
+  border-bottom: 1px solid #dfeacf;
+}
+.committee-list .views-row.views-row-first {
+  border-top: 0;
+  padding-top: 0;
+}
+.committee-list .views-row.views-row-last {
+  margin-bottom: 18px;
+  border-bottom: 1px solid #7dac41;
+}
+
+/* print styling overrides */
+@media print {
+  .committee-list h2.block__title {
+    color: #000;
+    background: none;
+    background-color: transparent;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+  .committee-list .views-row,
+  .committee-list .views-row.views-row-last {
+    border: none;
+  }
+}
+/* default menus for committee sites
+ * Requires block class: committee-menu
+ */
+.l-sidebar-first .committee-menu {
+  border-top: 4px solid #646464;
+  margin-bottom: 12px;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper ul, .l-sidebar-first .committee-menu .menu-block-wrapper li,
+.l-sidebar-first .committee-menu .block__content ul,
+.l-sidebar-first .committee-menu .block__content li {
+  font-size: 1em;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper ul,
+.l-sidebar-first .committee-menu .block__content ul {
+  display: block;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper ul.menu .leaf,
+.l-sidebar-first .committee-menu .menu-block-wrapper ul.menu .expanded,
+.l-sidebar-first .committee-menu .menu-block-wrapper ul.menu .collapsed,
+.l-sidebar-first .committee-menu .menu-block-wrapper ul.menu li,
+.l-sidebar-first .committee-menu .block__content ul.menu .leaf,
+.l-sidebar-first .committee-menu .block__content ul.menu .expanded,
+.l-sidebar-first .committee-menu .block__content ul.menu .collapsed,
+.l-sidebar-first .committee-menu .block__content ul.menu li {
+  list-style-image: none;
+  list-style-type: none;
+  list-style: none;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper li,
+.l-sidebar-first .committee-menu .block__content li {
+  margin: 0;
+  padding: 0;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper a,
+.l-sidebar-first .committee-menu .block__content a {
+  font-size: 1.2em;
+  text-decoration: none;
+  border-top: 1px solid #fff;
+  border-bottom: 1px solid #c4c4c4;
+  background: #f0f0f0 url("../images/committee/committee-sidebar-arrow-right.png") 10px center no-repeat;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper a.active,
+.l-sidebar-first .committee-menu .block__content a.active {
+  color: #02684a;
+  font-weight: bold;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper a:hover,
+.l-sidebar-first .committee-menu .block__content a:hover {
+  text-decoration: underline;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper li a,
+.l-sidebar-first .committee-menu .block__content li a {
+  display: block;
+  padding: 8px 12px 8px 24px;
+  color: #333;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper li li a,
+.l-sidebar-first .committee-menu .block__content li li a {
+  padding-left: 33px;
+  background: #f7f7f7 url("../images/committee/committee-thin-right-arrow.png") 23px center no-repeat;
+}
+.l-sidebar-first .committee-menu .menu-block-wrapper li.expanded > a,
+.l-sidebar-first .committee-menu .block__content li.expanded > a {
+  color: #02684a;
+  font-weight: bold;
+}
+
+/* variation of menu fo footer - we use the same block in sidebar and in footer */
+.l-footer-menu .committee-menu {
+  position: relative;
+  left: -4px;
+}
+.l-footer-menu .committee-menu ul {
+  padding: 0;
+  margin: 0;
+}
+.l-footer-menu .committee-menu ul.menu .leaf {
+  list-style-image: none;
+  list-style-type: none;
+}
+.l-footer-menu .committee-menu ul ul {
+  display: none;
+}
+.l-footer-menu .committee-menu li {
+  font-size: 1.1em;
+  line-height: 1em;
+  display: inline-block;
+  margin: 0 0 0.909em 0;
+  padding: 0 5px 0 4px;
+  border-right: 1px solid #666;
+  *display: inline;
+  zoom: 1;
+}
+.l-footer-menu .committee-menu li.last {
+  border-right: none;
+}
+.l-footer-menu .committee-menu a, .l-footer-menu .committee-menu a:visited {
+  color: #666;
+  text-decoration: none;
+}
+.l-footer-menu .committee-menu a:hover {
+  text-decoration: underline;
+}
+.l-footer-menu .committee-menu a.active {
+  font-weight: normal;
+}
+
+/* committee news
+ * requires block class: committee news
+ */
+.committee-news {
+  clear: both;
+  /* block heading */
+  /* teaser title */
+  /* teaser summary */
+}
+.committee-news h2.block__title,
+.committee-news h3.block__title {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+}
+.committee-news .node__title {
+  font-weight: bold;
+  display: block;
+}
+.committee-news .node__title a {
+  text-decoration: none;
+  color: #006f51;
+}
+.committee-news .node__title a:hover {
+  text-decoration: underline;
+}
+.committee-news .field--name-field-summary {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  color: #333;
+  margin-bottom: 0.2em;
+}
+
+/* print styling overrides */
+@media print {
+  .committee-news h2.block__title,
+  .committee-news h3.block__title {
+    color: #000;
+    background: none;
+    background-color: #000;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+  .committee-news .node__title a {
+    color: #000;
+  }
+}
+/* committee papers - statement and positioning papers */
+.view-committee-papers-listing .view-content h3 {
+  display: block;
+  margin: 0 0 0.8em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #333;
+  background: #f0f0f0;
+}
+.view-committee-papers-listing .view-content .views-field-sm-field-subtitle {
+  font-size: 1.3em;
+  line-height: 1.4em;
+  margin-bottom: 0.5em;
+  font-weight: bold;
+}
+.view-committee-papers-listing .views-row-last {
+  margin-bottom: 15px;
+}
+
+/* print styling overrides */
+@media print {
+  .view-committee-papers-listing .view-content h3 {
+    color: #000;
+  }
+}
+/* consultation page - consultation content type */
+.field--name-field-consultations-contact-name,
+.field--name-field-consultation-contact-add,
+.field--name-field-consultation-contact-tel,
+.field--name-field-consultation-contact-fax,
+.field--name-field-consultation-contact-email,
+.field--name-field-consultation-dates,
+.field--name-field-consultation-state,
+.field--name-field-data-protection,
+.field--name-field-consultation-pack .field__label {
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+.field--name-field-consultations-contact-name p, .field--name-field-consultations-contact-name ul, .field--name-field-consultations-contact-name li, .field--name-field-consultations-contact-name ol,
+.field--name-field-consultation-contact-add p,
+.field--name-field-consultation-contact-add ul,
+.field--name-field-consultation-contact-add li,
+.field--name-field-consultation-contact-add ol,
+.field--name-field-consultation-contact-tel p,
+.field--name-field-consultation-contact-tel ul,
+.field--name-field-consultation-contact-tel li,
+.field--name-field-consultation-contact-tel ol,
+.field--name-field-consultation-contact-fax p,
+.field--name-field-consultation-contact-fax ul,
+.field--name-field-consultation-contact-fax li,
+.field--name-field-consultation-contact-fax ol,
+.field--name-field-consultation-contact-email p,
+.field--name-field-consultation-contact-email ul,
+.field--name-field-consultation-contact-email li,
+.field--name-field-consultation-contact-email ol,
+.field--name-field-consultation-dates p,
+.field--name-field-consultation-dates ul,
+.field--name-field-consultation-dates li,
+.field--name-field-consultation-dates ol,
+.field--name-field-consultation-state p,
+.field--name-field-consultation-state ul,
+.field--name-field-consultation-state li,
+.field--name-field-consultation-state ol,
+.field--name-field-data-protection p,
+.field--name-field-data-protection ul,
+.field--name-field-data-protection li,
+.field--name-field-data-protection ol,
+.field--name-field-consultation-pack .field__label p,
+.field--name-field-consultation-pack .field__label ul,
+.field--name-field-consultation-pack .field__label li,
+.field--name-field-consultation-pack .field__label ol {
+  font-size: 1em;
+  line-height: 1.4em;
+}
+
+.field--name-field-consultation-pack .field__label,
+.field--name-field-consultation-pack label {
+  margin-bottom: 0.8em;
+  display: block;
+}
+
+.field--name-field-consultation-pack .file-item {
+  font-size: 1.3em;
+  font-weight: normal;
+  margin-bottom: 0.5em;
+  font-size: 1.3em;
+}
+
+/* these are file fields get their theming from the base styles for file field within its content */
+.field--name-field-consultation-pack,
+.field--name-field-consultation-summary {
+  font-size: 1em;
+}
+
+/* consultations summary */
+.field--name-field-consultation-summary {
+  margin-bottom: 1.3em;
+}
+
+/* contact details */
+.node-type-consultation .group-contact-details {
+  margin-bottom: 1.3em;
+}
+
+/* section headings for consultation main content area */
+.node-type-consultation #main-content {
+  /* section headings from the field collection */
+  /* toc block */
+}
+.node-type-consultation #main-content .node h2,
+.node-type-consultation #main-content h2.block__title {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+  clear: both;
+}
+.node-type-consultation #main-content .node .page-section-heading h2 {
+  font-size: 1em;
+  margin: 0;
+  padding: 0;
+}
+.node-type-consultation #main-content #block-toc-node-toc-node {
+  clear: both;
+}
+.node-type-consultation #main-content #block-toc-node-toc-node h2.block__title {
+  color: #333;
+  padding: 0;
+  background: none;
+  font-size: 1.5em;
+  line-height: 1.2em;
+  font-weight: bold;
+  margin: 0 0 .45em 0;
+}
+
+/* some spacng at the bottom of groups and blocks */
+.node-type-consultation #main-content .field-group-div,
+.node-type-consultation #main-content .block {
+  padding-bottom: 15px;
+  overflow: hidden;
+}
+.node-type-consultation #main-content .group-contact-details.field-group-div {
+  padding-bottom: 5px;
+}
+
+/* overrides for consultation and summary of responses file-blocks 
+ * requires block class: file-block
+ * implementation of styling for file-block, see _file_block.scss
+ */
+.node-type-consultation #main-content .file-block.block {
+  padding: 0;
+  margin-bottom: 18px;
+}
+.node-type-consultation #main-content .file-block.block h2.block__title {
+  display: block;
+  margin: 0 0 0.7em 0;
+  padding: 12px 10px 0px 10px;
+  color: #5d9711;
+  background: none;
+  font-size: 1.4em;
+  line-height: 1.3em;
+  font-weight: bold;
+}
+
+/* contacts listing
+ * requires block class: contact-glossary
+ */
+.contact-glossary {
+  /* glossary alphabet a-z */
+}
+.contact-glossary ul.contacts_alphabet {
+  padding-left: 0;
+  margin-left: 0;
+  margin-bottom: 1.2em;
+  overflow: hidden;
+}
+.contact-glossary ul.contacts_alphabet li {
+  float: left;
+  list-style-type: none;
+  padding: 0 5px 5px 0;
+  font-size: 1.4em;
+}
+.contact-glossary ul.contacts_alphabet li a {
+  display: block;
+  text-decoration: none;
+  color: #fff;
+  background: #5d9711;
+  font-weight: bold;
+  text-align: center;
+  min-width: 2.1em;
+  padding: 8px 8px;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  -o-border-radius: 10px;
+  border-radius: 10px;
+  line-height: 1.2em;
+}
+.contact-glossary ul.contacts_alphabet li a:hover {
+  text-decoration: underline;
+}
+.contact-glossary ul.contacts_alphabet li span.non_link_objects {
+  display: block;
+  text-decoration: none;
+  color: #fff;
+  background: #666;
+  font-weight: bold;
+  text-align: center;
+  min-width: 2.1em;
+  padding: 8px 8px;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  -o-border-radius: 10px;
+  border-radius: 10px;
+  line-height: 1.2em;
+}
+.contact-glossary .view-content {
+  clear: left;
+  /* hide empty h3 spacers */
+  /* alphabet section headings */
+}
+.contact-glossary .view-content h3 {
+  display: none;
+}
+.contact-glossary .view-content h2 {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+}
+.contact-glossary .view-content .views-row {
+  /* category title */
+  /* contact content */
+}
+.contact-glossary .view-content .views-row h3,
+.contact-glossary .view-content .views-row h3.node__title {
+  display: block;
+  font-size: 1.2em;
+  line-height: 1.5em;
+  margin-bottom: 0.5em;
+  padding: .3em 11px;
+  font-weight: bold;
+  color: #333;
+  background: #f0f0f0;
+}
+.contact-glossary .view-content .views-row h4,
+.contact-glossary .view-content .views-row h4.node__title {
+  font-size: 1.2em;
+  line-height: 1.5em;
+  margin-bottom: 0.5em;
+}
+.contact-glossary .view-content .views-row p {
+  margin-bottom: 0.5em;
+}
+.contact-glossary .view-content .views-row .field--name-field-phone-number,
+.contact-glossary .view-content .views-row .field--name-field-fax {
+  font-size: 1.2em;
+  line-height: 1.5em;
+  margin-bottom: 0.5em;
+}
+.contact-glossary .view-content .views-row .node__content {
+  margin-bottom: 8px;
+  padding-left: 11px;
+  padding-right: 11px;
+  overflow: hidden;
+}
+.contact-glossary .view-content .views-row .node__content .node__content {
+  padding: 0;
+  margin-bottom: 8px;
+}
+
+/* print styling overrides */
+@media print {
+  .contact-glossary ul.contacts_alphabet li a {
+    color: #000;
+  }
+  .contact-glossary ul.contacts_alphabet {
+    display: none;
+  }
+  .contact-glossary .view-content h2 {
+    color: #000;
+    background: none;
+    background-color: transparent;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+  .contact-glossary .views-row h3,
+  .contact-glossary .views-row h3.node__title {
+    color: #000;
+  }
+}
+.main-wrapper {
+  border-bottom: 4px solid #68A82A;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  .main-wrapper {
+    border-bottom: 4px solid #006f51;
+  }
+}
+.content-top {
+  /* stops the region from collapsing when content is floated within it */
+  *zoom: 1;
+}
+.content-top:after {
+  content: "\0020";
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+/* requires block class: current-topics and block class: blue-block */
+.current-topics {
+  font-size: 1em;
+  line-height: 1.4em;
+  /* node title */
+  /* subtitle */
+  /* teaser updated date */
+  /* teaser summary */
+  /* node links like read more (if enabled) */
+  /* line separator */
+}
+.current-topics h2.node__title {
+  font-size: 1.3em;
+  line-height: 1.4em;
+  margin-bottom: 1px;
+  font-weight: normal;
+}
+.current-topics .node__title {
+  font-weight: normal;
+  display: block;
+  margin-bottom: 1px;
+}
+.current-topics .node__title a {
+  text-decoration: none;
+  color: #00416c;
+  font-weight: bold;
+}
+.current-topics .node__title a:hover {
+  text-decoration: underline;
+}
+.current-topics h3 {
+  margin-bottom: 1px;
+}
+.current-topics .field--name-field-subtitle {
+  font-size: 1.1em;
+  line-height: 1.4em;
+  display: block;
+}
+.current-topics .field--name-field-updated {
+  font-size: 1.1em;
+  margin-bottom: 0.2em;
+}
+.current-topics .field--name-field-summary {
+  font-size: 1.1em;
+  line-height: 1.4em;
+  display: block;
+  color: #333;
+  margin-bottom: 0.2em;
+}
+.current-topics .field__item {
+  margin-bottom: 0.5em;
+}
+.current-topics .node__links a {
+  text-decoration: none;
+  color: #00416c;
+}
+.current-topics .node__links a:hover {
+  text-decoration: underline;
+}
+.current-topics .views-row {
+  border-bottom: 1px solid #c6d7dd;
+  padding-bottom: 2px;
+  margin-bottom: 5px;
+}
+.current-topics .views-row.views-row-last {
+  border-bottom: none;
+  padding-bottom: 2px;
+  margin-bottom: 0;
+}
+
+/* positioning of block on landing page */
+.node-type-landing-page .current-topics {
+  width: 225px;
+  margin-right: 6px;
+  float: left;
+}
+
+/* mobile view */
+@media (min-width: 0px) and (max-width: 480px) {
+  .node-type-landing-page .current-topics {
+    font-size: 1.1em;
+    width: 100%;
+    margin-right: 0px;
+    float: none;
+  }
+}
+/* print styling overrides */
+@media print {
+  .current-topics {
+    clear: both;
+    float: none;
+    width: auto;
+    margin-right: 0;
+  }
+  .current-topics .node__title a,
+  .current-topics .field--name-field-summary,
+  .current-topics .node__links a {
+    color: #000;
+  }
+  .current-topics .node__title a {
+    font-weight: normal;
+  }
+  .current-topics .views-row {
+    border-bottom: none;
+  }
+
+  .node-type-landing-page .current-topics {
+    width: auto;
+    margin-right: 0;
+    float: none;
+  }
+}
+/* last updated - when used directly on a content type */
+.field--name-field-updated {
+  font-size: 1.2em;
+  margin-bottom: 12px;
+}
+
+/* last updated - when used via a view field */
+.views-field-field-updated,
+.views-field-field-display-updated-date {
+  font-size: 1.2em;
+  margin-bottom: 12px;
+}
+.views-field-field-updated span.views-label,
+.views-field-field-display-updated-date span.views-label {
+  font-weight: bold;
+  display: inline-block;
+  *display: inline;
+  zoom: 1;
+}
+.views-field-field-updated div.field-content,
+.views-field-field-display-updated-date div.field-content {
+  display: inline-block;
+  *display: inline;
+  zoom: 1;
+}
+
+/**
+ * External sites block (the one without the logos)
+ * Dependant on block class: external-sites
+ */
+.external-sites {
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+  /* block title */
+  /* links */
+}
+.external-sites .custom-block-inner {
+  background: #fff;
+  padding: 1em 11px 1em 11px;
+  /* gradient */
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjMyJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNmMGYwZjAiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 32%, #f0f0f0 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(32%, white), color-stop(100%, #f0f0f0));
+  background: -webkit-linear-gradient(top, white 0, white 32%, #f0f0f0 100%);
+  background: -o-linear-gradient(top, white 0, white 32%, #f0f0f0 100%);
+  background: -ms-linear-gradient(top, white 0, white 32%, #f0f0f0 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 32%, #f0f0f0 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#f0f0f0',GradientType=0);
+}
+.external-sites h2.block__title {
+  font-size: 1.5em;
+  color: #5d9711;
+  margin: 0 0 .5em 0;
+}
+.external-sites .views-field-field-url {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  padding-left: 10px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+  margin-bottom: 2px;
+}
+.external-sites .views-field-field-url a {
+  text-decoration: none;
+  color: #006f51;
+}
+.external-sites .views-field-field-url a:hover {
+  text-decoration: underline;
+}
+.external-sites .views-field-field-subtitle {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  padding-left: 10px;
+}
+.external-sites .views-row {
+  margin-bottom: 0.834em;
+}
+.external-sites .views-row.views-row-last {
+  margin-bottom: 0;
+}
+.external-sites .external-link-disclaimer {
+  font-size: 1em;
+  line-height: 1.2em;
+  color: #666;
+  display: block;
+  padding-top: 9px;
+}
+
+/**
+ * External links block (the one with the logos)
+ * Dependant on block class: external-sites-with-logos
+ */
+.external-sites-with-logos {
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+  background: #fff;
+  padding: 1em 11px 1em 11px;
+  /* block title */
+  /* links */
+}
+.external-sites-with-logos h2.block__title {
+  font-size: 1.5em;
+  color: #5d9711;
+  margin: 0 0 .5em 0;
+  display: none;
+}
+.external-sites-with-logos .views-field-field-url {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  padding-left: 10px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+  margin-bottom: 2px;
+}
+.external-sites-with-logos .views-field-field-url a {
+  text-decoration: none;
+  color: #006f51;
+}
+.external-sites-with-logos .views-field-field-url a:hover {
+  text-decoration: underline;
+}
+.external-sites-with-logos .views-field-field-subtitle {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  padding-left: 10px;
+}
+.external-sites-with-logos .views-row {
+  margin-bottom: 0.834em;
+}
+.external-sites-with-logos .views-row.views-row-last {
+  margin-bottom: 1em;
+}
+.external-sites-with-logos .views-row.views-row-last:last-child {
+  margin-bottom: 0;
+}
+.external-sites-with-logos .view-content h2, .external-sites-with-logos .view-content h3 {
+  margin-bottom: 0;
+  font-size: 1em;
+}
+
+/* Foodbase links
+ * Requires block class: foodbase-links
+ */
+.foodbase-links {
+  /* links */
+}
+.foodbase-links .views-field-field-url {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  padding-left: 10px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+  margin-bottom: 2px;
+}
+.foodbase-links .views-field-field-url a {
+  text-decoration: none;
+  color: #006f51;
+}
+.foodbase-links .views-field-field-url a:hover {
+  text-decoration: underline;
+}
+.foodbase-links .views-field-field-subtitle {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  padding-left: 10px;
+}
+.foodbase-links .views-row {
+  margin-bottom: 0.834em;
+}
+.foodbase-links .views-row.views-row-last {
+  margin-bottom: 0;
+}
+
+/* foodbase links block styling */
+.foodbase-links {
+  overflow: hidden;
+  border: 1px solid #c4c4c4;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+  margin-bottom: 18px;
+}
+.foodbase-links h2.block__title,
+.foodbase-links h3.block__title,
+.foodbase-links .block__title {
+  display: block;
+  margin: 0 0 0.7em 0;
+  padding: 12px 10px 0px 10px;
+  color: #5d9711;
+  background: none;
+  font-size: 1.4em;
+  line-height: 1.3em;
+  font-weight: bold;
+}
+.foodbase-links .custom-block-inner {
+  overflow: hidden;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjQ2JSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlYWVhZWEiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(46%, white), color-stop(100%, #eaeaea));
+  background: -webkit-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -o-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -ms-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 46%, #eaeaea 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#eaeaea',GradientType=0);
+}
+.foodbase-links .custom-block-content-inner {
+  padding: 0px 10px 12px 10px;
+}
+
+/* print styling overrides */
+@media print {
+  .external-sites,
+  .external-sites-with-logos,
+  .foodbase-links {
+    display: none;
+  }
+}
+/* override default accordion theming */
+.field--name-field-fc-qanda {
+  margin-bottom: 20px;
+}
+.field--name-field-fc-qanda .ui-accordion .ui-accordion-header {
+  margin-top: 0;
+}
+.field--name-field-fc-qanda .ui-corner-all {
+  -moz-border-radius: 0px;
+  -webkit-border-radius: 0px;
+  -o-border-radius: 0px;
+  -ms-border-radius: 0px;
+  border-radius: 0px;
+}
+.field--name-field-fc-qanda .ui-state-default,
+.field--name-field-fc-qanda .ui-widget-content .ui-state-default,
+.field--name-field-fc-qanda .ui-widget-header .ui-state-default {
+  border: none;
+  background: none;
+  background-color: none;
+  color: #333;
+}
+.field--name-field-fc-qanda .ui-state-active,
+.field--name-field-fc-qanda .ui-widget-content .ui-state-active,
+.field--name-field-fc-qanda .ui-widget-header .ui-state-active {
+  border: none;
+  background: none;
+  background-color: none;
+  color: #333;
+}
+.field--name-field-fc-qanda .ui-widget-content {
+  border: none;
+  background: none;
+  background-color: none;
+  color: #333;
+}
+
+.field--name-field-fc-qanda.ui-widget {
+  font-family: Arial, Verdana, Helvetica, sans-serif;
+  font-size: 1em;
+}
+
+/* accordion tabs */
+.field--name-field-fc-qanda > .field__items > .field__item {
+  border-top: 1px solid #5D9711;
+}
+
+.field--name-field-fc-qanda > .field__items > .field__item:last-child {
+  border-bottom: 1px solid #5D9711;
+}
+
+/* accordion questions */
+.field--name-field-fc-quanda-question {
+  /* remove default ui icons */
+}
+.field--name-field-fc-quanda-question h2 {
+  color: #006f51;
+  padding-left: 24px;
+  background-image: url("../images/sidebar-arrow-right.png");
+  background-repeat: no-repeat;
+  background-position: 10px 4px;
+  margin-top: 8px;
+  margin-bottom: 10px;
+  font-size: 1.3em;
+}
+.field--name-field-fc-quanda-question h2:hover {
+  text-decoration: underline;
+}
+.field--name-field-fc-quanda-question span.ui-icon {
+  display: none;
+}
+
+.field--name-field-fc-quanda-question.ui-state-active h2 {
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 9px 4px;
+}
+
+/* accordion answers */
+.field--name-field-fc-quanda-answer.ui-accordion .ui-accordion-content {
+  padding: 0 0 0 24px;
+}
+
+div.field.field--name-field-fc-quanda-answer.field--type-text-long.field--label-hidden.ui-accordion-content.ui-helper-reset.ui-widget-content.ui-corner-bottom.ui-accordion-content-active {
+  padding: 0 0 0 24px;
+}
+
+/* print styling overrides */
+@media print {
+  .field--name-field-fc-qanda .ui-state-default,
+  .field--name-field-fc-qanda .ui-widget-content .ui-state-default,
+  .field--name-field-fc-qanda .ui-widget-header .ui-state-default {
+    color: #000;
+  }
+  .field--name-field-fc-qanda .ui-state-active,
+  .field--name-field-fc-qanda .ui-widget-content .ui-state-active,
+  .field--name-field-fc-qanda .ui-widget-header .ui-state-active {
+    color: #000;
+  }
+  .field--name-field-fc-qanda .ui-widget-content {
+    color: #000;
+  }
+
+  .field--name-field-fc-qanda > .field__items > .field__item {
+    border-top: 1px solid #000;
+  }
+
+  .field--name-field-fc-qanda > .field__items > .field__item:last-child {
+    border-bottom: 1px solid #000;
+  }
+
+  .field--name-field-fc-quanda-question h2 {
+    color: #000;
+  }
+
+  /* force collapsed questions to be expanded when we print them */
+  #field_collection_item_field_fc_qanda_full_group_accordion_set {
+    display: block !important;
+  }
+}
+/* Feature blocks are: Business and industry, Enforcement and regulation, Science and policy 
+ * requires block classes: feature-block green-block and for the last block we also use the class: last
+ * block styling comes from base styles and block content styling comes from this style sheet.
+ */
+.feature-block {
+  width: 225px;
+  margin-right: 12px;
+  margin-bottom: 40px;
+  overflow: hidden;
+  float: left;
+  /* feature image */
+  /* image mask overay - for curved bottom */
+  /* view footer */
+  /* links list */
+}
+.feature-block span.image-wrapper {
+  display: block;
+  position: relative;
+  width: 225px;
+  height: 95px;
+  overflow: hidden;
+}
+.feature-block span.image-mask {
+  overflow: hidden;
+  display: block;
+  width: 225px;
+  height: 95px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: url("../images/home-page-image-mask.png") 0 0 no-repeat;
+}
+.feature-block .view-footer {
+  padding-top: 0.5em;
+  margin-left: 10px;
+  margin-right: 10px;
+}
+.feature-block .block__content ul {
+  display: block;
+  margin: 8px 0 0 0;
+  padding: 0;
+}
+.feature-block .block__content ul li {
+  margin: 0 0 0.3em 0;
+  padding: 0 0 0 8px;
+  list-style: none;
+  list-style-type: none;
+  list-style-image: none;
+}
+.feature-block .block__content ul li a {
+  padding-left: 14px;
+  display: block;
+  text-decoration: none;
+  background-image: url("../images/orange-arrow-thin-right.png");
+  background-position: left 3px;
+  background-repeat: no-repeat;
+}
+.feature-block .block__content ul li a:hover {
+  text-decoration: underline;
+}
+
+/* no right margin on last feature block */
+.feature-block.last {
+  margin-right: 0px;
+}
+
+/* block styling */
+.feature-block {
+  overflow: hidden;
+  -moz-border-radius: 9px;
+  -webkit-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+}
+.feature-block h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 10px;
+  margin: 0;
+  background: #3b9356;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #3b9356), color-stop(100%, #02684a));
+  background: -webkit-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -o-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -ms-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: linear-gradient(top, #3b9356 0%, #02684a 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#3b9356',endColorstr='#02684a',GradientType=0);
+}
+.feature-block .block__content {
+  overflow: hidden;
+  padding: 0 0 0.8em 0;
+  background: #dde9c9;
+}
+.feature-block .block__content .custom-block-content-inner {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, #dde9c9 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(100%, #dde9c9));
+  background: -webkit-linear-gradient(top, white 0, #dde9c9 100%);
+  background: -o-linear-gradient(top, white 0, #dde9c9 100%);
+  background: -ms-linear-gradient(top, white 0, #dde9c9 100%);
+  background: linear-gradient(top, #ffffff 0%, #dde9c9 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#dde9c9',GradientType=0);
+}
+
+.l-content .feature-block {
+  margin-bottom: 40px;
+}
+
+/* for mobile */
+@media (min-width: 0px) and (max-width: 480px) {
+  .l-content .feature-block {
+    margin-bottom: 11px;
+  }
+
+  .feature-block {
+    display: none;
+  }
+}
+/* print styling overrides */
+@media print {
+  .feature-block {
+    display: none;
+  }
+}
+/**
+ * Requires block class: featured-side-content
+ */
+.featured-side-content {
+  overflow: hidden;
+  /* displayed as unordered list - make adjustments */
+  /* content title per featured block instance */
+  /* content main text body per featured block instance */
+  /* wrapper per featured block field collection instance */
+  /* first featured item */
+}
+.featured-side-content p {
+  font-size: 1em;
+}
+.featured-side-content ul, .featured-side-content li {
+  font-size: 1em;
+  list-style-type: none;
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+}
+.featured-side-content .field--name-field-title-side-content-generic {
+  font-size: 1.5em;
+  color: #4b800d;
+  padding: 0;
+  margin: .15em 0 .3em 0;
+}
+.featured-side-content .field--name-field-title-side-content-generic h1, .featured-side-content .field--name-field-title-side-content-generic h2, .featured-side-content .field--name-field-title-side-content-generic h3, .featured-side-content .field--name-field-title-side-content-generic h4, .featured-side-content .field--name-field-title-side-content-generic h5, .featured-side-content .field--name-field-title-side-content-generic h6 {
+  padding: 0;
+  margin: 0;
+  font-size: 1em;
+}
+.featured-side-content .field--name-field-body-side-content-generic {
+  font-size: 1.2em;
+  line-height: 1.3em;
+}
+.featured-side-content .field-collection-view {
+  overflow: hidden;
+  border: 1px solid #c4c4c4;
+  background: #fff;
+  padding: .5em 11px .3em 11px;
+  margin-bottom: 11px;
+  overflow: hidden;
+  clear: both;
+}
+.featured-side-content .field-collection-view img {
+  max-width: 100%;
+  height: auto;
+}
+.featured-side-content li:first-child .field-collection-view {
+  border: 1px solid #5d9711;
+  background: #5d9711;
+  color: #fff;
+}
+.featured-side-content li:first-child .field-collection-view a {
+  color: #fff;
+}
+.featured-side-content li:first-child .field-collection-view .field--name-field-title-side-content-generic {
+  color: #fff;
+  font-weight: bold;
+}
+.featured-side-content li:first-child .field-collection-view span.ext {
+  background: url("../images/icons/external-link-icon-white.png") right center no-repeat;
+}
+
+/* remove bottom margin of block - inner content already has bottom margin */
+.l-region--sidebar-second .block.featured-side-content {
+  margin-bottom: 0;
+}
+
+/* print styling overrides */
+@media print {
+  .featured-side-content .field--name-field-title-side-content-generic {
+    coloe: #000;
+  }
+  .featured-side-content .field-collection-view {
+    border: 1px solid #000;
+    background: transparent;
+  }
+  .featured-side-content li:first-child .field-collection-view {
+    border: 1px solid #000;
+    background: transparent;
+    color: #000;
+  }
+  .featured-side-content li:first-child .field-collection-view a {
+    color: #000;
+  }
+  .featured-side-content li:first-child .field-collection-view .field--name-field-title-side-content-generic {
+    color: #000;
+    font-weight: bold;
+  }
+  .featured-side-content li:first-child .field-collection-view span.ext {
+    background: none;
+    display: none;
+  }
+}
+/* overrides for zendesk feedback widget */
+/*
+body #zenbox_tab {
+	position: fixed;
+	bottom: 3%;
+}
+*/
+/* hide feedback tab for smaller screens - that are smaller than the popup form width */
+/*
+@media all and (max-width: 640px) {
+	body #zenbox_tab,
+	#zenbox_overlay {
+		display: none;
+	}
+}
+*/
+/* hide the extra feedback tab on the Drupal editing overlay */
+/*
+.overlay-open body {
+	#zenbox_tab,
+	#zenbox_overlay {
+		display: none;
+	}
+}
+*/
+/* Styling for blocks with files, similar to the file styling on page sections
+ * requires block style: file-block. Styles the block but not its contents
+ */
+.file-block {
+  overflow: hidden;
+  border: 1px solid #c4c4c4;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+  margin-bottom: 18px;
+}
+.file-block h2.block__title,
+.file-block h3.block__title,
+.file-block .block__title {
+  display: block;
+  margin: 0 0 0.7em 0;
+  padding: 12px 10px 0px 10px;
+  color: #5d9711;
+  background: none;
+  font-size: 1.4em;
+  line-height: 1.3em;
+  font-weight: bold;
+}
+.file-block .custom-block-inner {
+  overflow: hidden;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjQ2JSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlYWVhZWEiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(46%, white), color-stop(100%, #eaeaea));
+  background: -webkit-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -o-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -ms-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 46%, #eaeaea 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#eaeaea',GradientType=0);
+}
+.file-block .custom-block-content-inner {
+  padding: 0px 10px 12px 10px;
+}
+
+/* print styling overrides */
+@media print {
+  .file-block {
+    display: none;
+  }
+}
+/**
+ * Footer buttons
+ * Dependant on menu bock and block class: footer-buttons
+ */
+.footer-buttons {
+  /* menu block block does not seem to respect <none> in title */
+  /* override external links module css */
+}
+.footer-buttons h2.block__title {
+  display: none;
+}
+.footer-buttons ul.menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  float: right;
+}
+.footer-buttons ul.menu li {
+  font-size: 1em;
+  list-style: none;
+  display: block;
+  float: left;
+  padding: 0;
+  margin: 0 0 10px 8px;
+}
+.footer-buttons ul.menu li a {
+  display: block;
+  width: 77px;
+  height: 31px;
+  text-indent: -500px;
+  overflow: hidden;
+}
+.footer-buttons ul.menu li a[href="http://www.nhs.uk"],
+.footer-buttons ul.menu li a[href="https://www.nhs.uk"] {
+  background: url("../images/footer-buttons/nhschoices-default.png");
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+.footer-buttons ul.menu li a[href="http://www.nhs.uk"]:hover,
+.footer-buttons ul.menu li a[href="https://www.nhs.uk"]:hover,
+.footer-buttons ul.menu li a[href="http://www.nhs.uk"]:focus,
+.footer-buttons ul.menu li a[href="https://www.nhs.uk"]:focus {
+  background: url("../images/footer-buttons/nhschoices-hover.png");
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+.footer-buttons ul.menu li a[href="http://www.gov.uk"],
+.footer-buttons ul.menu li a[href="https://www.gov.uk"] {
+  background: url("../images/footer-buttons/govuk-default.png");
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+.footer-buttons ul.menu li a[href="http://www.gov.uk"]:hover,
+.footer-buttons ul.menu li a[href="https://www.gov.uk"]:hover,
+.footer-buttons ul.menu li a[href="http://www.gov.uk"]:focus,
+.footer-buttons ul.menu li a[href="https://www.gov.uk"]:focus {
+  background: url("../images/footer-buttons/govuk-hover.png");
+  background-repeat: no-repeat;
+  background-position: center center;
+}
+.footer-buttons span.ext {
+  display: none;
+}
+
+/* for mobile */
+@media (min-width: 0px) and (max-width: 480px) {
+  .footer-buttons {
+    margin-top: 6px;
+  }
+  .footer-buttons ul.menu {
+    float: none;
+  }
+  .footer-buttons ul.menu li {
+    margin: 0 8px 10px 0;
+  }
+}
+.footer-menu {
+  position: relative;
+  left: -4px;
+}
+.footer-menu ul {
+  padding: 0;
+  margin: 0;
+}
+.footer-menu ul.menu .leaf {
+  list-style-image: none;
+  list-style-type: none;
+}
+.footer-menu li {
+  font-size: 1.1em;
+  line-height: 1em;
+  display: inline-block;
+  margin: 0 0 0.909em 0;
+  padding: 0 5px 0 4px;
+  border-right: 1px solid #666;
+  *display: inline;
+  zoom: 1;
+}
+.footer-menu li.last {
+  border-right: none;
+}
+.footer-menu a, .footer-menu a:visited {
+  color: #666;
+  text-decoration: none;
+}
+.footer-menu a:hover {
+  text-decoration: underline;
+}
+.footer-menu a.active {
+  font-weight: normal;
+}
+
+.footer-wrapper {
+  background: #f1f1f1;
+  border-bottom: 16px solid #FFF;
+}
+
+.footer-wrapper-inner {
+  border-top: 1px solid #f9f9f9;
+  border-bottom: 1px solid #f6f6f6;
+}
+
+.footer-inner {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+span.copyright {
+  display: block;
+  font-size: 1.1em;
+  line-height: 1em;
+  margin-bottom: 0.909em;
+  color: #333;
+}
+
+/**
+ * @file
+ * SASS styles for the social media footer
+ */
+.footer-social-media-wrapper {
+  background: #2a8641;
+  background: -moz-linear-gradient(top, #2a8641 0, #016c4e 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #2a8641), color-stop(100%, #016c4e));
+  background: -webkit-linear-gradient(top, #2a8641 0, #016c4e 100%);
+  background: -o-linear-gradient(top, #2a8641 0, #016c4e 100%);
+  background: -ms-linear-gradient(top, #2a8641 0, #016c4e 100%);
+  background: linear-gradient(to top, #2a8641 0%, #016c4e 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#2a8641',endColorstr='#016c4e',GradientType=0);
+}
+@media (min-width: 481px) {
+  .footer-social-media-wrapper {
+    display: none;
+  }
+}
+.footer-social-media-wrapper .social-media-icons {
+  margin: 0 auto;
+  max-width: 365px;
+  padding: 20px 6px;
+  top: auto;
+}
+.footer-social-media-wrapper .social-media-icons .block__content li {
+  margin-right: 10px;
+}
+.footer-social-media-wrapper .social-media-icons .block__content li:last-child, .footer-social-media-wrapper .social-media-icons .block__content li.last {
+  margin-right: 0;
+}
+.footer-social-media-wrapper .social-media-icons .block__content li img {
+  height: auto;
+  width: auto;
+}
+.footer-social-media-wrapper .social-media-icons .block__content .right-label {
+  margin-left: 142px;
+}
+.footer-social-media-wrapper .social-media-icons .block__content .label-wrapper {
+  font-size: 1.2em;
+  margin-bottom: 10px;
+}
+@media print {
+  .footer-social-media-wrapper {
+    display: none;
+  }
+}
+
+/* FSA in the nations block on home page
+ * depends on custom html in the block
+ * requires bock class: fsa-in-the-nations
+ */
+.fsa-in-the-nations {
+  max-height: 269px;
+  clear: both;
+}
+.fsa-in-the-nations h2 {
+  display: none;
+}
+.fsa-in-the-nations .nation-icon-link {
+  position: absolute;
+  right: 10px;
+  top: 50px;
+}
+.fsa-in-the-nations .block__content a {
+  text-decoration: none;
+}
+.fsa-in-the-nations .block__content a:hover {
+  text-decoration: underline;
+}
+.fsa-in-the-nations .block__content h3 {
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+  -ms-border-radius: 5px;
+  -o-border-radius: 5px;
+  border-radius: 5px;
+  color: #fff;
+  font-size: 1em;
+  font-weight: bold;
+  padding: 5px 11px;
+  margin: 0 0 0.5em 0;
+  width: 100%;
+}
+.fsa-in-the-nations .block__content h3 a img {
+  display: none;
+  position: absolute;
+  top: 12px;
+  right: 0;
+  border: 0;
+}
+.fsa-in-the-nations .block__content h3 a {
+  color: #fff;
+  font-size: 1.4em;
+  line-height: 1.4em;
+}
+.fsa-in-the-nations .block__content ul {
+  list-style: none;
+  margin: 0 0 1.2em 0;
+  padding: 0;
+  font-size: 1em;
+  display: block;
+  clear: both;
+  overflow: hidden;
+}
+.fsa-in-the-nations .block__content li {
+  margin-left: 0;
+  font-size: 1em;
+}
+.fsa-in-the-nations .block__content .scotland {
+  display: none;
+  position: relative;
+  min-height: 75px;
+}
+.fsa-in-the-nations .block__content .northern-ireland {
+  position: relative;
+  min-height: 75px;
+}
+.fsa-in-the-nations .block__content .northern-ireland h3 {
+  background-color: #800c6f;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #800c6f 6%, #660459 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(6%, #800c6f), color-stop(100%, #660459));
+  background: -webkit-linear-gradient(top, #800c6f 6%, #660459 100%);
+  background: -o-linear-gradient(top, #800c6f 6%, #660459 100%);
+  background: -ms-linear-gradient(top, #800c6f 6%, #660459 100%);
+  background: linear-gradient(top, #800c6f 6%, #660459 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#800c6f',endColorstr='#660459',GradientType=0);
+}
+.fsa-in-the-nations .block__content .wales {
+  position: relative;
+  min-height: 61px;
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+.fsa-in-the-nations .block__content .wales h3 {
+  background-color: #888;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #be1627 6%, #a70415 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(6%, #be1627), color-stop(100%, #a70415));
+  background: -webkit-linear-gradient(top, #be1627 6%, #a70415 100%);
+  background: -o-linear-gradient(top, #be1627 6%, #a70415 100%);
+  background: -ms-linear-gradient(top, #be1627 6%, #a70415 100%);
+  background: linear-gradient(top, #be1627 6%, #3e3e3e 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#be1627',endColorstr='#a70415',GradientType=0);
+}
+.fsa-in-the-nations .block__content ul.nation-links {
+  margin: 20px 20px 12px 20px;
+  clear: both;
+}
+.fsa-in-the-nations .block__content ul.nation-links li {
+  padding-bottom: 0;
+  margin-bottom: 5px;
+  min-height: 0;
+  border: none;
+}
+.fsa-in-the-nations .block__content ul.nation-links li a {
+  display: inline-block;
+  font-size: 1.35em;
+  line-height: 1em;
+  margin-right: 4px;
+  padding-right: 4px;
+}
+.fsa-in-the-nations .block__content ul.nation-links li.last a {
+  border-right: none;
+}
+
+.fsa-in-the-nations,
+.fsa-in-the-nations.grey-block {
+  border-color: #c9c9c9;
+}
+.fsa-in-the-nations .block__content,
+.fsa-in-the-nations.grey-block .block__content {
+  padding: 0 !important;
+  min-height: 240px;
+}
+
+.l-region--sidebar-second .fsa-in-the-nations.block {
+  margin-bottom: 20px;
+}
+
+/* Structure of the block html and content
+
+<div class="section">
+<ul>
+	<li class="scotland">
+	<h3><a href="/scotland/">FSA in Scotland<img alt="FSA in Scotland icon" src="/sites/all/themes/site_frontend/images/icons/fsa-scotland.gif" /></a></h3>
+
+	<ul class="nation-links">
+		<li class="first"><a href="/scotland/news-updates/news/">News</a></li>
+		<li><a href="/scotland/scotnut/">Nutrition</a></li>
+		<li class="last"><a href="/scotland/safetyhygienescot/">Safety</a></li>
+	</ul>
+	</li>
+	<li class="northern-ireland">
+	<h3><a href="/northern-ireland/">FSA in Northern Ireland<img alt="FSA in Northern Ireland icon" src="/sites/all/themes/site_frontend/images/icons/fsa-northern-ireland.gif" /></a></h3>
+
+	<ul class="nation-links">
+		<li class="first"><a href="/northern-ireland/news-updates/news/">News</a></li>
+		<li><a href="/northern-ireland/safetyhygieneni/">Safety</a></li>
+		<li class="last"><a href="/northern-ireland/nutritionni/">Nutrition</a></li>
+	</ul>
+	</li>
+	<li class="wales">
+	<h3><a href="/wales/">FSA in Wales<img alt="FSA in Wales icon" src="/sites/all/themes/site_frontend/images/icons/fsa-wales.gif" /></a></h3>
+
+	<ul class="nation-links">
+		<li class="first"><a href="/wales/news-updates/news/">News</a></li>
+		<li><a href="/wales/about-fsa-wales/cymru/">Cymru</a></li>
+		<li class="last"><a href="/wales/safetyhygienewales/">Safety</a></li>
+	</ul>
+	</li>
+</ul>
+</div>
+
+*/
+/* print styling overrides */
+@media print {
+  .fsa-in-the-nations {
+    display: none;
+  }
+}
+/**
+ * Requires a block class: generic-blocks
+ */
+.generic-blocks {
+  overflow: hidden;
+  /* content title per generic block instance */
+  /* content main text body per generic block instance */
+  /* wrapper per generic block field collection instance */
+}
+.generic-blocks p {
+  font-size: 1em;
+}
+.generic-blocks ul, .generic-blocks li {
+  font-size: 1em;
+  list-style-type: none;
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+}
+.generic-blocks .field--name-field-title-side-content-generic {
+  font-size: 1.5em;
+  color: #4b800d;
+  padding: 0;
+  margin: .15em 0 .3em 0;
+}
+.generic-blocks .field--name-field-title-side-content-generic h1, .generic-blocks .field--name-field-title-side-content-generic h2, .generic-blocks .field--name-field-title-side-content-generic h3, .generic-blocks .field--name-field-title-side-content-generic h4, .generic-blocks .field--name-field-title-side-content-generic h5, .generic-blocks .field--name-field-title-side-content-generic h6 {
+  padding: 0;
+  margin: 0;
+  font-size: 1em;
+}
+.generic-blocks .field--name-field-body-side-content-generic {
+  font-size: 1.2em;
+  line-height: 1.3em;
+}
+.generic-blocks .field-collection-view {
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+  background: #fff;
+  padding: .5em 11px .3em 11px;
+  margin-bottom: 11px;
+  overflow: hidden;
+  clear: both;
+}
+.generic-blocks .field-collection-view img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* remove bottom margin of block - inner content already has bottom margin */
+.l-region--sidebar-second .block.generic-blocks {
+  margin-bottom: 0;
+}
+
+/* print styling overrides */
+@media print {
+  .generic-blocks .field--name-field-title-side-content-generic {
+    color: #000;
+  }
+  .generic-blocks .field-collection-view {
+    border: 1px solid #000;
+  }
+}
+.global-search {
+  overflow: hidden;
+  margin: 0;
+  padding: 10px;
+  background: #e9e9e9;
+  border: 2px solid #fff;
+  border-top: none;
+  -moz-border-radius: 0 0 10px 10px;
+  -webkit-border-radius: 0 0 10px 10px;
+  -o-border-radius: 0 0 10px 10px;
+  -ms-border-radius: 0 0 10px 10px;
+  border-radius: 0 0 10px 10px;
+}
+.global-search input.form-text {
+  padding: 4px;
+  border: 1px solid #ccc;
+  vertical-align: middle;
+  font-size: 1.2em;
+  width: 170px;
+  margin-left: 2px;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  -o-border-radius: 5px;
+  -ms-border-radius: 5px;
+  border-radius: 5px;
+  font-family: Arial,Verdana,Helvetica,san-serif;
+}
+.global-search input.form-submit {
+  overflow: hidden;
+  display: inline-block;
+  *display: inline;
+  zoom: 1;
+  margin: 0;
+  padding: 4px;
+  width: 24px;
+  border: 1px solid #ccc;
+  border-left: none;
+  vertical-align: middle;
+  font-size: 1.2em;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  -o-border-radius: 5px;
+  -ms-border-radius: 5px;
+  border-radius: 5px;
+  background-color: #D34D1A;
+  background-image: url("../images/search.png");
+  background-repeat: no-repeat;
+  background-position: 5px 3px;
+  text-indent: -9999px;
+}
+.global-search input.form-submit:hover {
+  background-color: #CC3708;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  .global-search {
+    -moz-border-radius: 10px;
+    -webkit-border-radius: 10px;
+    -o-border-radius: 10px;
+    -ms-border-radius: 10px;
+    border-radius: 10px;
+  }
+  .global-search input.form-text {
+    width: 80%;
+  }
+}
+.header-wrapper {
+  border-bottom: 3px solid #74ae27;
+  background: #2a8641;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzJhODY0MSIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiMwMTZjNGUiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #2a8641 0, #016c4e 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #2a8641), color-stop(100%, #016c4e));
+  background: -webkit-linear-gradient(top, #2a8641 0, #016c4e 100%);
+  background: -o-linear-gradient(top, #2a8641 0, #016c4e 100%);
+  background: -ms-linear-gradient(top, #2a8641 0, #016c4e 100%);
+  background: linear-gradient(top, #2a8641 0%, #016c4e 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#2a8641',endColorstr='#016c4e',GradientType=0);
+}
+
+.header-top {
+  padding-bottom: 16px;
+}
+
+.site-logo img {
+  margin-top: 10px;
+}
+
+/* Hygiene ratings block on home page
+ * depends on custom html in the block
+ * requires bock class: food-hygiene-ratings
+ */
+/* block content styling */
+.food-hygiene-ratings {
+  overflow: hidden;
+  position: relative;
+  /*
+  .block-footer {
+  	width: 225px;
+  	position: absolute;
+  	bottom: 0px;
+  	right: 0px;
+  	font-size: 1em;
+  	p.more-button-wrapper {
+  		margin-right: 11px;
+  	}
+  }
+  .block-body {
+  	padding-bottom: 45px;
+  }
+  */
+}
+.food-hygiene-ratings .block-image {
+  margin: 0 0 10px 0;
+  padding: 0;
+}
+.food-hygiene-ratings .block-body {
+  margin: 0;
+  overflow: hidden;
+}
+.food-hygiene-ratings .block-body h2, .food-hygiene-ratings .block-body h3 {
+  font-size: 1.5em;
+  font-weight: bold;
+  margin-bottom: 0.5em;
+}
+
+/* block styling */
+.l-region--sidebar-second .food-hygiene-ratings.block {
+  margin-bottom: 20px;
+}
+
+.food-hygiene-ratings {
+  overflow: hidden;
+  background-color: #dde9c9;
+  min-height: 230px;
+  -moz-border-radius: 9px;
+  -webkit-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+}
+.food-hygiene-ratings h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 11px;
+  margin: 0;
+  background: #3b9356;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #3b9356), color-stop(100%, #02684a));
+  background: -webkit-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -o-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -ms-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: linear-gradient(top, #3b9356 0%, #02684a 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#3b9356',endColorstr='#02684a',GradientType=0);
+}
+.food-hygiene-ratings .block__content {
+  padding: 1em 11px .8em 11px;
+}
+.food-hygiene-ratings .block__content .custom-block-content-inner {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #f0f5e7 0, #dde9c9 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #f0f5e7), color-stop(100%, #dde9c9));
+  background: -webkit-linear-gradient(top, #f0f5e7 0, #dde9c9 100%);
+  background: -o-linear-gradient(top, #f0f5e7 0, #dde9c9 100%);
+  background: -ms-linear-gradient(top, #f0f5e7 0, #dde9c9 100%);
+  background: linear-gradient(top, #f0f5e7 0%, #dde9c9 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f5e7',endColorstr='#dde9c9',GradientType=0);
+  /* link in a p-tag */
+}
+.food-hygiene-ratings .block__content .custom-block-content-inner p a {
+  color: #333;
+}
+
+/* Above styling is based on this html structure in the content:
+<a href="/ratings" title=" Food hygiene ratings" style="display: block;">
+<div class="block-image"><img src="/sites/all/themes/site_frontend/images/content/hygiene-ratings.png" /></div>
+<div class="block-body">
+<h3>Eating out? Getting food in?</h3>
+<p>Check the food hygiene standards of a resturant, takeaway or food shop.</p>
+</div>
+</a>
+
+*/
+/* Alternative (old) styling
+<div class="block-image"><img src="/sites/all/themes/site_frontend/images/content/hygiene-ratings.png" /></div>
+<div class="block-body">
+<h3><a href="/ratings">Eating out? Getting food in?</a></h3>
+<p>Check the food hygiene standards of a resturant, takeaway or food shop.</p>
+</div>
+<div class="block-footer">
+<p class="more-button-wrapper"><a class="more-button" href="/ratings" title=" Food hygiene ratings"><span class="link-text">More</span></a></p>
+</div>
+
+*/
+/* banner image on landing pages */
+.field--name-field-banner-image img {
+  margin-bottom: 17px;
+}
+
+/* mobile view */
+@media (min-width: 0px) and (max-width: 480px) {
+  .field--name-field-banner-image {
+    display: none;
+  }
+}
+/* print styling overrides */
+@media print {
+  .field--name-field-banner-image {
+    display: none;
+  }
+}
+/* featured image - when used directly on a content type */
+.field--name-field-feature-image img {
+  float: right;
+  margin: 0 0 17px 10px;
+  padding: 0;
+  border: 0;
+}
+
+/* featured image - when used in a view as a field */
+.views-field-field-feature-image img {
+  float: right;
+  margin: 0 0 17px 10px;
+  padding: 0;
+  border: 0;
+}
+
+/* mobile view */
+@media (min-width: 0px) and (max-width: 480px) {
+  .field--name-field-feature-image,
+  .views-field-field-feature-image {
+    display: none;
+  }
+}
+/* print styling overrides */
+@media print {
+  .field--name-field-feature-image,
+  .views-field-field-feature-image {
+    display: none;
+  }
+}
+/**
+ * Image placement is dependant on the field collection template: field-collection-item--field_fc_page_section.tpl.php
+ */
+.field-collection-item-field-fc-page-section .wrapper-img-pos-left,
+.field-collection-item-field-fc-page-section .wrapper-img-pos-right {
+  width: 200px;
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+.field-collection-item-field-fc-page-section .wrapper-img-pos-left img,
+.field-collection-item-field-fc-page-section .wrapper-img-pos-right img {
+  display: block;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+.field-collection-item-field-fc-page-section .wrapper-img-pos-left {
+  float: left;
+  margin-right: 10px;
+}
+.field-collection-item-field-fc-page-section .wrapper-img-pos-right {
+  float: right;
+  margin-left: 10px;
+}
+.field-collection-item-field-fc-page-section .wrapper-img-pos-top,
+.field-collection-item-field-fc-page-section .wrapper-img-pos-bottom {
+  width: 462px;
+  overflow: hidden;
+  margin-bottom: 15px;
+}
+.field-collection-item-field-fc-page-section .wrapper-img-pos-top img,
+.field-collection-item-field-fc-page-section .wrapper-img-pos-bottom img {
+  display: block;
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+.field-collection-item-field-fc-page-section .image-caption {
+  background-color: #e6e6e6;
+  margin: 0;
+  padding: 0.5em 11px;
+  font-size: 1.2em;
+  font-style: italic;
+}
+
+/* print styling overrides */
+@media print {
+  .field-collection-item-field-fc-page-section img,
+  .field-collection-item-field-fc-page-section .image-caption,
+  .field-collection-item-field-fc-page-section .wrapper-img-pos-left,
+  .field-collection-item-field-fc-page-section .wrapper-img-pos-right,
+  .field-collection-item-field-fc-page-section .wrapper-img-pos-top,
+  .field-collection-item-field-fc-page-section .wrapper-img-pos-bottom {
+    display: none;
+  }
+}
+/** 
+ * inline file block
+ * requires custom markup in teaxtarea
+ * used for manually adding files that won't change very often
+ * scroll down to too markup requirements
+ */
+.inline-file-block-wrapper {
+  overflow: hidden;
+  border: 1px solid #c4c4c4;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+  margin-bottom: 18px;
+}
+
+.inline-file-block {
+  overflow: hidden;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjQ2JSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlYWVhZWEiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(46%, white), color-stop(100%, #eaeaea));
+  background: -webkit-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -o-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: -ms-linear-gradient(top, white 0, white 46%, #eaeaea 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 46%, #eaeaea 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#eaeaea',GradientType=0);
+}
+
+.inline-file-block-content {
+  padding: 12px 10px 12px 10px;
+  /* remove styling just in case */
+}
+.inline-file-block-content ul, .inline-file-block-content li {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 1em;
+}
+.inline-file-block-content .file-item {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  font-weight: normal;
+  margin-bottom: 0.5em;
+}
+.inline-file-block-content a {
+  color: #006f51;
+  text-decoration: none;
+}
+.inline-file-block-content a:hover {
+  text-decoration: underline;
+}
+.inline-file-block-content .span.filesize {
+  margin-left: 10px;
+  font-size: 0.846em;
+}
+
+/* override base styles for links within textareas */
+.field--type-text-with-summary .inline-file-block-content a,
+.field--type-text-long .inline-file-block-content a,
+.field-type-text-long .inline-file-block-content a,
+.field-type-text-with-summary .inline-file-block-content a {
+  text-decoration: none !important;
+}
+.field--type-text-with-summary .inline-file-block-content a:hover,
+.field--type-text-long .inline-file-block-content a:hover,
+.field-type-text-long .inline-file-block-content a:hover,
+.field-type-text-with-summary .inline-file-block-content a:hover {
+  text-decoration: underline !important;
+}
+.field--type-text-with-summary .inline-file-block-content a:focus,
+.field--type-text-long .inline-file-block-content a:focus,
+.field-type-text-long .inline-file-block-content a:focus,
+.field-type-text-with-summary .inline-file-block-content a:focus {
+  text-decoration: underline !important;
+}
+
+/* print styling overrides */
+@media print {
+  .inline-file-block {
+    display: none;
+  }
+}
+/* markup requirement:
+
+<!-- start inline files -->
+	<div class="inline-file-block-wrapper">
+		<div class="inline-file-block">
+			<div class="inline-file-block-content">
+				<div class="file-item">
+					<a href="/sites/default/files/multimedia/pdfs/consultfeedback.pdf"><img alt="" class="file-icon" src="/modules/file/icons/application-pdf.png" title="application/pdf" /> Consultation feedback questionnaire</a>
+				</div>
+				<div class="file-item">
+					<a href="/sites/default/files/multimedia/worddocs/consultfeedback.doc"><img alt="" class="file-icon" src="/modules/file/icons/x-office-document.png" title="application/msword" /> Consultation feedback questionnaire</a>
+				</div>
+			</div>
+		</div>
+	</div>
+<!-- end inline files -->
+
+*/
+/**
+ * Interactive block
+ * Requires block class: interactive-block
+ * Dependant on h2 class-"block-title" in view mode display settings
+ */
+.interactive-block {
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+  /* hide node title that the view mode automatically inserts */
+  /* custom block title - this is a field withn the block content area, not default block___title */
+  /* content wrapper - appears within the block content area */
+}
+.interactive-block .node__title {
+  display: none;
+}
+.interactive-block h2.block-title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 11px;
+  margin: 0;
+  background: #999;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(6%, #999999), color-stop(100%, #3e3e3e));
+  background: -webkit-linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  background: -o-linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  background: -ms-linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  background: linear-gradient(top, #999999 6%, #3e3e3e 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#999999',endColorstr='#3e3e3e',GradientType=0);
+  border-bottom: none;
+}
+.interactive-block .field-collection-container {
+  padding: 1em 11px 1em 11px;
+  background: #fff;
+  /* if we add a background colour we need to add rounded bottom borders here too */
+  overflow: hidden;
+}
+.interactive-block .field-collection-view {
+  border-bottom: 1px solid #c6c6c6;
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  clear: left;
+  overflow: hidden;
+}
+.interactive-block .field-collection-view.field-collection-view-final {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin-bottom: 0;
+}
+.interactive-block img {
+  float: left;
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+.interactive-block h3 {
+  margin-bottom: 0;
+}
+.interactive-block .field--name-field-fc-section-title,
+.interactive-block .field--name-field-fc-section-link {
+  margin-left: 62px;
+}
+.interactive-block .field--name-field-fc-section-link .field__item {
+  font-size: 1.2em;
+  font-weight: normal;
+  display: block;
+  padding-left: 10px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+  margin-bottom: 2px;
+}
+.interactive-block .field--name-field-fc-section-link .field__item a {
+  text-decoration: none;
+  color: #555;
+}
+.interactive-block .field--name-field-fc-section-link .field__item a:hover {
+  text-decoration: underline;
+}
+
+/**
+ * Job type field
+ * In display settings, requires prefix, for example: <p class="job-line-item"><span class="job-line-item-label">Reference: </span> and suffix: </p>
+ * We are not using inline label setting for label because the div around it interferes with floating of text around feature image
+ * Without the p-tag, wrapping of text around feature image breaks. We use a p-tag so that the right font size is pulled through.
+ */
+p.job-line-item {
+  margin-bottom: 10px;
+}
+
+.job-line-item-label {
+  font-weight: bold;
+}
+
+/**
+ * Jump menu block (the one one nation landing pages)
+ * Dependant on block class: jump-menu-block
+ */
+.jump-menu-block {
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+  /* block title */
+}
+.jump-menu-block .custom-block-inner {
+  background: #fff;
+  padding: 1em 11px 1em 11px;
+  /* gradient */
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjMyJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNmMGYwZjAiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, white 32%, #f0f0f0 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(32%, white), color-stop(100%, #f0f0f0));
+  background: -webkit-linear-gradient(top, white 0, white 32%, #f0f0f0 100%);
+  background: -o-linear-gradient(top, white 0, white 32%, #f0f0f0 100%);
+  background: -ms-linear-gradient(top, white 0, white 32%, #f0f0f0 100%);
+  background: linear-gradient(top, #ffffff 0%, #ffffff 32%, #f0f0f0 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#f0f0f0',GradientType=0);
+}
+.jump-menu-block h2.block__title {
+  font-size: 1.5em;
+  color: #5d9711;
+  margin: 0 0 .5em 0;
+}
+.jump-menu-block select {
+  width: 100%;
+  margin-bottom: 1em;
+  padding: 2px 0;
+  background: #fff;
+  vertical-align: middle;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  font-family: Arial, Verdana, Helvetica, sans-serif;
+  font-size: 1.2em;
+  color: #333;
+}
+.jump-menu-block .form-item label {
+  font-weight: normal;
+  display: block;
+  font-size: 1.2em;
+  line-height: 1.4em;
+  margin: 0 0 1em 0;
+}
+
+/* depends on block class: language-switcher */
+.language-switcher {
+  overflow: hidden;
+  width: 90px;
+  height: 25px;
+  float: right;
+  padding: 0;
+  margin-bottom: 4px;
+  border: 1px solid #02684a;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  -moz-box-shadow: 1px 1px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 1px 1px 2px 2px rgba(0, 0, 0, 0.1);
+  -o-box-shadow: 1px 1px 2px 2px rgba(0, 0, 0, 0.1);
+  -ms-box-shadow: 1px 1px 2px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: 1px 1px 2px 2px rgba(0, 0, 0, 0.1);
+}
+.language-switcher .custom-block-content-inner {
+  background: #398e6e;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIxNSUiIHN0b3AtY29sb3I9IiMzOThlNmUiIHN0b3Atb3BhY2l0eT0iMSIvPgogICAgPHN0b3Agb2Zmc2V0PSI1NSUiIHN0b3AtY29sb3I9IiMwMjY4NGEiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #398e6e 15%, #02684a 55%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(15%, #398e6e), color-stop(55%, #02684a));
+  background: -webkit-linear-gradient(top, #398e6e 15%, #02684a 55%);
+  background: -o-linear-gradient(top, #398e6e 15%, #02684a 55%);
+  background: -ms-linear-gradient(top, #398e6e 15%, #02684a 55%);
+  background: linear-gradient(top, #398e6e 15%, #02684a 55%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#398e6e',endColorstr='#02684a',GradientType=0);
+}
+.language-switcher a {
+  display: block;
+  padding-top: 5px;
+  padding-left: 36px;
+  padding-bottom: 7px;
+  color: #fff;
+  font-size: 1.1em;
+  font-weight: normal;
+  text-decoration: none;
+}
+.language-switcher a:hover {
+  text-decoration: underline;
+}
+.language-switcher a.cy {
+  background-image: url("../images/flag-cy.gif");
+  background-repeat: no-repeat;
+  background-position: 5px 4px;
+}
+.language-switcher a.en {
+  background-image: url("../images/flag-en.gif");
+  background-repeat: no-repeat;
+  background-position: 5px 4px;
+}
+.language-switcher p {
+  margin: 0;
+  font-size: 1em;
+  line-height: 1;
+}
+.language-switcher h1, .language-switcher h2, .language-switcher h3, .language-switcher h4, .language-switcher h5, .language-switcher h6 {
+  display: none;
+}
+
+/* print styling overrides */
+@media print {
+  .language-switcher {
+    display: none;
+  }
+}
+/* for nation news blocks for nation "home pages", see _nation_news.scss */
+/** 
+ * the block itself is themed in base/_blockreference_blocks.scss 
+ * we are only theming the block content here 
+ * note: blockreference does not pull in the block class when the block is placed in landing page node
+ * dependant on the view been set as unformatted list
+ */
+.latest-news,
+.field--type-blockreference .block--views-news-block,
+.field--type-blockreference .block--views-news-block-1,
+.field--type-blockreference .block--views-news-block-2,
+.field--type-blockreference .block--views-news-block-3,
+.field--type-blockreference .block--views-news-block-4,
+.field--type-blockreference .block--views-news-block-5,
+.field--type-blockreference .block--views-news-block-6,
+.field--type-blockreference .block--views-news-block-7,
+.field--type-blockreference .block--views-news-block-8,
+.field--type-blockreference .block--views-news-block-9,
+.field--type-blockreference .block--views-news-block-10,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12,
+.field--type-blockreference .block--views-news-block-13,
+.field--type-blockreference .block--views-news-block-14,
+.field--type-blockreference .block--views-news-block-15 {
+  font-size: 1em;
+  line-height: 1.4em;
+  margin-bottom: 18px;
+  /* node title */
+  /* subtitle */
+  /* teaser updated date */
+  /* teaser summary */
+  /* node links like read more (if enabled) */
+  /* view rows */
+  /* more link - omplemented in base/_links.scss */
+  /* view footer */
+}
+.latest-news h2.node__title,
+.latest-news h3.node__title,
+.field--type-blockreference .block--views-news-block h2.node__title,
+.field--type-blockreference .block--views-news-block h3.node__title,
+.field--type-blockreference .block--views-news-block-1 h2.node__title,
+.field--type-blockreference .block--views-news-block-1 h3.node__title,
+.field--type-blockreference .block--views-news-block-2 h2.node__title,
+.field--type-blockreference .block--views-news-block-2 h3.node__title,
+.field--type-blockreference .block--views-news-block-3 h2.node__title,
+.field--type-blockreference .block--views-news-block-3 h3.node__title,
+.field--type-blockreference .block--views-news-block-4 h2.node__title,
+.field--type-blockreference .block--views-news-block-4 h3.node__title,
+.field--type-blockreference .block--views-news-block-5 h2.node__title,
+.field--type-blockreference .block--views-news-block-5 h3.node__title,
+.field--type-blockreference .block--views-news-block-6 h2.node__title,
+.field--type-blockreference .block--views-news-block-6 h3.node__title,
+.field--type-blockreference .block--views-news-block-7 h2.node__title,
+.field--type-blockreference .block--views-news-block-7 h3.node__title,
+.field--type-blockreference .block--views-news-block-8 h2.node__title,
+.field--type-blockreference .block--views-news-block-8 h3.node__title,
+.field--type-blockreference .block--views-news-block-9 h2.node__title,
+.field--type-blockreference .block--views-news-block-9 h3.node__title,
+.field--type-blockreference .block--views-news-block-10 h2.node__title,
+.field--type-blockreference .block--views-news-block-10 h3.node__title,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 h2.node__title,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 h3.node__title,
+.field--type-blockreference .block--views-news-block-13 h2.node__title,
+.field--type-blockreference .block--views-news-block-13 h3.node__title,
+.field--type-blockreference .block--views-news-block-14 h2.node__title,
+.field--type-blockreference .block--views-news-block-14 h3.node__title,
+.field--type-blockreference .block--views-news-block-15 h2.node__title,
+.field--type-blockreference .block--views-news-block-15 h3.node__title {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  margin-bottom: 0;
+  font-weight: normal;
+}
+.latest-news .node__title,
+.field--type-blockreference .block--views-news-block .node__title,
+.field--type-blockreference .block--views-news-block-1 .node__title,
+.field--type-blockreference .block--views-news-block-2 .node__title,
+.field--type-blockreference .block--views-news-block-3 .node__title,
+.field--type-blockreference .block--views-news-block-4 .node__title,
+.field--type-blockreference .block--views-news-block-5 .node__title,
+.field--type-blockreference .block--views-news-block-6 .node__title,
+.field--type-blockreference .block--views-news-block-7 .node__title,
+.field--type-blockreference .block--views-news-block-8 .node__title,
+.field--type-blockreference .block--views-news-block-9 .node__title,
+.field--type-blockreference .block--views-news-block-10 .node__title,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .node__title,
+.field--type-blockreference .block--views-news-block-13 .node__title,
+.field--type-blockreference .block--views-news-block-14 .node__title,
+.field--type-blockreference .block--views-news-block-15 .node__title {
+  font-weight: normal;
+  display: block;
+  padding-left: 14px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 5px;
+}
+.latest-news .node__title a,
+.field--type-blockreference .block--views-news-block .node__title a,
+.field--type-blockreference .block--views-news-block-1 .node__title a,
+.field--type-blockreference .block--views-news-block-2 .node__title a,
+.field--type-blockreference .block--views-news-block-3 .node__title a,
+.field--type-blockreference .block--views-news-block-4 .node__title a,
+.field--type-blockreference .block--views-news-block-5 .node__title a,
+.field--type-blockreference .block--views-news-block-6 .node__title a,
+.field--type-blockreference .block--views-news-block-7 .node__title a,
+.field--type-blockreference .block--views-news-block-8 .node__title a,
+.field--type-blockreference .block--views-news-block-9 .node__title a,
+.field--type-blockreference .block--views-news-block-10 .node__title a,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .node__title a,
+.field--type-blockreference .block--views-news-block-13 .node__title a,
+.field--type-blockreference .block--views-news-block-14 .node__title a,
+.field--type-blockreference .block--views-news-block-15 .node__title a {
+  text-decoration: none;
+  color: #006f51;
+}
+.latest-news .node__title a:hover,
+.field--type-blockreference .block--views-news-block .node__title a:hover,
+.field--type-blockreference .block--views-news-block-1 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-2 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-3 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-4 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-5 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-6 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-7 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-8 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-9 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-10 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-13 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-14 .node__title a:hover,
+.field--type-blockreference .block--views-news-block-15 .node__title a:hover {
+  text-decoration: underline;
+}
+.latest-news .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-1 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-2 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-3 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-4 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-5 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-6 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-7 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-8 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-9 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-10 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-13 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-14 .field--name-field-subtitle,
+.field--type-blockreference .block--views-news-block-15 .field--name-field-subtitle {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  padding-left: 14px;
+}
+.latest-news .field--name-field-updated,
+.field--type-blockreference .block--views-news-block .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-1 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-2 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-3 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-4 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-5 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-6 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-7 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-8 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-9 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-10 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-13 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-14 .field--name-field-updated,
+.field--type-blockreference .block--views-news-block-15 .field--name-field-updated {
+  font-size: 1.1em;
+  margin-bottom: 0.2em;
+  padding-left: 14px;
+}
+.latest-news .field--name-field-summary,
+.field--type-blockreference .block--views-news-block .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-1 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-2 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-3 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-4 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-5 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-6 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-7 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-8 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-9 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-10 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-13 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-14 .field--name-field-summary,
+.field--type-blockreference .block--views-news-block-15 .field--name-field-summary {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  color: #333;
+  margin-bottom: 0.2em;
+  padding-left: 14px;
+}
+.latest-news .field__item,
+.field--type-blockreference .block--views-news-block .field__item,
+.field--type-blockreference .block--views-news-block-1 .field__item,
+.field--type-blockreference .block--views-news-block-2 .field__item,
+.field--type-blockreference .block--views-news-block-3 .field__item,
+.field--type-blockreference .block--views-news-block-4 .field__item,
+.field--type-blockreference .block--views-news-block-5 .field__item,
+.field--type-blockreference .block--views-news-block-6 .field__item,
+.field--type-blockreference .block--views-news-block-7 .field__item,
+.field--type-blockreference .block--views-news-block-8 .field__item,
+.field--type-blockreference .block--views-news-block-9 .field__item,
+.field--type-blockreference .block--views-news-block-10 .field__item,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .field__item,
+.field--type-blockreference .block--views-news-block-13 .field__item,
+.field--type-blockreference .block--views-news-block-14 .field__item,
+.field--type-blockreference .block--views-news-block-15 .field__item {
+  margin-bottom: 0.5em;
+}
+.latest-news .node__links,
+.field--type-blockreference .block--views-news-block .node__links,
+.field--type-blockreference .block--views-news-block-1 .node__links,
+.field--type-blockreference .block--views-news-block-2 .node__links,
+.field--type-blockreference .block--views-news-block-3 .node__links,
+.field--type-blockreference .block--views-news-block-4 .node__links,
+.field--type-blockreference .block--views-news-block-5 .node__links,
+.field--type-blockreference .block--views-news-block-6 .node__links,
+.field--type-blockreference .block--views-news-block-7 .node__links,
+.field--type-blockreference .block--views-news-block-8 .node__links,
+.field--type-blockreference .block--views-news-block-9 .node__links,
+.field--type-blockreference .block--views-news-block-10 .node__links,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .node__links,
+.field--type-blockreference .block--views-news-block-13 .node__links,
+.field--type-blockreference .block--views-news-block-14 .node__links,
+.field--type-blockreference .block--views-news-block-15 .node__links {
+  padding-left: 14px;
+}
+.latest-news .node__links a,
+.field--type-blockreference .block--views-news-block .node__links a,
+.field--type-blockreference .block--views-news-block-1 .node__links a,
+.field--type-blockreference .block--views-news-block-2 .node__links a,
+.field--type-blockreference .block--views-news-block-3 .node__links a,
+.field--type-blockreference .block--views-news-block-4 .node__links a,
+.field--type-blockreference .block--views-news-block-5 .node__links a,
+.field--type-blockreference .block--views-news-block-6 .node__links a,
+.field--type-blockreference .block--views-news-block-7 .node__links a,
+.field--type-blockreference .block--views-news-block-8 .node__links a,
+.field--type-blockreference .block--views-news-block-9 .node__links a,
+.field--type-blockreference .block--views-news-block-10 .node__links a,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .node__links a,
+.field--type-blockreference .block--views-news-block-13 .node__links a,
+.field--type-blockreference .block--views-news-block-14 .node__links a,
+.field--type-blockreference .block--views-news-block-15 .node__links a {
+  text-decoration: none;
+  color: #006f51;
+}
+.latest-news .node__links a:hover,
+.field--type-blockreference .block--views-news-block .node__links a:hover,
+.field--type-blockreference .block--views-news-block-1 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-2 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-3 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-4 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-5 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-6 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-7 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-8 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-9 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-10 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-13 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-14 .node__links a:hover,
+.field--type-blockreference .block--views-news-block-15 .node__links a:hover {
+  text-decoration: underline;
+}
+.latest-news .views-row,
+.field--type-blockreference .block--views-news-block .views-row,
+.field--type-blockreference .block--views-news-block-1 .views-row,
+.field--type-blockreference .block--views-news-block-2 .views-row,
+.field--type-blockreference .block--views-news-block-3 .views-row,
+.field--type-blockreference .block--views-news-block-4 .views-row,
+.field--type-blockreference .block--views-news-block-5 .views-row,
+.field--type-blockreference .block--views-news-block-6 .views-row,
+.field--type-blockreference .block--views-news-block-7 .views-row,
+.field--type-blockreference .block--views-news-block-8 .views-row,
+.field--type-blockreference .block--views-news-block-9 .views-row,
+.field--type-blockreference .block--views-news-block-10 .views-row,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .views-row,
+.field--type-blockreference .block--views-news-block-13 .views-row,
+.field--type-blockreference .block--views-news-block-14 .views-row,
+.field--type-blockreference .block--views-news-block-15 .views-row {
+  margin-bottom: 0.35em;
+}
+.latest-news .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-1 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-2 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-3 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-4 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-5 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-6 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-7 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-8 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-9 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-10 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-13 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-14 .views-row.views-row-last,
+.field--type-blockreference .block--views-news-block-15 .views-row.views-row-last {
+  margin-bottom: 0.2em;
+}
+.latest-news .fsa-more-link,
+.field--type-blockreference .block--views-news-block .fsa-more-link,
+.field--type-blockreference .block--views-news-block-1 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-2 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-3 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-4 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-5 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-6 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-7 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-8 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-9 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-10 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-13 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-14 .fsa-more-link,
+.field--type-blockreference .block--views-news-block-15 .fsa-more-link {
+  font-weight: bold;
+}
+.latest-news .view-footer,
+.field--type-blockreference .block--views-news-block .view-footer,
+.field--type-blockreference .block--views-news-block-1 .view-footer,
+.field--type-blockreference .block--views-news-block-2 .view-footer,
+.field--type-blockreference .block--views-news-block-3 .view-footer,
+.field--type-blockreference .block--views-news-block-4 .view-footer,
+.field--type-blockreference .block--views-news-block-5 .view-footer,
+.field--type-blockreference .block--views-news-block-6 .view-footer,
+.field--type-blockreference .block--views-news-block-7 .view-footer,
+.field--type-blockreference .block--views-news-block-8 .view-footer,
+.field--type-blockreference .block--views-news-block-9 .view-footer,
+.field--type-blockreference .block--views-news-block-10 .view-footer,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .view-footer,
+.field--type-blockreference .block--views-news-block-13 .view-footer,
+.field--type-blockreference .block--views-news-block-14 .view-footer,
+.field--type-blockreference .block--views-news-block-15 .view-footer {
+  margin-top: 0.5em;
+  padding-top: 0.5em;
+  border-top: 1px solid #5d9711;
+  font-size: 1.2em;
+  line-height: 1.4em;
+  margin-bottom: 5px;
+}
+.latest-news .view-footer p,
+.field--type-blockreference .block--views-news-block .view-footer p,
+.field--type-blockreference .block--views-news-block-1 .view-footer p,
+.field--type-blockreference .block--views-news-block-2 .view-footer p,
+.field--type-blockreference .block--views-news-block-3 .view-footer p,
+.field--type-blockreference .block--views-news-block-4 .view-footer p,
+.field--type-blockreference .block--views-news-block-5 .view-footer p,
+.field--type-blockreference .block--views-news-block-6 .view-footer p,
+.field--type-blockreference .block--views-news-block-7 .view-footer p,
+.field--type-blockreference .block--views-news-block-8 .view-footer p,
+.field--type-blockreference .block--views-news-block-9 .view-footer p,
+.field--type-blockreference .block--views-news-block-10 .view-footer p,
+.field--type-blockreference .block--views-news-block-11
+.field--type-blockreference .block--views-news-block-12 .view-footer p,
+.field--type-blockreference .block--views-news-block-13 .view-footer p,
+.field--type-blockreference .block--views-news-block-14 .view-footer p,
+.field--type-blockreference .block--views-news-block-15 .view-footer p {
+  font-size: 1em;
+}
+
+/* positioning of block on landing page */
+.field--type-blockreference .block.block--views-news-block,
+.field--type-blockreference .block.block--views-news-block-1,
+.field--type-blockreference .block.block--views-news-block-2,
+.field--type-blockreference .block.block--views-news-block-3,
+.field--type-blockreference .block.block--views-news-block-4,
+.field--type-blockreference .block.block--views-news-block-5,
+.field--type-blockreference .block.block--views-news-block-6,
+.field--type-blockreference .block.block--views-news-block-7,
+.field--type-blockreference .block.block--views-news-block-8,
+.field--type-blockreference .block.block--views-news-block-9,
+.field--type-blockreference .block.block--views-news-block-10,
+.field--type-blockreference .block.block--views-news-block-11,
+.field--type-blockreference .block.block--views-news-block-12,
+.field--type-blockreference .block.block--views-news-block-13,
+.field--type-blockreference .block.block--views-news-block-14,
+.field--type-blockreference .block.block--views-news-block-15 {
+  width: 225px;
+  margin-left: 12px;
+  margin-bottom: 20px;
+  float: right;
+}
+
+/* mobile view */
+@media (min-width: 0px) and (max-width: 480px) {
+  /* increase all font sizes that are nested in here */
+  .field--type-blockreference .block--views-news-block,
+  .field--type-blockreference .block--views-news-block-1,
+  .field--type-blockreference .block--views-news-block-2,
+  .field--type-blockreference .block--views-news-block-3,
+  .field--type-blockreference .block--views-news-block-4,
+  .field--type-blockreference .block--views-news-block-5,
+  .field--type-blockreference .block--views-news-block-6,
+  .field--type-blockreference .block--views-news-block-7,
+  .field--type-blockreference .block--views-news-block-8,
+  .field--type-blockreference .block--views-news-block-9,
+  .field--type-blockreference .block--views-news-block-10,
+  .field--type-blockreference .block--views-news-block-11,
+  .field--type-blockreference .block--views-news-block-12,
+  .field--type-blockreference .block--views-news-block-13,
+  .field--type-blockreference .block--views-news-block-14,
+  .field--type-blockreference .block--views-news-block-15 {
+    font-size: 1.1em;
+  }
+
+  /* positioning of block on landing page */
+  .field--type-blockreference .block.block--views-news-block,
+  .field--type-blockreference .block.block--views-news-block-1,
+  .field--type-blockreference .block.block--views-news-block-2,
+  .field--type-blockreference .block.block--views-news-block-3,
+  .field--type-blockreference .block.block--views-news-block-4,
+  .field--type-blockreference .block.block--views-news-block-5,
+  .field--type-blockreference .block.block--views-news-block-5,
+  .field--type-blockreference .block.block--views-news-block-6,
+  .field--type-blockreference .block.block--views-news-block-7,
+  .field--type-blockreference .block.block--views-news-block-8,
+  .field--type-blockreference .block.block--views-news-block-9,
+  .field--type-blockreference .block.block--views-news-block-10,
+  .field--type-blockreference .block.block--views-news-block-11,
+  .field--type-blockreference .block.block--views-news-block-12,
+  .field--type-blockreference .block.block--views-news-block-13,
+  .field--type-blockreference .block.block--views-news-block-14,
+  .field--type-blockreference .block.block--views-news-block-15 {
+    width: 100%;
+    margin-left: 0px;
+    margin-bottom: 17px;
+    float: none;
+  }
+}
+/* print styling overrides */
+@media print {
+  .field--type-blockreference .block.block--views-news-block,
+  .field--type-blockreference .block.block--views-news-block-1,
+  .field--type-blockreference .block.block--views-news-block-2,
+  .field--type-blockreference .block.block--views-news-block-3,
+  .field--type-blockreference .block.block--views-news-block-4,
+  .field--type-blockreference .block.block--views-news-block-5,
+  .field--type-blockreference .block.block--views-news-block-5,
+  .field--type-blockreference .block.block--views-news-block-6,
+  .field--type-blockreference .block.block--views-news-block-7,
+  .field--type-blockreference .block.block--views-news-block-8,
+  .field--type-blockreference .block.block--views-news-block-9,
+  .field--type-blockreference .block.block--views-news-block-10,
+  .field--type-blockreference .block.block--views-news-block-11,
+  .field--type-blockreference .block.block--views-news-block-12,
+  .field--type-blockreference .block.block--views-news-block-13,
+  .field--type-blockreference .block.block--views-news-block-14,
+  .field--type-blockreference .block.block--views-news-block-15 {
+    width: auto;
+    margin-left: 0px;
+    margin-bottom: 17px;
+    float: none;
+  }
+  .field--type-blockreference .block.block--views-news-block .node__title a,
+  .field--type-blockreference .block.block--views-news-block-1 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-2 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-3 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-4 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-5 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-5 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-6 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-7 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-8 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-9 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-10 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-11 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-12 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-13 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-14 .node__title a,
+  .field--type-blockreference .block.block--views-news-block-15 .node__title a {
+    color: #000;
+  }
+  .field--type-blockreference .block.block--views-news-block .view-footer,
+  .field--type-blockreference .block.block--views-news-block-1 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-2 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-3 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-4 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-5 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-5 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-6 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-7 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-8 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-9 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-10 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-11 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-12 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-13 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-14 .view-footer,
+  .field--type-blockreference .block.block--views-news-block-15 .view-footer {
+    display: none;
+  }
+  .field--type-blockreference .block.block--views-news-block .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-1 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-2 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-3 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-4 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-5 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-5 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-6 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-7 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-8 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-9 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-10 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-11 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-12 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-13 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-14 .field--name-field-summary,
+  .field--type-blockreference .block.block--views-news-block-15 .field--name-field-summary {
+    color: #000;
+  }
+}
+/** 
+ * Latest news and alerts block  on site home page
+ * we are only theming the block content here as the block class: green-block-white-background is applied to the block
+ * and that is themed in base/_blocks.scss
+ */
+.latest-news-and-alerts {
+  position: relative;
+  margin-bottom: 20px;
+  font-size: 1em;
+  /* featured image */
+  /* title */
+  /* updated date */
+  /* each teaser views row */
+  /* view content wrapper */
+  /* view footer */
+  /* more links with orange icons on the right of them */
+}
+.latest-news-and-alerts .views-field-field-feature-image img {
+  float: none;
+  margin: 0 0 8px 0;
+  padding: 0;
+  border: 0;
+}
+.latest-news-and-alerts .views-field-title,
+.latest-news-and-alerts .views-field-field-title-short {
+  font-size: 1.3em;
+  line-height: 1.2em;
+  margin-bottom: 0.5em;
+  font-weight: normal;
+}
+.latest-news-and-alerts .views-field-title a,
+.latest-news-and-alerts .views-field-field-title-short a {
+  text-decoration: none;
+  color: #006f51;
+}
+.latest-news-and-alerts .views-field-title a:hover,
+.latest-news-and-alerts .views-field-field-title-short a:hover {
+  text-decoration: underline;
+}
+.latest-news-and-alerts .views-field-title h2, .latest-news-and-alerts .views-field-title h3,
+.latest-news-and-alerts .views-field-field-title-short h2,
+.latest-news-and-alerts .views-field-field-title-short h3 {
+  margin-bottom: 0px;
+  font-weight: normal;
+  font-size: 1em;
+}
+.latest-news-and-alerts .views-field-field-updated,
+.latest-news-and-alerts .views-field-field-display-updated-date {
+  font-size: 1.2em;
+  margin-bottom: 0.2em;
+}
+.latest-news-and-alerts .views-row {
+  width: 161px;
+  overflow: hidden;
+  display: block;
+  float: left;
+  margin-right: 11px;
+  margin-bottom: 15px;
+}
+.latest-news-and-alerts .views-row.views-row-last {
+  margin-right: 0;
+}
+.latest-news-and-alerts .view-content {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+.latest-news-and-alerts .view-footer {
+  overflow: hidden;
+  width: 697px;
+  position: absolute;
+  bottom: 1px;
+  left: 1px;
+  font-size: 1.2em;
+  line-height: 1em;
+  clear: both;
+  margin-top: 0.5em;
+  border-top: 1px solid #ccc;
+  -moz-border-radius: 0 0 8px 8px;
+  -webkit-border-radius: 0 0 8px 8px;
+  -o-border-radius: 0 0 8px 8px;
+  -ms-border-radius: 0 0 8px 8px;
+  border-radius: 0 0 8px 8px;
+  overflow: hidden;
+}
+.latest-news-and-alerts .view-footer .custom-views-footer-inner {
+  overflow: hidden;
+  padding-top: 0.45em;
+  padding-bottom: 0.45em;
+  background: #fff;
+  background: -moz-linear-gradient(top, white 0%, #cfcfcf 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(100%, #cfcfcf));
+  background: -webkit-linear-gradient(top, white 0%, #cfcfcf 100%);
+  background: -o-linear-gradient(top, white 0%, #cfcfcf 100%);
+  background: -ms-linear-gradient(top, white 0%, #cfcfcf 100%);
+  background: linear-gradient(top, #ffffff 0%, #cfcfcf 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#cfcfcf',GradientType=0);
+}
+.latest-news-and-alerts p.more-link-orange-icon-right-wrapper {
+  margin: 0;
+  font-size: 1em;
+}
+.latest-news-and-alerts a.more-link-orange-icon-right {
+  margin-right: 30px;
+  font-size: 1em;
+}
+.latest-news-and-alerts a.more-link-orange-icon-right.first {
+  margin-left: 85px;
+}
+.latest-news-and-alerts a.more-link-orange-icon-right.last {
+  margin-right: 0;
+}
+
+/* Required html structure for above styling to work:
+	<p class="more-link-orange-icon-right-wrapper">
+	<a class="more-link-orange-icon-right first" href="/news-updates/news" title="More about: News">More news</a>
+	<a class="more-link-orange-icon-right" href="/enforcement/alerts" title="More about: Food alerts">More food alerts</a>
+	<a class="more-link-orange-icon-right" href="/news-updates/news" title="More about: Allergy alerts">More allergy alerts</a>
+	<a class="more-link-orange-icon-right last" href="/news-updates/consultations" title="More about: Consultations">Consultations</a>
+	</p>
+*/
+/* block styling */
+.latest-news-and-alerts {
+  overflow: hidden;
+}
+.latest-news-and-alerts .custom-block-title-wrapper {
+  -moz-border-radius: 9px 9px 0 0;
+  -webkit-border-radius: 9px 9px 0 0;
+  -o-border-radius: 9px 9px 0 0;
+  -ms-border-radius: 9px 9px 0 0;
+  border-radius: 9px 9px 0 0;
+}
+.latest-news-and-alerts h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .3em 10px;
+  margin: 0;
+  background: #3b9356;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #3b9356), color-stop(100%, #02684a));
+  background: -webkit-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -o-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: -ms-linear-gradient(top, #3b9356 0, #02684a 100%);
+  background: linear-gradient(top, #3b9356 0%, #02684a 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#3b9356',endColorstr='#02684a',GradientType=0);
+}
+.latest-news-and-alerts .block__content {
+  padding: 0.5em 0em 0em 0em;
+  min-height: 242px;
+  background-color: #fff;
+  border: 1px solid #02684a;
+  -moz-border-radius: 0 0 9px 9px;
+  -webkit-border-radius: 0 0 9px 9px;
+  -o-border-radius: 0 0 9px 9px;
+  -ms-border-radius: 0 0 9px 9px;
+  border-radius: 0 0 9px 9px;
+  overflow: hidden;
+}
+
+/* mobile view */
+@media (min-width: 0px) and (max-width: 480px) {
+  .latest-news-and-alerts .views-row {
+    width: auto;
+    float: none;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #c9c9c9;
+    margin-bottom: 6px;
+    margin-right: 0;
+  }
+  .latest-news-and-alerts .views-row .views-field-field-feature-image img {
+    float: left;
+    margin-right: 12px;
+    margin-bottom: 0px;
+  }
+  .latest-news-and-alerts .view-footer {
+    position: static;
+    width: auto;
+    border: 0;
+    background: 0;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 5px;
+  }
+  .latest-news-and-alerts .view-footer .custom-views-footer-inner {
+    background: 0;
+    background-color: #fff;
+  }
+  .latest-news-and-alerts a.more-link-orange-icon-right.first {
+    margin-left: 0;
+  }
+  .latest-news-and-alerts a.more-link-orange-icon-right {
+    display: block;
+    margin: 0 0 1em 0;
+  }
+  .latest-news-and-alerts a.more-link-orange-icon-right {
+    padding-right: 0;
+    padding-left: 14px;
+    background: url("../images/orange-arrow-thin-right.png") no-repeat left 3px;
+    font-weight: normal;
+    display: block;
+    padding-left: 14px;
+    color: #006f51;
+  }
+}
+/* print styling overrides */
+@media print {
+  .latest-news-and-alerts h2.block__title {
+    color: #000;
+    background: none;
+    background-color: transparent;
+    padding: .3em 0px;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+  .latest-news-and-alerts .custom-block-title-wrapper {
+    -moz-border-radius: 0;
+    -webkit-border-radius: 0;
+    -o-border-radius: 0;
+    -ms-border-radius: 0;
+    border-radius: 0;
+  }
+  .latest-news-and-alerts .block__content {
+    border: none;
+    padding: none;
+    -moz-border-radius: 0;
+    -webkit-border-radius: 0;
+    -o-border-radius: 0;
+    -ms-border-radius: 0;
+    border-radius: 0;
+  }
+  .latest-news-and-alerts .view-content {
+    margin: 0;
+  }
+  .latest-news-and-alerts .views-field-title a,
+  .latest-news-and-alerts .views-field-field-title-short a {
+    color: #000;
+  }
+  .latest-news-and-alerts .views-row {
+    width: auto;
+    float: none;
+    padding-bottom: 0;
+    border-bottom: none;
+    margin-bottom: 12px;
+    margin-right: 0;
+  }
+  .latest-news-and-alerts .views-row .views-field-field-feature-image img {
+    display: none;
+  }
+  .latest-news-and-alerts .view-footer {
+    display: none;
+  }
+}
+/** Main menu depends on Superfish module
+  * Superfish block settings:
+	* Block title: <none>, Menu parent: Mian Menu, Menu depth: 2, Menu type: Horizontal, Style: none,
+	*	Animation speed: fast, Mouse delay: 800, Path class: active-trail, Path levels 1, 
+	* Slide in effect: Vertical, Auto-arrows: off, Drip-shadows: on, More options: botb "use theme functions" ticked,
+	* Plugins - BigFrame: off, Use jQuery Supposition: on, Enable hoverintent: on, Touchscreen: disable, Smallscreen: disable,
+	* Plugins - Enable Supersubs: on, Supersubs min-widh: 25 max-width: 25, Multi-column submenus: off, 
+	* Advanced HTML: none set, HTML wrappers: none set, Advanced CSS: none set, CSS classes: main-menu-desktop
+  * The Superfish menu block needs a block class: main-menu-desktop
+  * Important note: CSS below hides first item of second level Superfish menu items
+  */
+.main-menu-desktop,
+.main-menu-desktop.block {
+  overflow: visible;
+}
+
+#main-menu .block,
+#main-menu .block__content,
+#main-menu .custom-block-inner,
+#main-menu .custom-block-title-wrapper,
+#main-menu .custom-block-content-inner,
+#main-menu .custom-views-footer-inner {
+  overflow: visible;
+}
+
+.main-menu-desktop .sf-menu.sf-style-none {
+  float: left;
+  margin: 0;
+  padding: 0;
+}
+.main-menu-desktop .sf-menu.sf-style-none ul {
+  padding-left: 0;
+}
+.main-menu-desktop .sf-menu.sf-style-none li {
+  font-size: 1em;
+  line-height: 1em;
+}
+.main-menu-desktop .sf-menu.sf-style-none li a {
+  font-size: 1.3em;
+  line-height: 1.1em;
+}
+.main-menu-desktop .sf-menu.sf-style-none li a, .main-menu-desktop .sf-menu.sf-style-none li a:visited {
+  color: #006f51;
+  text-decoration: none;
+}
+.main-menu-desktop .sf-menu.sf-style-none li:hover > a, .main-menu-desktop .sf-menu.sf-style-none li:sfHover > a {
+  color: #ffffff;
+}
+.main-menu-desktop .sf-menu.sf-style-none li a:focus, .main-menu-desktop .sf-menu.sf-style-none li a:hover, .main-menu-desktop .sf-menu.sf-style-none li a:active {
+  color: #ffffff;
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-1 > a {
+  padding: 8px 15px 4px 15px;
+  min-height: 3.33765em;
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-2 > a {
+  padding: 8px 21px 8px 21px;
+}
+.main-menu-desktop .sf-menu.sf-style-none li li:hover > a, .main-menu-desktop .sf-menu.sf-style-none li li:sfHover > a {
+  color: #333333;
+}
+.main-menu-desktop .sf-menu.sf-style-none li li a, .main-menu-desktop .sf-menu.sf-style-none li li a:visited {
+  color: #333333;
+}
+.main-menu-desktop .sf-menu.sf-style-none li li a:focus, .main-menu-desktop .sf-menu.sf-style-none li li a:hover, .main-menu-desktop .sf-menu.sf-style-none li li a:active {
+  color: #333333;
+}
+.main-menu-desktop .sf-menu.sf-style-none a.sf-with-ul {
+  padding-right: 3em;
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-1 > a {
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #fff;
+  border-bottom: 0;
+  -moz-border-radius: 17px 17px 0 0;
+  -webkit-border-radius: 17px 17px 0 0;
+  -ms-border-radius: 17px 17px 0 0;
+  -o-border-radius: 17px 17px 0 0;
+  border-radius: 17px 17px 0 0;
+  background: #e0e0e0;
+  background: -moz-linear-gradient(top, #e0e0e0 0, white 97%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #e0e0e0), color-stop(97%, white));
+  background: -webkit-linear-gradient(top, #e0e0e0 0, white 97%);
+  background: -o-linear-gradient(top, #e0e0e0 0, white 97%);
+  background: -ms-linear-gradient(top, #e0e0e0 0, white 97%);
+  background: linear-gradient(to bottom, #e0e0e0 0%, #ffffff 97%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#e0e0e0',endColorstr='#ffffff',GradientType=0);
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-1 > a:hover,
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-1 > a:focus {
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #fff;
+  border-bottom: 0;
+  -moz-border-radius: 17px 17px 0 0;
+  -webkit-border-radius: 17px 17px 0 0;
+  -ms-border-radius: 17px 17px 0 0;
+  -o-border-radius: 17px 17px 0 0;
+  border-radius: 17px 17px 0 0;
+  background: #4f850c;
+  background: -moz-linear-gradient(top, #46750b 0, #4f850c 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #46750b), color-stop(100%, #4f850c));
+  background: -webkit-linear-gradient(top, #46750b 0, #4f850c 100%);
+  background: -o-linear-gradient(top, #46750b 0, #4f850c 100%);
+  background: -ms-linear-gradient(top, #46750b 0, #4f850c 100%);
+  background: linear-gradient(top, #46750b 0%, #4f850c 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#46750b',endColorstr='#4f850c',GradientType=0);
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-1 > a:focus {
+  text-decoration: underline;
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-1.active-trail > a {
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-right: 2px solid #fff;
+  border-bottom: 0;
+  -moz-border-radius: 17px 17px 0 0;
+  -webkit-border-radius: 17px 17px 0 0;
+  -ms-border-radius: 17px 17px 0 0;
+  -o-border-radius: 17px 17px 0 0;
+  border-radius: 17px 17px 0 0;
+  color: #ffffff;
+  background: #4f850c;
+  background: -moz-linear-gradient(top, #46750b 0, #4f850c 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #46750b), color-stop(100%, #4f850c));
+  background: -webkit-linear-gradient(top, #46750b 0, #4f850c 100%);
+  background: -o-linear-gradient(top, #46750b 0, #4f850c 100%);
+  background: -ms-linear-gradient(top, #46750b 0, #4f850c 100%);
+  background: linear-gradient(top, #46750b 0%, #4f850c 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#46750b',endColorstr='#4f850c',GradientType=0);
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-2 > a {
+  background: #ffffff;
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-2 > a:hover,
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-2 > a:focus {
+  background: #f9f9f9;
+  background: -moz-linear-gradient(top, #f9f9f9 0, #dfdfdf 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #f9f9f9), color-stop(100%, #dfdfdf));
+  background: -webkit-linear-gradient(top, #f9f9f9 0, #dfdfdf 100%);
+  background: -o-linear-gradient(top, #f9f9f9 0, #dfdfdf 100%);
+  background: -ms-linear-gradient(top, #f9f9f9 0, #dfdfdf 100%);
+  background: linear-gradient(top, #f9f9f9 0%, #dfdfdf 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f9f9f9',endColorstr='#dfdfdf',GradientType=0);
+}
+.main-menu-desktop .sf-menu.sf-style-none li.sf-depth-2 > a:focus {
+  text-decoration: underline;
+}
+
+.main-menu-desktop {
+  /* drop shadow */
+  /* menu block should prevent more depths, but we are doing this as a safety net */
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal {
+  /* top level last tab */
+  /* top level tabs */
+  /* when there is only one child menu item */
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal > li.first:hover > ul,
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal > li.first.sfHover > ul {
+  left: 10px;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal > li:hover > ul,
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal > li.sfHover > ul {
+  left: -1px;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li:hover > ul,
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li.sfHover > ul {
+  top: 43px;
+  left: -35px;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li.sf-depth-1 {
+  margin-right: 5px;
+  background: none;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li.sf-depth-2 a {
+  border-left: 3px solid #d0d0d0;
+  border-right: 3px solid #d0d0d0;
+  border-bottom: 1px solid #ebebeb;
+  border-top: 0;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li.sf-depth-2.first a {
+  border-top: 3px solid #d0d0d0;
+  -moz-border-radius: 3px 3px 0 0;
+  -webkit-border-radius: 3px 3px 0 0;
+  -ms-border-radius: 3px 3px 0 0;
+  -o-border-radius: 3px 3px 0 0;
+  border-radius: 3px 3px 0 0;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li.sf-depth-2.last a {
+  border-bottom: 3px solid #d0d0d0;
+  -moz-border-radius: 0 0 3px 3px;
+  -webkit-border-radius: 0 0 3px 3px;
+  -ms-border-radius: 0 0 3px 3px;
+  -o-border-radius: 0 0 3px 3px;
+  border-radius: 0 0 3px 3px;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li.sf-depth-2.firstandlast a {
+  border-top: 3px solid #d0d0d0;
+  border-bottom: 3px solid #d0d0d0;
+  -moz-border-radius: 3px 3px 3px 3px;
+  -webkit-border-radius: 3px 3px 3px 3px;
+  -ms-border-radius: 3px 3px 3px 3px;
+  -o-border-radius: 3px 3px 3px 3px;
+  border-radius: 3px 3px 3px 3px;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li li:hover > ul,
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li li.sfHover > ul {
+  top: -1px;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal.sf-shadow ul {
+  padding: 0 8px 7px 0 !important;
+}
+.main-menu-desktop li.sf-depth-3, .main-menu-desktop li.sf-depth-4, .main-menu-desktop li.sf-depth-5, .main-menu-desktop li.sf-depth-6, .main-menu-desktop li.sf-depth-7, .main-menu-desktop li.sf-depth-8, .main-menu-desktop li.sf-depth-9, .main-menu-desktop li.sf-depth-10 {
+  display: none;
+}
+
+/* hide first child of the top level menu items only in Superfish. ie first item on second level will be hidden 
+ * we are doing this because we repeat the first level menu item as the first child item, biut we don't want to see
+ * ther duplicate links so we hide them with CSS
+ */
+.main-menu-desktop {
+  /* hide first child menu item */
+  /* add top borders theming to the second child, because the first child is gone now */
+}
+.main-menu-desktop .sf-item-1.sf-depth-2 {
+  display: none;
+}
+.main-menu-desktop .sf-menu.sf-style-none.sf-horizontal li.sf-item-2.sf-depth-2 a {
+  border-top: 3px solid #d0d0d0;
+  -moz-border-radius: 3px 3px 0 0;
+  -webkit-border-radius: 3px 3px 0 0;
+  -ms-border-radius: 3px 3px 0 0;
+  -o-border-radius: 3px 3px 0 0;
+  border-radius: 3px 3px 0 0;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  .main-menu-desktop {
+    display: none;
+  }
+}
+/** Mobile menu is just a menu block applied to main menu with only first level items displayed
+  * Requires tinynav module to apply a select list to class (include the dots in class): .main-menu-mobile ul.menu
+  * Requires setting on tinynav admin for media query: max width 480px.
+  * Requires a block class on the menublock (without dots in class): main-menu-mobile
+  */
+/* hide main menu mobile by default */
+.main-menu-mobile {
+  display: none;
+}
+
+/* mobile layout show main menu mobile */
+@media (min-width: 0px) and (max-width: 480px) {
+  .main-menu-mobile {
+    display: block;
+    margin-bottom: 12px;
+    /* select list created by tinynav module */
+  }
+  .main-menu-mobile .tinynav-wrapper {
+    width: 100%;
+  }
+  .main-menu-mobile .tinynav-wrapper select.tinynav {
+    width: 100%;
+    font-size: 18px;
+    border-color: #fff;
+    border-width: 2px;
+  }
+}
+/* meetings table
+ * requires block class: meetings-table
+ */
+.meetings-table table {
+  width: 100%;
+  margin-bottom: 20px;
+}
+.meetings-table table caption {
+  margin: 0;
+}
+.meetings-table table caption h2, .meetings-table table caption h3 {
+  display: block;
+  margin: 0;
+  padding: 0.64em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+  overflow: hidden;
+  text-align: left;
+}
+.meetings-table table td {
+  padding-top: 0.75em;
+  padding-bottom: 0.75em;
+  width: 25%;
+}
+.meetings-table table tr {
+  border-bottom: 1px solid #5d9711;
+}
+.meetings-table .views-field-field-publication-date {
+  font-weight: bold;
+}
+
+/* print styling overrides */
+@media print {
+  .meetings-table table caption h2, .meetings-table table caption h3 {
+    color: #000;
+    background: transparent;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+  .meetings-table table tr {
+    border-bottom: 1px solid #000;
+  }
+}
+.nation-banner-scotland {
+  overflow: hidden;
+  margin-bottom: 10px;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+}
+.nation-banner-scotland .custom-block-inner {
+  background: #79adf6;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIxJSIgc3RvcC1jb2xvcj0iIzc5YWRmNiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiMwMTViYTciIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #79adf6 1%, #015ba7 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(1%, #79adf6), color-stop(100%, #015ba7));
+  background: -webkit-linear-gradient(top, #79adf6 1%, #015ba7 100%);
+  background: -o-linear-gradient(top, #79adf6 1%, #015ba7 100%);
+  background: -ms-linear-gradient(top, #79adf6 1%, #015ba7 100%);
+  background: linear-gradient(top, #79adf6 1%, #015ba7 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#79adf6',endColorstr='#015ba7',GradientType=0);
+}
+
+.nation-banner-northern-ireland {
+  overflow: hidden;
+  margin-bottom: 10px;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+}
+.nation-banner-northern-ireland .custom-block-inner {
+  background: #851074;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzg1MTA3NCIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM2MjAyNTQiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #851074 0, #620254 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #851074), color-stop(100%, #620254));
+  background: -webkit-linear-gradient(top, #851074 0, #620254 100%);
+  background: -o-linear-gradient(top, #851074 0, #620254 100%);
+  background: -ms-linear-gradient(top, #851074 0, #620254 100%);
+  background: linear-gradient(top, #851074 0%, #620254 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#851074',endColorstr='#620254',GradientType=0);
+}
+
+.nation-banner-wales {
+  overflow: hidden;
+  margin-bottom: 10px;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+}
+.nation-banner-wales .custom-block-inner {
+  background: #c11d2d;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIxJSIgc3RvcC1jb2xvcj0iI2MxMWQyZCIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNhMzAxMTAiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #c11d2d 1%, #a30110 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(1%, #c11d2d), color-stop(100%, #a30110));
+  background: -webkit-linear-gradient(top, #c11d2d 1%, #a30110 100%);
+  background: -o-linear-gradient(top, #c11d2d 1%, #a30110 100%);
+  background: -ms-linear-gradient(top, #c11d2d 1%, #a30110 100%);
+  background: linear-gradient(top, #c11d2d 1%, #a30110 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#c11d2d',endColorstr='#a30110',GradientType=0);
+}
+
+h1.nation-scotland,
+h1.nation-northern-ireland,
+h1.nation-wales {
+  margin: 0;
+  padding: 4px 12px;
+  color: #fff;
+  font-size: 2.8em;
+  line-height: 1.2em;
+  font-weight: normal;
+  color: #fff;
+}
+
+.nation-menu {
+  margin-top: 10px;
+}
+.nation-menu ul {
+  padding: 0;
+  margin: 0;
+}
+.nation-menu ul.menu .leaf {
+  list-style-image: none;
+  list-style-type: none;
+}
+.nation-menu li {
+  font-size: 1.1em;
+  display: inline-block;
+  margin: 0;
+  padding: 0 10px 0 10px;
+  border-right: 1px solid #ffffff;
+  *display: inline;
+  zoom: 1;
+}
+.nation-menu li.last {
+  border-right: none;
+}
+.nation-menu a, .nation-menu a:visited {
+  color: #ffffff;
+  text-decoration: none;
+}
+.nation-menu a:hover,
+.nation-menu a:focus {
+  text-decoration: underline;
+}
+.nation-menu a.active {
+  font-weight: bold;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  .nation-menu li {
+    display: block;
+    padding: 0 0 0.75em 0;
+    text-align: right;
+    border-right: 0px;
+  }
+}
+/* Nation news
+ * requires block class: nation-news
+ */
+/* block content styling */
+.nation-news {
+  font-size: 1em;
+  line-height: 1.4em;
+  /* block title */
+  /* block content */
+  /* featured image */
+  /* content */
+  /* more link */
+  /* rows of content */
+}
+.nation-news h2.block__title {
+  color: #4B7A0A;
+  margin: 0 0 0.5em 0;
+  font-size: 1.6em;
+  font-weight: normal;
+  padding: .46875em 11px .140625em 11px;
+}
+.nation-news .block__content {
+  padding: .5em 11px .3em 11px;
+  overflow: hidden;
+}
+.nation-news .views-field-field-feature-image .field-content img {
+  float: left;
+  margin: 0 12px 0 0;
+}
+.nation-news h3 {
+  margin-left: 118px;
+  font-size: 1.2em;
+  line-height: 1.3em;
+  margin: 0 100px 0.5em 118px;
+  font-weight: normal;
+}
+.nation-news p, .nation-news span.more-link-wrapper {
+  margin-left: 118px;
+  font-size: 1.2em;
+  line-height: 1.3em;
+  margin-bottom: 15px;
+}
+.nation-news span.more-link-wrapper, .nation-news p.more-link-wrapper {
+  display: block;
+  margin-left: 118px;
+}
+.nation-news span.more-link-wrapper a.fsa-more-link, .nation-news p.more-link-wrapper a.fsa-more-link {
+  font-weight: bold;
+  padding-left: 11px;
+}
+.nation-news .views-row {
+  margin-bottom: 11px;
+  clear: left;
+  overflow: hidden;
+}
+
+/* the block styling */
+.nation-news {
+  overflow: hidden;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+  background: #f5f8f1;
+  margin-bottom: 20px;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  .nation-news h3 {
+    margin: 0 0px 0.5em 118px;
+  }
+}
+/* print styling overrides */
+@media print {
+  .nation-news {
+    overflow: hidden;
+    -webkit-border-radius: 0px;
+    -moz-border-radius: 0px;
+    -o-border-radius: 0px;
+    -ms-border-radius: 0px;
+    border-radius: 0px;
+    background: transparent;
+  }
+  .nation-news h2.block__title {
+    color: #000;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+    margin: 0;
+    font-size: 1.5em;
+    padding: 0.3em 11px;
+    font-weight: bold;
+  }
+  .nation-news h3 {
+    margin: 0;
+  }
+  .nation-news span.more-link-wrapper, .nation-news p.more-link-wrapper {
+    display: none;
+  }
+  .nation-news p {
+    margin-left: 0;
+    margin-bottom: 0;
+  }
+  .nation-news .views-field-field-feature-image {
+    display: none;
+  }
+  .nation-news .views-row.views-row-last {
+    margin-bottom: 0;
+  }
+}
+/* nation statement banner
+ * requires block class: nation-statement-banner
+ */
+/* Wales */
+.section-wales .nation-statement-banner {
+  position: relative;
+  margin-bottom: 20px;
+}
+.section-wales .nation-statement-banner .views-field-field-nation-banner-image {
+  width: 250px;
+  height: 190px;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  z-index: 10;
+}
+.section-wales .nation-statement-banner .views-field-field-nation-banner-image .mask {
+  z-index: 15;
+  width: 19px;
+  height: 190px;
+  position: absolute;
+  top: 0px;
+  right: 231px;
+  background: url("../images/banners/banner-curve-wales.png") left top no-repeat;
+}
+.section-wales .nation-statement-banner .block__content {
+  padding: 10px 10px 11px 11px;
+  margin-right: 250px;
+  background-color: #a30110;
+  min-height: 190px;
+}
+.section-wales .nation-statement-banner p {
+  margin: 0 0 .3em 0;
+  font-size: 2em;
+  line-height: 1.2em;
+}
+.section-wales .nation-statement-banner .views-field-field-nation-banner-text p a {
+  display: block;
+}
+.section-wales .nation-statement-banner p.banner-more {
+  margin: 0;
+  padding: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+.section-wales .nation-statement-banner a {
+  color: #fff;
+  text-decoration: none;
+}
+.section-wales .nation-statement-banner a:hover {
+  text-decoration: none;
+}
+.section-wales .nation-statement-banner p.banner-more a {
+  display: block;
+  padding-left: 13px;
+  background: url("../images/banners/banner-arrow-wales.png") 0 0.2em no-repeat;
+  text-decoration: none;
+}
+.section-wales .nation-statement-banner p.banner-more a:hover {
+  text-decoration: underline;
+}
+
+/* Scotland */
+.section-scotland .nation-statement-banner {
+  position: relative;
+  margin-bottom: 20px;
+}
+.section-scotland .nation-statement-banner .views-field-field-nation-banner-image {
+  width: 250px;
+  height: 190px;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  z-index: 10;
+}
+.section-scotland .nation-statement-banner .views-field-field-nation-banner-image .mask {
+  z-index: 15;
+  width: 19px;
+  height: 190px;
+  position: absolute;
+  top: 0px;
+  right: 231px;
+  background: url("../images/banners/banner-curve-scotland.png") left top no-repeat;
+}
+.section-scotland .nation-statement-banner .block__content {
+  padding: 10px 10px 11px 11px;
+  margin-right: 250px;
+  background-color: #035aaa;
+  min-height: 190px;
+}
+.section-scotland .nation-statement-banner p {
+  margin: 0 0 .3em 0;
+  font-size: 2em;
+  line-height: 1.2em;
+}
+.section-scotland .nation-statement-banner .views-field-field-nation-banner-text p a {
+  display: block;
+}
+.section-scotland .nation-statement-banner p.banner-more {
+  margin: 0;
+  padding: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+.section-scotland .nation-statement-banner a {
+  color: #fff;
+  text-decoration: none;
+}
+.section-scotland .nation-statement-banner a:hover {
+  text-decoration: none;
+}
+.section-scotland .nation-statement-banner p.banner-more a {
+  display: block;
+  padding-left: 13px;
+  background: url("../images/banners/banner-arrow-scotland.png") 0 0.2em no-repeat;
+  text-decoration: none;
+}
+.section-scotland .nation-statement-banner p.banner-more a:hover {
+  text-decoration: underline;
+}
+
+/* Northern Ireland */
+.section-northern-ireland .nation-statement-banner {
+  position: relative;
+  margin-bottom: 20px;
+}
+.section-northern-ireland .nation-statement-banner .views-field-field-nation-banner-image {
+  width: 250px;
+  height: 190px;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  z-index: 10;
+}
+.section-northern-ireland .nation-statement-banner .views-field-field-nation-banner-image .mask {
+  z-index: 15;
+  width: 19px;
+  height: 190px;
+  position: absolute;
+  top: 0px;
+  right: 231px;
+  background: url("../images/banners/banner-curve-northern-ireland.png") left top no-repeat;
+}
+.section-northern-ireland .nation-statement-banner .block__content {
+  padding: 10px 10px 11px 11px;
+  margin-right: 250px;
+  background-color: #760b67;
+  min-height: 190px;
+}
+.section-northern-ireland .nation-statement-banner p {
+  margin: 0 0 .3em 0;
+  font-size: 2em;
+  line-height: 1.2em;
+}
+.section-northern-ireland .nation-statement-banner .views-field-field-nation-banner-text p a {
+  display: block;
+}
+.section-northern-ireland .nation-statement-banner p.banner-more {
+  margin: 0;
+  padding: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+.section-northern-ireland .nation-statement-banner a {
+  color: #fff;
+  text-decoration: none;
+}
+.section-northern-ireland .nation-statement-banner a:hover {
+  text-decoration: none;
+}
+.section-northern-ireland .nation-statement-banner p.banner-more a {
+  display: block;
+  padding-left: 13px;
+  background: url("../images/banners/banner-arrow-northern-ireland.png") 0 0.2em no-repeat;
+  text-decoration: none;
+  margin-left: 1px;
+}
+.section-northern-ireland .nation-statement-banner p.banner-more a:hover {
+  text-decoration: underline;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  .section-wales .nation-statement-banner .views-field-field-nation-banner-image,
+  .section-scotland .nation-statement-banner .views-field-field-nation-banner-image,
+  .section-northern-ireland .nation-statement-banner .views-field-field-nation-banner-image {
+    display: none;
+  }
+  .section-wales .nation-statement-banner .block__content,
+  .section-scotland .nation-statement-banner .block__content,
+  .section-northern-ireland .nation-statement-banner .block__content {
+    margin-right: 0;
+    min-height: 0;
+  }
+}
+/* print styling overrides */
+@media print {
+  .section-wales .nation-statement-banner .views-field-field-nation-banner-image,
+  .section-scotland .nation-statement-banner .views-field-field-nation-banner-image,
+  .section-northern-ireland .nation-statement-banner .views-field-field-nation-banner-image {
+    display: none;
+  }
+  .section-wales .nation-statement-banner .block__content,
+  .section-scotland .nation-statement-banner .block__content,
+  .section-northern-ireland .nation-statement-banner .block__content {
+    margin-right: 0;
+    min-height: 0;
+    padding: 0;
+    background-color: transparent;
+    min-height: 0;
+  }
+  .section-wales .nation-statement-banner .views-field-field-nation-banner-link,
+  .section-scotland .nation-statement-banner .views-field-field-nation-banner-link,
+  .section-northern-ireland .nation-statement-banner .views-field-field-nation-banner-link {
+    display: none;
+  }
+  .section-wales .nation-statement-banner a,
+  .section-scotland .nation-statement-banner a,
+  .section-northern-ireland .nation-statement-banner a {
+    color: #000;
+    font-weight: bold;
+  }
+}
+ul.pager {
+  display: block;
+  margin-top: 20px;
+  margin-bottom: 1em;
+}
+ul.pager li {
+  font-weight: bold;
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+ul.pager li a {
+  color: #368303;
+  font-weight: normal;
+  text-decoration: none;
+}
+ul.pager li a:hover {
+  text-decoration: underline;
+}
+ul.pager li.pager__item--current {
+  color: #333;
+}
+ul.pager li.pager__item--first a,
+ul.pager li.pager__item--previous a,
+ul.pager li.pager__item--next a,
+ul.pager li.pager__item--last a {
+  font-weight: bold;
+  text-decoration: none;
+}
+ul.pager li.pager__item--first a:hover,
+ul.pager li.pager__item--previous a:hover,
+ul.pager li.pager__item--next a:hover,
+ul.pager li.pager__item--last a:hover {
+  text-decoration: underline;
+}
+
+/* print styling overrides */
+@media print {
+  ul.pager {
+    display: none;
+  }
+}
+/** requires block class: popular-links and purple-block. 
+ *  purple-block implemented in base/blocks.scss 
+ */
+.popular-links select {
+  width: 100%;
+  margin-bottom: 1em;
+  padding: 2px 0;
+  background: #fff;
+  vertical-align: middle;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  font-family: Arial, Verdana, Helvetica, sans-serif;
+  font-size: 1.2em;
+  color: #333;
+}
+.popular-links label {
+  display: block;
+  font-size: 1.5em;
+  color: #fff;
+  margin: 0 0 0.4em 0;
+}
+
+/* Contact for further information */
+#node_programme_full_group_further_info {
+  padding-bottom: 12px;
+}
+
+/* Project list */
+#node_programme_full_group_projects {
+  padding-bottom: 12px;
+  /* teaser title */
+  /* teaser text */
+  /* field items */
+  /* rows */
+}
+#node_programme_full_group_projects h3.node__title {
+  font-size: 1.3em;
+  line-height: 1.4em;
+  margin-bottom: 0;
+  font-weight: bold;
+}
+#node_programme_full_group_projects .field--name-field-subtitle {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+}
+#node_programme_full_group_projects .field__item {
+  margin-bottom: 0.5em;
+}
+#node_programme_full_group_projects .node__content {
+  border-bottom: 1px solid #5d9711;
+  padding-bottom: 7px;
+  margin-bottom: 7px;
+}
+
+/* research project list
+ * requires block class: research-project-list
+ */
+.research-project-list .views-field-title h2 {
+  font-size: 1.3em;
+  line-height: 1.3em;
+  margin-bottom: 0.5em;
+  font-weight: bold;
+}
+.research-project-list .views-field-field-summary {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  display: block;
+  color: #333;
+  margin-bottom: 0.5em;
+}
+.research-project-list .views-field-field-results-added {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  font-weight: bold;
+}
+.research-project-list .views-row {
+  padding-bottom: 15px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid #5d9711;
+}
+.research-project-list .field__item {
+  margin-bottom: 0.5em;
+}
+
+#views-exposed-form-research-projects-page .form-text {
+  width: 100%;
+}
+#views-exposed-form-research-projects-page .views-exposed-widget {
+  float: none;
+}
+#views-exposed-form-research-projects-page .views-widget-filter-keyword {
+  max-width: none !important;
+}
+#views-exposed-form-research-projects-page .views-widget-filter-project_status {
+  display: inline-block !important;
+}
+#views-exposed-form-research-projects-page .views-exposed-widget.views-submit-button {
+  display: inline-block !important;
+}
+
+/* project node header (view block)
+ * requires block class: project-node-header
+ */
+.project-node-header {
+  margin-bottom: 20px;
+}
+.project-node-header .views-field-field-duration,
+.project-node-header .views-field-field-contractor,
+.project-node-header .views-field-field-project-code,
+.project-node-header .views-field-field-contact-blolb,
+.project-node-header .views-field-field-start-date,
+.project-node-header .views-field-field-end-date,
+.project-node-header .views-field-field-lead-author,
+.project-node-header .views-field-field-budget {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  margin-bottom: 0.3em;
+}
+.project-node-header p {
+  font-size: 1em;
+}
+.project-node-header div.display-inline {
+  display: inline;
+}
+.project-node-header div.display-inline p {
+  display: inline;
+}
+
+/* requires block class: resources and blokc class: blue-block */
+.resources {
+  font-size: 1em;
+  line-height: 1.4em;
+  /* node title */
+  /* subtitle */
+  /* teaser updated date */
+  /* teaser summary */
+  /* node links like read more (if enabled) */
+  /* line separator */
+}
+.resources h2.node__title {
+  font-size: 1.3em;
+  line-height: 1.4em;
+  margin-bottom: 1px;
+  font-weight: normal;
+}
+.resources .node__title {
+  font-weight: normal;
+  display: block;
+  margin-bottom: 1px;
+}
+.resources .node__title a {
+  text-decoration: none;
+  color: #00416c;
+  font-weight: bold;
+}
+.resources .node__title a:hover {
+  text-decoration: underline;
+}
+.resources h3 {
+  margin-bottom: 1px;
+}
+.resources .field--name-field-subtitle {
+  font-size: 1.1em;
+  line-height: 1.4em;
+  display: block;
+}
+.resources .field--name-field-updated {
+  font-size: 1.1em;
+  margin-bottom: 0.2em;
+}
+.resources .field--name-field-summary {
+  font-size: 1.1em;
+  line-height: 1.4em;
+  display: block;
+  color: #333;
+  margin-bottom: 0.2em;
+}
+.resources .field__item {
+  margin-bottom: 0.5em;
+}
+.resources .node__links a {
+  text-decoration: none;
+  color: #00416c;
+}
+.resources .node__links a:hover {
+  text-decoration: underline;
+}
+.resources .views-row {
+  border-bottom: 1px solid #c6d7dd;
+  padding-bottom: 2px;
+  margin-bottom: 5px;
+}
+.resources .views-row.views-row-last {
+  border-bottom: none;
+  padding-bottom: 2px;
+  margin-bottom: 0;
+}
+
+/* positioning of block on landing page */
+.node-type-landing-page .resources {
+  width: 225px;
+  margin-left: 6px;
+  float: right;
+}
+
+/* mobile view */
+@media (min-width: 0px) and (max-width: 480px) {
+  .node-type-landing-page .resources {
+    font-size: 1.1em;
+    width: 100%;
+    margin-left: 0px;
+    float: none;
+  }
+}
+/* print styling overrides */
+@media print {
+  .resources {
+    clear: both;
+    float: none;
+    width: auto;
+    margin-left: 0;
+  }
+  .resources .node__title a,
+  .resources .field--name-field-summary,
+  .resources .node__links a {
+    color: #000;
+  }
+  .resources .node__title a {
+    font-weight: normal;
+  }
+  .resources .views-row {
+    border-bottom: none;
+  }
+
+  .node-type-landing-page .resources {
+    width: auto;
+    margin-left: 0;
+    float: none;
+  }
+}
+/* science field - note wysiwyg also has a science style - for that implementation see base/_wysiwyg.scss */
+.field--name-field-science-data {
+  clear: both;
+  display: block;
+  background: #fff;
+  border: 1px solid #5d9711;
+  color: #333;
+  padding: 9px 10px 6px 10px;
+  margin-bottom: 1.3em;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+}
+.field--name-field-science-data h2, .field--name-field-science-data h3,
+.field--name-field-science-data .field__label {
+  margin: 0 0 0.5em 0;
+  padding: 0;
+  font-size: 1.4em;
+  color: #5d9711;
+  background: none;
+  font-weight: bold;
+}
+
+/* print styling overrides */
+@media print {
+  .field--name-field-science-data {
+    background: transparent;
+    border: 1px solid #000;
+    color: #000;
+    -webkit-border-radius: 0px;
+    -moz-border-radius: 0px;
+    -o-border-radius: 0px;
+    -ms-border-radius: 0px;
+    border-radius: 0px;
+  }
+  .field--name-field-science-data h2, .field--name-field-science-data h3,
+  .field--name-field-science-data .field__label {
+    color: #000;
+  }
+}
+/** 
+ * search form 
+ * dependant on having block class: search-keyword-page
+ */
+.search-keyword-page {
+  /* wrapper for search text box and its label */
+  /* wrapper for submit button */
+}
+.search-keyword-page .views-exposed-form .views-exposed-widget.views-widget-filter-keyword {
+  padding: 0.5em 0.5em 0 0;
+  max-width: 80%;
+  /* need to restrict width to prevent wraping of submit button when increasing font size */
+}
+.search-keyword-page label,
+.search-keyword-page .views-exposed-form label,
+.search-keyword-page .form-item label,
+.search-keyword-page .form-actions label {
+  padding-bottom: 0.25em;
+  display: block;
+  padding-left: 3px;
+  color: #333;
+  font-weight: normal;
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+.search-keyword-page input.form-text {
+  width: 100%;
+  /* input form text is restricted by width of its wrapper */
+  margin-bottom: .8em;
+  padding: 2px 4px;
+  background: #fff;
+  font-size: 1.2em;
+  vertical-align: middle;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  font-family: Arial,Verdana,Helvetica,sans-serif;
+  font-size: 1.2em;
+  color: #333;
+}
+.search-keyword-page input.form-submit {
+  overflow: hidden;
+  display: block;
+  margin: 0;
+  padding: 4px;
+  width: 24px;
+  border: 1px solid #ccc;
+  border-left: none;
+  vertical-align: middle;
+  font-size: 1.2em;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  -o-border-radius: 5px;
+  -ms-border-radius: 5px;
+  border-radius: 5px;
+  background-color: #D34D1A;
+  background-image: url("../images/search.png");
+  background-repeat: no-repeat;
+  background-position: 5px 3px;
+  text-indent: -9999px;
+}
+.search-keyword-page input.form-submit:hover {
+  background-color: #CC3708;
+}
+.search-keyword-page .views-exposed-form .views-exposed-widget.views-submit-button {
+  position: relative;
+  top: -2px;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  .search-keyword-page {
+    -moz-border-radius: 10px;
+    -webkit-border-radius: 10px;
+    -o-border-radius: 10px;
+    -ms-border-radius: 10px;
+    border-radius: 10px;
+    /* wrapper for search text box and its label */
+  }
+  .search-keyword-page input.form-text {
+    width: 100%;
+  }
+  .search-keyword-page .views-exposed-form .views-exposed-widget.views-widget-filter-keyword {
+    max-width: 70%;
+    /* need to restrict this to prevent wrapping of submit button */
+  }
+}
+/**
+ * Search facet
+ * dependant on black class: search-facet
+ */
+.search-facet label,
+.search-facet .views-exposed-form label,
+.search-facet .form-item label,
+.search-facet .form-actions label {
+  padding-bottom: 0.25em;
+  display: block;
+  padding-left: 3px;
+  color: #333;
+  font-weight: normal;
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+.search-facet select {
+  color: #666;
+  width: 99%;
+  padding: 1px 2px;
+  margin-bottom: .5em;
+  vertical-align: middle;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  font-family: Arial, Verdana, Helvetica, sans-serif;
+  font-size: 1.2em;
+}
+
+.l-sidebar-second .search-facet .form-item,
+.l-sidebar-first .search-facet .form-item {
+  margin-bottom: 0.35em;
+}
+
+/* active links tabs */
+.current-search-item-active-links {
+  margin-bottom: 20px;
+}
+.current-search-item-active-links ul {
+  margin: 0 0 0.75em 0;
+  padding: 0;
+  list-style-type: none;
+}
+.current-search-item-active-links ul li {
+  font-size: 1em;
+  margin: 0px 5px 5px 0px;
+  display: inline-block;
+  *display: inline;
+  zoom: 1;
+}
+.current-search-item-active-links ul li a {
+  font-size: 1.2em;
+  font-weight: normal;
+  color: #ffffff;
+  background-color: #D3461A;
+  padding: 5px 8px 5px 8px;
+  border: none;
+  text-decoration: none;
+}
+.current-search-item-active-links ul li a:hover {
+  color: #ffffff;
+  background-color: #CC3708;
+  text-decoration: none;
+}
+
+/**
+ * container around the search filter wrapper 
+ * dependant on container_blocks custom module and block class: grey-container-block
+ */
+.grey-container-block {
+  overflow: hidden;
+  margin-bottom: 20px;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+  /* direct children only, not decendants - the grey container block contains other blocks that also has this class and we don't want to effect them */
+}
+.grey-container-block > .custom-block-inner {
+  padding: 11px 9px 21px 11px;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlNWU1ZTUiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(100%, #e5e5e5));
+  background: -webkit-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -o-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -ms-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: linear-gradient(top, #ffffff 0%, #e5e5e5 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#e5e5e5',GradientType=0);
+}
+.grey-container-block h2.block__title {
+  color: #5d9711;
+  background: none;
+  padding-left: 0;
+  margin: 0 0 .6em 0;
+  padding: 0;
+  font-size: 1.5em;
+  font-weight: bold;
+}
+
+/* print styling overrides */
+@media print {
+  .grey-container-block {
+    border: 1px solid #000;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+    -o-border-radius: 0;
+    -ms-border-radius: 0;
+    border-radius: 0;
+  }
+  .grey-container-block > .custom-block-inner {
+    background: none;
+    background-color: transparent;
+  }
+  .grey-container-block h2.block__title {
+    color: #000;
+  }
+  .grey-container-block .block__content {
+    display: none;
+  }
+
+  .search-facet {
+    display: none;
+  }
+}
+/**
+ * Local authority search forms
+ * Requires block class: local-authority-search
+ */
+/* default for main and sidebar - local authority search form */
+.local-authority-search label {
+  font-weight: normal;
+}
+.local-authority-search .form-type-radio label {
+  position: relative;
+  top: 2px;
+}
+.local-authority-search .form-type-textfield label {
+  padding-bottom: 0.25em;
+  display: block;
+  padding-left: 3px;
+  font-weight: normal;
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+.local-authority-search input.form-text {
+  padding: 2px 4px;
+  background: #fff;
+  font-size: 1.2em;
+  vertical-align: middle;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  font-family: Arial,Verdana,Helvetica,sans-serif;
+  font-size: 1.2em;
+  color: #333;
+}
+.local-authority-search input.form-submit {
+  overflow: hidden;
+  border: 1px solid #fff;
+  line-height: 1em;
+  font-size: 1.2em;
+  font-weight: bold;
+  white-space: normal;
+  word-wrap: break-word;
+  display: block;
+  text-decoration: none;
+  color: #3d3d3d;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSI0NiUiIHN0b3AtY29sb3I9IiNmZmZmZmYiIHN0b3Atb3BhY2l0eT0iMSIvPgogICAgPHN0b3Agb2Zmc2V0PSI5OSUiIHN0b3AtY29sb3I9IiNjZGNkY2QiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(46%, white), color-stop(99%, #cdcdcd));
+  background: -webkit-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -o-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -ms-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: linear-gradient(top, #ffffff 46%, #cdcdcd 99%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#cdcdcd',GradientType=0);
+  padding: 6px;
+}
+
+/* main - local authority search form */
+#main-content .local-authority-search {
+  overflow: hidden;
+  margin-bottom: 20px;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+}
+#main-content .local-authority-search .custom-block-inner {
+  padding: 11px 9px 21px 11px;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlNWU1ZTUiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(100%, #e5e5e5));
+  background: -webkit-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -o-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -ms-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: linear-gradient(top, #ffffff 0%, #e5e5e5 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#e5e5e5',GradientType=0);
+}
+#main-content .local-authority-search h2.block__title {
+  color: #5d9711;
+  background: none;
+  padding-left: 0;
+  margin: 0 0 .6em 0;
+  padding: 0;
+  font-size: 1.5em;
+  font-weight: bold;
+}
+#main-content .local-authority-search fieldset,
+#main-content .local-authority-search form,
+#main-content .local-authority-search legend {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#main-content .local-authority-search fieldset {
+  margin-bottom: 1.5em;
+}
+#main-content .local-authority-search legend {
+  color: #333;
+  font-size: 1.2em;
+  font-weight: bold;
+  padding: 0 0 0.8em 0;
+  line-height: 1.1em;
+  margin: 0;
+  position: relative;
+  width: auto;
+  left: 0;
+  display: block;
+}
+#main-content .local-authority-search input.form-submit {
+  border: 1px solid #bbb;
+  float: right;
+}
+#main-content .local-authority-search input.form-submit:hover,
+#main-content .local-authority-search input.form-submit:focus {
+  text-decoration: underline;
+  border: 1px solid #f67f2a;
+}
+#main-content .local-authority-search .form-type-radio {
+  width: auto;
+  padding-right: 33px;
+  float: left;
+}
+#main-content .local-authority-search .form-item.form-type-textfield {
+  width: 138px;
+  margin-right: 13px;
+  float: left;
+  overflow: hidden;
+  margin-bottom: 0;
+}
+#main-content .local-authority-search .form-item.form-type-textfield.form-item-postcode {
+  margin-right: 0px;
+}
+#main-content .local-authority-search input.form-text {
+  width: 100%;
+  /* input form text is restricted by width of its wrapper */
+}
+
+/* sidebar - local authority search form */
+.l-sidebar-second .local-authority-search,
+.l-sidebar-first .local-authority-search {
+  overflow: hidden;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+}
+.l-sidebar-second .local-authority-search .custom-block-inner,
+.l-sidebar-first .local-authority-search .custom-block-inner {
+  background: #9e218a;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJod…EiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(1%, #9e218a), color-stop(100%, #5d0050));
+  background: -webkit-linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  background: -o-linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  background: -ms-linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  background: linear-gradient(top, #9e218a 1%, #5d0050 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#9e218a',endColorstr='#5d0050',GradientType=0);
+}
+.l-sidebar-second .local-authority-search h2.block__title,
+.l-sidebar-first .local-authority-search h2.block__title {
+  font-size: 1.5em;
+  color: #fff;
+  padding: .5em 11px .15em 11px;
+  margin: 0;
+}
+.l-sidebar-second .local-authority-search .block__content,
+.l-sidebar-first .local-authority-search .block__content {
+  color: #fff;
+  padding: .5em 11px 21px 11px;
+}
+.l-sidebar-second .local-authority-search fieldset,
+.l-sidebar-second .local-authority-search form,
+.l-sidebar-second .local-authority-search legend,
+.l-sidebar-first .local-authority-search fieldset,
+.l-sidebar-first .local-authority-search form,
+.l-sidebar-first .local-authority-search legend {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.l-sidebar-second .local-authority-search legend,
+.l-sidebar-first .local-authority-search legend {
+  color: #fff;
+  position: absolute;
+  left: -1000px;
+  margin: 0 !important;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.l-sidebar-second .local-authority-search .form-item,
+.l-sidebar-first .local-authority-search .form-item {
+  margin-bottom: 0.5em;
+}
+.l-sidebar-second .local-authority-search .form-item.form-item-postcode,
+.l-sidebar-first .local-authority-search .form-item.form-item-postcode {
+  margin-bottom: 1em;
+}
+.l-sidebar-second .local-authority-search input.form-text,
+.l-sidebar-first .local-authority-search input.form-text {
+  width: 100%;
+  /* input form text is restricted by width of its wrapper */
+  margin-bottom: 0;
+}
+.l-sidebar-second .local-authority-search input.form-submit,
+.l-sidebar-first .local-authority-search input.form-submit {
+  border: 1px solid #fff;
+  float: right;
+  margin-bottom: 12px;
+  padding: 3px 6px 3px 6px;
+}
+.l-sidebar-second .local-authority-search input.form-submit:hover,
+.l-sidebar-second .local-authority-search input.form-submit:focus,
+.l-sidebar-first .local-authority-search input.form-submit:hover,
+.l-sidebar-first .local-authority-search input.form-submit:focus {
+  text-decoration: underline;
+  border: 1px solid #fff;
+}
+
+/* local authority map - dependant on block class: local-authority-map */
+.local-authority-map {
+  margin-bottom: 20px;
+}
+
+/* local authority search results - depandant on block class: local-authority-search-results */
+.local-authority-search-results .block__content a {
+  text-decoration: underline;
+}
+.local-authority-search-results .block__content a:hover {
+  text-decoration: none;
+}
+.local-authority-search-results .block__content h2.block__title {
+  display: none;
+}
+.local-authority-search-results .block__content ol {
+  padding-left: 2em;
+}
+.local-authority-search-results .block__content li {
+  font-size: 1.2em;
+  line-height: 1.4em;
+  margin-bottom: 1em;
+  padding-bottom: 0.8em;
+  border-bottom: 1px solid #ccc;
+}
+.local-authority-search-results .block__content li p, .local-authority-search-results .block__content li li {
+  font-size: 1em;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  /* form default for mobile */
+  .local-authority-search .form-type-textfield label,
+  #main-content .local-authority-search .form-type-textfield label,
+  .l-sidebar-second .local-authority-search .form-type-textfield label,
+  .l-sidebar-first .local-authority-search .form-type-textfield label {
+    padding-bottom: 0.25em;
+    display: block;
+    padding-left: 3px;
+  }
+  .local-authority-search input.form-submit,
+  #main-content .local-authority-search input.form-submit,
+  .l-sidebar-second .local-authority-search input.form-submit,
+  .l-sidebar-first .local-authority-search input.form-submit {
+    float: none;
+    margin-bottom: none;
+  }
+  .local-authority-search input.form-text,
+  #main-content .local-authority-search input.form-text,
+  .l-sidebar-second .local-authority-search input.form-text,
+  .l-sidebar-first .local-authority-search input.form-text {
+    width: 100%;
+    /* input form text is restricted by width of its wrapper */
+    margin-bottom: 0.8em;
+    padding: 2px 4px;
+  }
+
+  /* form in main for mobile */
+  #main-content .local-authority-search .form-item.form-type-textfield {
+    width: 100%;
+    margin-right: 0;
+    float: none;
+    overflow: auto;
+    margin-bottom: 0.5em;
+  }
+  #main-content .local-authority-search .form-type-radio {
+    width: auto;
+    padding-right: 0;
+    float: none;
+  }
+
+  /* form in sidebar for mobile */
+  .l-sidebar-second .local-authority-search h2.block__title,
+  .l-sidebar-first .local-authority-search h2.block__title {
+    margin-top: 0.5em;
+  }
+  .l-sidebar-second .local-authority-search legend,
+  .l-sidebar-first .local-authority-search legend {
+    padding: 0 0 1em 0;
+  }
+  .l-sidebar-second .local-authority-search input.form-submit,
+  .l-sidebar-first .local-authority-search input.form-submit {
+    padding: 6px;
+  }
+
+  .l-region--sidebar-second .local-authority-search.block {
+    margin-bottom: 20px;
+  }
+}
+/* print styling overrides */
+@media print {
+  .local-authority-search,
+  #main-content .local-authority-search {
+    display: none;
+  }
+}
+.current-search-item-text .result-count {
+  color: #666;
+  display: block;
+  font-weight: normal;
+  padding: 3px 0;
+  font-size: 1.2em;
+  line-height: 1.4em;
+  margin-bottom: 12px;
+}
+.current-search-item-text .search-results-heading,
+.current-search-item-text h2.search-results-heading {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+}
+
+.views-field-zs-view-mode-search-result,
+.views-field-zs-view-mode-search-results-2,
+.views-field-zs-view-mode-search-results-3,
+.views-field-zs-view-mode-search-results-4,
+.views-field-zs-view-mode-search-results-5,
+.views-field-zs-view-mode-search-results-6,
+.views-field-zs-view-mode-search-results-7,
+.views-field-zs-view-mode-search-results-8,
+.views-field-zs-view-mode-search-results-9,
+.views-field-zs-view-mode-search-results-10 {
+  border-bottom: 1px solid #5d9711;
+  padding: 12px 0 7px 0;
+  /* setup defualt formatting for content */
+  /* override formatting of summary */
+  /* override formatting of subtitle */
+  /* override formatting of last updated */
+}
+.views-field-zs-view-mode-search-result li,
+.views-field-zs-view-mode-search-results-2 li,
+.views-field-zs-view-mode-search-results-3 li,
+.views-field-zs-view-mode-search-results-4 li,
+.views-field-zs-view-mode-search-results-5 li,
+.views-field-zs-view-mode-search-results-6 li,
+.views-field-zs-view-mode-search-results-7 li,
+.views-field-zs-view-mode-search-results-8 li,
+.views-field-zs-view-mode-search-results-9 li,
+.views-field-zs-view-mode-search-results-10 li {
+  font-size: 1em;
+}
+.views-field-zs-view-mode-search-result p,
+.views-field-zs-view-mode-search-results-2 p,
+.views-field-zs-view-mode-search-results-3 p,
+.views-field-zs-view-mode-search-results-4 p,
+.views-field-zs-view-mode-search-results-5 p,
+.views-field-zs-view-mode-search-results-6 p,
+.views-field-zs-view-mode-search-results-7 p,
+.views-field-zs-view-mode-search-results-8 p,
+.views-field-zs-view-mode-search-results-9 p,
+.views-field-zs-view-mode-search-results-10 p {
+  font-size: 1em;
+}
+.views-field-zs-view-mode-search-result h1.node__title,
+.views-field-zs-view-mode-search-result h2.node__title,
+.views-field-zs-view-mode-search-result h3.node__title,
+.views-field-zs-view-mode-search-result h3.file__title,
+.views-field-zs-view-mode-search-result h1, .views-field-zs-view-mode-search-result h2,
+.views-field-zs-view-mode-search-results-2 h1.node__title,
+.views-field-zs-view-mode-search-results-2 h2.node__title,
+.views-field-zs-view-mode-search-results-2 h3.node__title,
+.views-field-zs-view-mode-search-results-2 h3.file__title,
+.views-field-zs-view-mode-search-results-2 h1,
+.views-field-zs-view-mode-search-results-2 h2,
+.views-field-zs-view-mode-search-results-3 h1.node__title,
+.views-field-zs-view-mode-search-results-3 h2.node__title,
+.views-field-zs-view-mode-search-results-3 h3.node__title,
+.views-field-zs-view-mode-search-results-3 h3.file__title,
+.views-field-zs-view-mode-search-results-3 h1,
+.views-field-zs-view-mode-search-results-3 h2,
+.views-field-zs-view-mode-search-results-4 h1.node__title,
+.views-field-zs-view-mode-search-results-4 h2.node__title,
+.views-field-zs-view-mode-search-results-4 h3.node__title,
+.views-field-zs-view-mode-search-results-4 h3.file__title,
+.views-field-zs-view-mode-search-results-4 h1,
+.views-field-zs-view-mode-search-results-4 h2,
+.views-field-zs-view-mode-search-results-5 h1.node__title,
+.views-field-zs-view-mode-search-results-5 h2.node__title,
+.views-field-zs-view-mode-search-results-5 h3.node__title,
+.views-field-zs-view-mode-search-results-5 h3.file__title,
+.views-field-zs-view-mode-search-results-5 h1,
+.views-field-zs-view-mode-search-results-5 h2,
+.views-field-zs-view-mode-search-results-6 h1.node__title,
+.views-field-zs-view-mode-search-results-6 h2.node__title,
+.views-field-zs-view-mode-search-results-6 h3.node__title,
+.views-field-zs-view-mode-search-results-6 h3.file__title,
+.views-field-zs-view-mode-search-results-6 h1,
+.views-field-zs-view-mode-search-results-6 h2,
+.views-field-zs-view-mode-search-results-7 h1.node__title,
+.views-field-zs-view-mode-search-results-7 h2.node__title,
+.views-field-zs-view-mode-search-results-7 h3.node__title,
+.views-field-zs-view-mode-search-results-7 h3.file__title,
+.views-field-zs-view-mode-search-results-7 h1,
+.views-field-zs-view-mode-search-results-7 h2,
+.views-field-zs-view-mode-search-results-8 h1.node__title,
+.views-field-zs-view-mode-search-results-8 h2.node__title,
+.views-field-zs-view-mode-search-results-8 h3.node__title,
+.views-field-zs-view-mode-search-results-8 h3.file__title,
+.views-field-zs-view-mode-search-results-8 h1,
+.views-field-zs-view-mode-search-results-8 h2,
+.views-field-zs-view-mode-search-results-9 h1.node__title,
+.views-field-zs-view-mode-search-results-9 h2.node__title,
+.views-field-zs-view-mode-search-results-9 h3.node__title,
+.views-field-zs-view-mode-search-results-9 h3.file__title,
+.views-field-zs-view-mode-search-results-9 h1,
+.views-field-zs-view-mode-search-results-9 h2,
+.views-field-zs-view-mode-search-results-10 h1.node__title,
+.views-field-zs-view-mode-search-results-10 h2.node__title,
+.views-field-zs-view-mode-search-results-10 h3.node__title,
+.views-field-zs-view-mode-search-results-10 h3.file__title,
+.views-field-zs-view-mode-search-results-10 h1,
+.views-field-zs-view-mode-search-results-10 h2 {
+  font-size: 1.4em;
+  line-height: 1.3em;
+  margin-bottom: .4em;
+}
+.views-field-zs-view-mode-search-result a,
+.views-field-zs-view-mode-search-results-2 a,
+.views-field-zs-view-mode-search-results-3 a,
+.views-field-zs-view-mode-search-results-4 a,
+.views-field-zs-view-mode-search-results-5 a,
+.views-field-zs-view-mode-search-results-6 a,
+.views-field-zs-view-mode-search-results-7 a,
+.views-field-zs-view-mode-search-results-8 a,
+.views-field-zs-view-mode-search-results-9 a,
+.views-field-zs-view-mode-search-results-10 a {
+  color: #006f51;
+  text-decoration: none;
+}
+.views-field-zs-view-mode-search-result a:hover,
+.views-field-zs-view-mode-search-results-2 a:hover,
+.views-field-zs-view-mode-search-results-3 a:hover,
+.views-field-zs-view-mode-search-results-4 a:hover,
+.views-field-zs-view-mode-search-results-5 a:hover,
+.views-field-zs-view-mode-search-results-6 a:hover,
+.views-field-zs-view-mode-search-results-7 a:hover,
+.views-field-zs-view-mode-search-results-8 a:hover,
+.views-field-zs-view-mode-search-results-9 a:hover,
+.views-field-zs-view-mode-search-results-10 a:hover {
+  text-decoration: underline;
+}
+.views-field-zs-view-mode-search-result .node__content .field,
+.views-field-zs-view-mode-search-result .node .content .field,
+.views-field-zs-view-mode-search-results-2 .node__content .field,
+.views-field-zs-view-mode-search-results-2 .node .content .field,
+.views-field-zs-view-mode-search-results-3 .node__content .field,
+.views-field-zs-view-mode-search-results-3 .node .content .field,
+.views-field-zs-view-mode-search-results-4 .node__content .field,
+.views-field-zs-view-mode-search-results-4 .node .content .field,
+.views-field-zs-view-mode-search-results-5 .node__content .field,
+.views-field-zs-view-mode-search-results-5 .node .content .field,
+.views-field-zs-view-mode-search-results-6 .node__content .field,
+.views-field-zs-view-mode-search-results-6 .node .content .field,
+.views-field-zs-view-mode-search-results-7 .node__content .field,
+.views-field-zs-view-mode-search-results-7 .node .content .field,
+.views-field-zs-view-mode-search-results-8 .node__content .field,
+.views-field-zs-view-mode-search-results-8 .node .content .field,
+.views-field-zs-view-mode-search-results-9 .node__content .field,
+.views-field-zs-view-mode-search-results-9 .node .content .field,
+.views-field-zs-view-mode-search-results-10 .node__content .field,
+.views-field-zs-view-mode-search-results-10 .node .content .field {
+  font-size: 1.2em;
+  margin-bottom: .6em;
+  line-height: 1.5em;
+  color: #333;
+}
+.views-field-zs-view-mode-search-result .node__content .field li, .views-field-zs-view-mode-search-result .node__content .field p,
+.views-field-zs-view-mode-search-result .node .content .field li,
+.views-field-zs-view-mode-search-result .node .content .field p,
+.views-field-zs-view-mode-search-results-2 .node__content .field li,
+.views-field-zs-view-mode-search-results-2 .node__content .field p,
+.views-field-zs-view-mode-search-results-2 .node .content .field li,
+.views-field-zs-view-mode-search-results-2 .node .content .field p,
+.views-field-zs-view-mode-search-results-3 .node__content .field li,
+.views-field-zs-view-mode-search-results-3 .node__content .field p,
+.views-field-zs-view-mode-search-results-3 .node .content .field li,
+.views-field-zs-view-mode-search-results-3 .node .content .field p,
+.views-field-zs-view-mode-search-results-4 .node__content .field li,
+.views-field-zs-view-mode-search-results-4 .node__content .field p,
+.views-field-zs-view-mode-search-results-4 .node .content .field li,
+.views-field-zs-view-mode-search-results-4 .node .content .field p,
+.views-field-zs-view-mode-search-results-5 .node__content .field li,
+.views-field-zs-view-mode-search-results-5 .node__content .field p,
+.views-field-zs-view-mode-search-results-5 .node .content .field li,
+.views-field-zs-view-mode-search-results-5 .node .content .field p,
+.views-field-zs-view-mode-search-results-6 .node__content .field li,
+.views-field-zs-view-mode-search-results-6 .node__content .field p,
+.views-field-zs-view-mode-search-results-6 .node .content .field li,
+.views-field-zs-view-mode-search-results-6 .node .content .field p,
+.views-field-zs-view-mode-search-results-7 .node__content .field li,
+.views-field-zs-view-mode-search-results-7 .node__content .field p,
+.views-field-zs-view-mode-search-results-7 .node .content .field li,
+.views-field-zs-view-mode-search-results-7 .node .content .field p,
+.views-field-zs-view-mode-search-results-8 .node__content .field li,
+.views-field-zs-view-mode-search-results-8 .node__content .field p,
+.views-field-zs-view-mode-search-results-8 .node .content .field li,
+.views-field-zs-view-mode-search-results-8 .node .content .field p,
+.views-field-zs-view-mode-search-results-9 .node__content .field li,
+.views-field-zs-view-mode-search-results-9 .node__content .field p,
+.views-field-zs-view-mode-search-results-9 .node .content .field li,
+.views-field-zs-view-mode-search-results-9 .node .content .field p,
+.views-field-zs-view-mode-search-results-10 .node__content .field li,
+.views-field-zs-view-mode-search-results-10 .node__content .field p,
+.views-field-zs-view-mode-search-results-10 .node .content .field li,
+.views-field-zs-view-mode-search-results-10 .node .content .field p {
+  font-size: 1em;
+}
+.views-field-zs-view-mode-search-result .field--name-field-summary,
+.views-field-zs-view-mode-search-results-2 .field--name-field-summary,
+.views-field-zs-view-mode-search-results-3 .field--name-field-summary,
+.views-field-zs-view-mode-search-results-4 .field--name-field-summary,
+.views-field-zs-view-mode-search-results-5 .field--name-field-summary,
+.views-field-zs-view-mode-search-results-6 .field--name-field-summary,
+.views-field-zs-view-mode-search-results-7 .field--name-field-summary,
+.views-field-zs-view-mode-search-results-8 .field--name-field-summary,
+.views-field-zs-view-mode-search-results-9 .field--name-field-summary,
+.views-field-zs-view-mode-search-results-10 .field--name-field-summary {
+  font-size: 1.2em;
+  margin-bottom: .6em;
+  line-height: 1.5em;
+  color: #333;
+}
+.views-field-zs-view-mode-search-result .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-2 .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-3 .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-4 .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-5 .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-6 .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-7 .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-8 .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-9 .field--name-field-subtitle,
+.views-field-zs-view-mode-search-results-10 .field--name-field-subtitle {
+  font-size: 1.2em;
+  margin-bottom: .6em;
+  line-height: 1.5em;
+  color: #333;
+}
+.views-field-zs-view-mode-search-result .field--name-field-updated,
+.views-field-zs-view-mode-search-results-2 .field--name-field-updated,
+.views-field-zs-view-mode-search-results-3 .field--name-field-updated,
+.views-field-zs-view-mode-search-results-4 .field--name-field-updated,
+.views-field-zs-view-mode-search-results-5 .field--name-field-updated,
+.views-field-zs-view-mode-search-results-6 .field--name-field-updated,
+.views-field-zs-view-mode-search-results-7 .field--name-field-updated,
+.views-field-zs-view-mode-search-results-8 .field--name-field-updated,
+.views-field-zs-view-mode-search-results-9 .field--name-field-updated,
+.views-field-zs-view-mode-search-results-10 .field--name-field-updated {
+  font-size: 1.1em;
+  margin-bottom: 0.2em;
+  color: #333;
+}
+
+.page-search .l-content {
+  margin-bottom: 20px;
+}
+
+/* consultation search results */
+.view-consultation-search .view-content h3 {
+  display: block;
+  margin: 0 0 0.8em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #333;
+  background: #f0f0f0;
+}
+.view-consultation-search .view-content .views-row h3 {
+  font-size: 1.4em;
+  line-height: 1.3em;
+  margin: 0 0 0 0.4em 0;
+  padding: 0;
+  background: none;
+  background-color: transparent;
+}
+.view-consultation-search .views-row-last .views-field-zs-view-mode-search-result {
+  border-bottom: 0;
+}
+.view-consultation-search .views-field-zs-view-mode-search-result .node .content .field.field-type-file {
+  font-size: 1em;
+}
+.view-consultation-search .field-name-field-consultation-summary .file {
+  font-size: 1em;
+}
+
+/* audit report search results - themed differently because of html structure of some of the search rewsults */
+.view-audit-reports .view-content h3 {
+  display: block;
+  margin: 0 0 0.8em 0;
+  padding: .3em 11px;
+  font-size: 1.4em;
+  font-weight: bold;
+  color: #333;
+  background: #f0f0f0;
+}
+.view-audit-reports .view-content .views-row h3 {
+  font-size: 1.4em;
+  line-height: 1.3em;
+  margin: 0 0 0.4em 0;
+  padding: 0;
+  background: none;
+  background-color: transparent;
+}
+.view-audit-reports .views-row-last .views-field-zs-view-mode-search-result {
+  border-bottom: 0;
+}
+.view-audit-reports .views-field-zs-view-mode-search-result .node .content .field.field-type-file {
+  font-size: 1em;
+}
+.view-audit-reports .field-name-field-consultation-summary .file {
+  font-size: 1em;
+}
+.view-audit-reports .views-field-zs-view-mode-search-result,
+.view-audit-reports .views-field-zs-view-mode-search-results-2,
+.view-audit-reports .views-field-zs-view-mode-search-results-3,
+.view-audit-reports .views-field-zs-view-mode-search-results-4,
+.view-audit-reports .views-field-zs-view-mode-search-results-5,
+.view-audit-reports .views-field-zs-view-mode-search-results-6,
+.view-audit-reports .views-field-zs-view-mode-search-results-7,
+.view-audit-reports .views-field-zs-view-mode-search-results-8,
+.view-audit-reports .views-field-zs-view-mode-search-results-9,
+.view-audit-reports .views-field-zs-view-mode-search-results-10 {
+  border-bottom: none;
+  padding: 0;
+  /* for old content before we updated display view mode */
+}
+.view-audit-reports .views-field-zs-view-mode-search-result .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-result .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-2 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-2 .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-3 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-3 .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-4 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-4 .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-5 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-5 .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-6 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-6 .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-7 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-7 .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-8 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-8 .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-9 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-9 .field-name-field-audit-type.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-10 .field-name-field-audit-authority.field,
+.view-audit-reports .views-field-zs-view-mode-search-results-10 .field-name-field-audit-type.field {
+  display: inline;
+  margin-right: 0.5em;
+  margin-bottom: 0;
+}
+.view-audit-reports .views-field-zs-view-mode-search-result .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-result .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-2 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-2 .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-3 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-3 .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-4 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-4 .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-5 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-5 .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-6 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-6 .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-7 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-7 .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-8 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-8 .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-9 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-9 .field-name-field-audit-type.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-10 .field-name-field-audit-authority.field div,
+.view-audit-reports .views-field-zs-view-mode-search-results-10 .field-name-field-audit-type.field div {
+  display: inline;
+}
+.view-audit-reports .views-field-zs-view-mode-search-result .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-2 .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-3 .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-4 .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-5 .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-6 .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-7 .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-8 .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-9 .field-name-field-audit-type,
+.view-audit-reports .views-field-zs-view-mode-search-results-10 .field-name-field-audit-type {
+  font-style: italic;
+}
+.view-audit-reports .views-row {
+  border-bottom: 1px solid #5d9711;
+  padding: 12px 0 7px 0;
+}
+.view-audit-reports .views-row.views-row-last,
+.view-audit-reports .views-row.views-row-first.views-row-last {
+  border-bottom: 0;
+  padding-bottom: 15px;
+}
+.view-audit-reports .field-name-field-audit-authority,
+.view-audit-reports .field-name-field-audit-type {
+  display: inline;
+  margin-right: 0.5em;
+}
+.view-audit-reports .field-name-field-audit-authority div,
+.view-audit-reports .field-name-field-audit-type div {
+  display: inline;
+}
+.view-audit-reports .field-name-field-audit-type {
+  font-style: italic;
+}
+.view-audit-reports .field--name-field-audit-state {
+  display: inline-block;
+  padding-left: 3px;
+  margin-top: -5px;
+}
+.view-audit-reports .field--name-field-audit-type {
+  display: inline-block;
+  padding-right: 3px;
+  margin-top: -5px;
+}
+
+/* print styling overrides */
+@media print {
+  .current-search-item-text .result-count {
+    color: #000;
+  }
+  .current-search-item-text .search-results-heading,
+  .current-search-item-text h2.search-results-heading {
+    color: #000;
+    background: transparent;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+
+  .views-field-zs-view-mode-search-result,
+  .views-field-zs-view-mode-search-results-2,
+  .views-field-zs-view-mode-search-results-3,
+  .views-field-zs-view-mode-search-results-4,
+  .views-field-zs-view-mode-search-results-5,
+  .views-field-zs-view-mode-search-results-6,
+  .views-field-zs-view-mode-search-results-7,
+  .views-field-zs-view-mode-search-results-8,
+  .views-field-zs-view-mode-search-results-9,
+  .views-field-zs-view-mode-search-results-10 {
+    border-bottom: 1px solid #000;
+  }
+  .views-field-zs-view-mode-search-result a,
+  .views-field-zs-view-mode-search-results-2 a,
+  .views-field-zs-view-mode-search-results-3 a,
+  .views-field-zs-view-mode-search-results-4 a,
+  .views-field-zs-view-mode-search-results-5 a,
+  .views-field-zs-view-mode-search-results-6 a,
+  .views-field-zs-view-mode-search-results-7 a,
+  .views-field-zs-view-mode-search-results-8 a,
+  .views-field-zs-view-mode-search-results-9 a,
+  .views-field-zs-view-mode-search-results-10 a {
+    color: #000;
+  }
+  .views-field-zs-view-mode-search-result .node__content .field,
+  .views-field-zs-view-mode-search-result .node .content .field,
+  .views-field-zs-view-mode-search-results-2 .node__content .field,
+  .views-field-zs-view-mode-search-results-2 .node .content .field,
+  .views-field-zs-view-mode-search-results-3 .node__content .field,
+  .views-field-zs-view-mode-search-results-3 .node .content .field,
+  .views-field-zs-view-mode-search-results-4 .node__content .field,
+  .views-field-zs-view-mode-search-results-4 .node .content .field,
+  .views-field-zs-view-mode-search-results-5 .node__content .field,
+  .views-field-zs-view-mode-search-results-5 .node .content .field,
+  .views-field-zs-view-mode-search-results-6 .node__content .field,
+  .views-field-zs-view-mode-search-results-6 .node .content .field,
+  .views-field-zs-view-mode-search-results-7 .node__content .field,
+  .views-field-zs-view-mode-search-results-7 .node .content .field,
+  .views-field-zs-view-mode-search-results-8 .node__content .field,
+  .views-field-zs-view-mode-search-results-8 .node .content .field,
+  .views-field-zs-view-mode-search-results-9 .node__content .field,
+  .views-field-zs-view-mode-search-results-9 .node .content .field,
+  .views-field-zs-view-mode-search-results-10 .node__content .field,
+  .views-field-zs-view-mode-search-results-10 .node .content .field {
+    color: #000;
+  }
+  .views-field-zs-view-mode-search-result .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-2 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-3 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-4 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-5 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-6 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-7 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-8 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-9 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-10 .field--name-field-summary {
+    color: #000;
+  }
+  .views-field-zs-view-mode-search-result .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-2 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-3 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-4 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-5 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-6 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-7 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-8 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-9 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-10 .field--name-field-subtitle {
+    color: #000;
+  }
+  .views-field-zs-view-mode-search-result .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-2 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-3 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-4 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-5 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-6 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-7 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-8 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-9 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-10 .field--name-field-updated {
+    color: #000;
+  }
+
+  .views-field-zs-view-mode-search-result,
+  .views-field-zs-view-mode-search-results-2,
+  .views-field-zs-view-mode-search-results-3,
+  .views-field-zs-view-mode-search-results-4,
+  .views-field-zs-view-mode-search-results-5,
+  .views-field-zs-view-mode-search-results-6,
+  .views-field-zs-view-mode-search-results-7,
+  .views-field-zs-view-mode-search-results-8,
+  .views-field-zs-view-mode-search-results-9,
+  .views-field-zs-view-mode-search-results-10 {
+    border-bottom: 1px solid #000;
+  }
+  .views-field-zs-view-mode-search-result a,
+  .views-field-zs-view-mode-search-results-2 a,
+  .views-field-zs-view-mode-search-results-3 a,
+  .views-field-zs-view-mode-search-results-4 a,
+  .views-field-zs-view-mode-search-results-5 a,
+  .views-field-zs-view-mode-search-results-6 a,
+  .views-field-zs-view-mode-search-results-7 a,
+  .views-field-zs-view-mode-search-results-8 a,
+  .views-field-zs-view-mode-search-results-9 a,
+  .views-field-zs-view-mode-search-results-10 a {
+    color: #000;
+  }
+  .views-field-zs-view-mode-search-result .node__content .field,
+  .views-field-zs-view-mode-search-result .node .content .field,
+  .views-field-zs-view-mode-search-results-2 .node__content .field,
+  .views-field-zs-view-mode-search-results-2 .node .content .field,
+  .views-field-zs-view-mode-search-results-3 .node__content .field,
+  .views-field-zs-view-mode-search-results-3 .node .content .field,
+  .views-field-zs-view-mode-search-results-4 .node__content .field,
+  .views-field-zs-view-mode-search-results-4 .node .content .field,
+  .views-field-zs-view-mode-search-results-5 .node__content .field,
+  .views-field-zs-view-mode-search-results-5 .node .content .field,
+  .views-field-zs-view-mode-search-results-6 .node__content .field,
+  .views-field-zs-view-mode-search-results-6 .node .content .field,
+  .views-field-zs-view-mode-search-results-7 .node__content .field,
+  .views-field-zs-view-mode-search-results-7 .node .content .field,
+  .views-field-zs-view-mode-search-results-8 .node__content .field,
+  .views-field-zs-view-mode-search-results-8 .node .content .field,
+  .views-field-zs-view-mode-search-results-9 .node__content .field,
+  .views-field-zs-view-mode-search-results-9 .node .content .field,
+  .views-field-zs-view-mode-search-results-10 .node__content .field,
+  .views-field-zs-view-mode-search-results-10 .node .content .field {
+    color: #000;
+  }
+  .views-field-zs-view-mode-search-result .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-2 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-3 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-4 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-5 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-6 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-7 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-8 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-9 .field--name-field-summary,
+  .views-field-zs-view-mode-search-results-10 .field--name-field-summary {
+    color: #000;
+  }
+  .views-field-zs-view-mode-search-result .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-2 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-3 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-4 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-5 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-6 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-7 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-8 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-9 .field--name-field-subtitle,
+  .views-field-zs-view-mode-search-results-10 .field--name-field-subtitle {
+    color: #000;
+  }
+  .views-field-zs-view-mode-search-result .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-2 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-3 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-4 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-5 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-6 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-7 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-8 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-9 .field--name-field-updated,
+  .views-field-zs-view-mode-search-results-10 .field--name-field-updated {
+    color: #000;
+  }
+}
+/**
+ * See also block
+ * Dependant on block class see-also
+ */
+.see-also {
+  overflow: hidden;
+  border: 1px solid #e8e8e8;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -o-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+  background: #fff;
+  padding: 1em 11px 1em 11px;
+  /* links */
+}
+.see-also h2.block__title {
+  font-size: 1.5em;
+  color: #5d9711;
+  margin: 0 0 .5em 0;
+}
+.see-also .views-field-title {
+  font-size: 1.2em;
+  padding-left: 10px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+  margin-bottom: 2px;
+}
+.see-also .views-field-title a {
+  text-decoration: none;
+  color: #006f51;
+}
+.see-also .views-field-title a:hover {
+  text-decoration: underline;
+}
+.see-also .views-field-field-subtitle {
+  font-size: 1.2em;
+  padding-left: 10px;
+}
+.see-also .views-row {
+  margin-bottom: 0.834em;
+}
+.see-also .views-row.views-row-last {
+  margin-bottom: 0;
+}
+
+/* print styling overrides */
+@media print {
+  .see-also {
+    display: none;
+  }
+}
+/* social media share icons
+ * requires block class: share-icons
+ */
+.share-icons,
+.block--social-tab share-icons {
+  overflow: hidden;
+  padding: 20px 0 20px 0;
+}
+
+/* print styling overrides */
+@media print {
+  .share-icons,
+  .block--social-tab share-icons {
+    display: none;
+  }
+}
+/**
+ * Sidebar menu with first top level menu item looking different to the rest of the top level items.
+ * Requires a block class: sidebar-menu
+ */
+.sidebar-menu {
+  margin-bottom: 12px;
+}
+.sidebar-menu .menu-block-wrapper ul, .sidebar-menu .menu-block-wrapper li {
+  font-size: 1em;
+}
+.sidebar-menu .menu-block-wrapper ul {
+  display: block;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.sidebar-menu .menu-block-wrapper ul.menu .leaf,
+.sidebar-menu .menu-block-wrapper ul.menu .expanded,
+.sidebar-menu .menu-block-wrapper ul.menu .collapsed,
+.sidebar-menu .menu-block-wrapper ul.menu li {
+  list-style-image: none;
+  list-style-type: none;
+  list-style: none;
+}
+.sidebar-menu .menu-block-wrapper li {
+  margin: 0;
+  padding: 0;
+}
+.sidebar-menu .menu-block-wrapper a {
+  font-size: 1.2em;
+  text-decoration: none;
+  border-top: 1px solid #fff;
+  border-bottom: 1px solid #c4c4c4;
+  background-color: #f0f0f0;
+  background-image: url("../images/sidebar-arrow-right.png");
+  background-repeat: no-repeat;
+  background-position: 10px center;
+}
+.sidebar-menu .menu-block-wrapper a.active {
+  color: #02684a;
+  font-weight: bold;
+}
+.sidebar-menu .menu-block-wrapper a:hover {
+  text-decoration: underline;
+}
+.sidebar-menu .menu-block-wrapper li a {
+  display: block;
+  padding: 8px 12px 8px 24px;
+  color: #333;
+}
+.sidebar-menu .menu-block-wrapper li li a {
+  background-color: #f7f7f7;
+  padding-left: 33px;
+  background-image: url("../images/sidebar-sub-arrow-right.png");
+  background-repeat: no-repeat;
+  background-position: 23px center;
+}
+.sidebar-menu .menu-block-wrapper li.expanded > a {
+  color: #02684a;
+  font-weight: bold;
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 9px center;
+}
+.sidebar-menu .menu-block-wrapper li.first a {
+  font-weight: bold;
+  color: #fff;
+  background-color: #02684a;
+  background-image: none;
+}
+.sidebar-menu .menu-block-wrapper li.first a.active {
+  font-weight: bold;
+  color: #fff;
+}
+.sidebar-menu .menu-block-wrapper li li.first a {
+  font-weight: normal;
+  color: #333;
+  background-color: #f7f7f7;
+  background-image: url("../images/sidebar-sub-arrow-right.png");
+  background-repeat: no-repeat;
+  background-position: 23px center;
+}
+.sidebar-menu .menu-block-wrapper li li.first a.active {
+  color: #02684a;
+  font-weight: bold;
+}
+
+/**
+ * Sidebar menu with all top level menu items looking the same
+ * Requires a block class: sidebar-menu-option-2
+ */
+.sidebar-menu-2 {
+  margin-bottom: 12px;
+}
+.sidebar-menu-2 .menu-block-wrapper ul, .sidebar-menu-2 .menu-block-wrapper li,
+.sidebar-menu-2 .block__content ul,
+.sidebar-menu-2 .block__content li {
+  font-size: 1em;
+}
+.sidebar-menu-2 .menu-block-wrapper ul,
+.sidebar-menu-2 .block__content ul {
+  display: block;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.sidebar-menu-2 .menu-block-wrapper ul.menu .leaf,
+.sidebar-menu-2 .menu-block-wrapper ul.menu .expanded,
+.sidebar-menu-2 .menu-block-wrapper ul.menu .collapsed,
+.sidebar-menu-2 .menu-block-wrapper ul.menu li,
+.sidebar-menu-2 .block__content ul.menu .leaf,
+.sidebar-menu-2 .block__content ul.menu .expanded,
+.sidebar-menu-2 .block__content ul.menu .collapsed,
+.sidebar-menu-2 .block__content ul.menu li {
+  list-style-image: none;
+  list-style-type: none;
+  list-style: none;
+}
+.sidebar-menu-2 .menu-block-wrapper li,
+.sidebar-menu-2 .block__content li {
+  margin: 0;
+  padding: 0;
+}
+.sidebar-menu-2 .menu-block-wrapper a,
+.sidebar-menu-2 .block__content a {
+  font-size: 1.2em;
+  text-decoration: none;
+  border-top: 1px solid #fff;
+  border-bottom: 1px solid #c4c4c4;
+  background-color: #f0f0f0;
+  background-image: url("../images/sidebar-arrow-right.png");
+  background-repeat: no-repeat;
+  background-position: 10px center;
+}
+.sidebar-menu-2 .menu-block-wrapper a.active,
+.sidebar-menu-2 .block__content a.active {
+  color: #02684a;
+  font-weight: bold;
+}
+.sidebar-menu-2 .menu-block-wrapper a:hover,
+.sidebar-menu-2 .block__content a:hover {
+  text-decoration: underline;
+}
+.sidebar-menu-2 .menu-block-wrapper li a,
+.sidebar-menu-2 .block__content li a {
+  display: block;
+  padding: 8px 12px 8px 24px;
+  color: #333;
+}
+.sidebar-menu-2 .menu-block-wrapper li li a,
+.sidebar-menu-2 .block__content li li a {
+  background-color: #f7f7f7;
+  padding-left: 33px;
+  background-image: url("../images/sidebar-sub-arrow-right.png");
+  background-repeat: no-repeat;
+  background-position: 23px center;
+}
+.sidebar-menu-2 .menu-block-wrapper li.expanded > a,
+.sidebar-menu-2 .block__content li.expanded > a {
+  color: #02684a;
+  font-weight: bold;
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 9px center;
+}
+
+/* site map menublock
+ * requires block class: site-map
+ */
+.site-map {
+  /* prevent nested em's from affecting font sizes */
+  /* remove menu name */
+}
+.site-map ul ul,
+.site-map li li {
+  font-size: 1em;
+}
+.site-map h2.block__title {
+  display: none;
+}
+.site-map ul.menu {
+  margin-left: 0;
+  padding-left: 0;
+  /* hide first item (the home link) */
+  /* hide first second level item (its a repeat of its parent) */
+}
+.site-map ul.menu li, .site-map ul.menu li.leaf, .site-map ul.menu li.expanded, .site-map ul.menu li.collapsed {
+  list-style-image: none;
+  list-style-type: none;
+  list-style: none;
+  margin-left: 0;
+  padding-left: 1em;
+}
+.site-map ul.menu li.first {
+  display: none;
+}
+.site-map ul.menu li li.first {
+  display: none;
+}
+.site-map ul.menu li li {
+  margin-bottom: 0.5em;
+}
+.site-map ul.menu li li.last,
+.site-map ul.menu li li.first.last {
+  margin-bottom: 1em;
+}
+.site-map ul.menu li a {
+  display: block;
+  margin: 0 0 1em 0;
+  padding: .3em 11px;
+  font-size: 1.167em;
+  font-weight: bold;
+  color: #fff;
+  background: #5d9711;
+}
+.site-map ul.menu li li a {
+  display: inline;
+  font-size: 1em;
+  font-weight: normal;
+  color: #006f51;
+  background-color: transparent;
+  padding: 0 0 0 10px;
+  background-image: url("../images/green-arrow-thin-right.png");
+  background-repeat: no-repeat;
+  background-position: left 3px;
+  margin: 0 0 2px 0;
+}
+
+/* print styling overrides */
+@media print {
+  .site-map ul.menu li a {
+    color: #000;
+    background-color: transparent;
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+  }
+  .site-map ul.menu li li a {
+    color: #000;
+    background: none;
+    padding-left: 0;
+    border-top: none;
+    border-bottom: none;
+  }
+}
+/* social media icons
+ * requires block class: social-media-icons
+ */
+.social-media-icons {
+  position: relative;
+  top: -20px;
+  margin-bottom: -20px;
+}
+.social-media-icons .block__content ul {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+.social-media-icons .block__content li {
+  list-style-type: none;
+  padding: 0;
+  margin: 0 4px 0 0;
+  float: left;
+}
+.social-media-icons .block__content li img {
+  width: 26px;
+  height: 26px;
+}
+.social-media-icons .block__content li a {
+  display: block;
+  min-width: 26px;
+  min-height: 26px;
+}
+.social-media-icons .block__content li a:focus img {
+  border: 1px solid #fff;
+}
+.social-media-icons .block__content li.extra-margin {
+  margin-right: 18px;
+}
+.social-media-icons .block__content .label-wrapper {
+  color: #fff;
+  font-size: 1.1em;
+  margin-bottom: 5px;
+}
+.social-media-icons .block__content .left-label {
+  margin-left: 2px;
+  float: left;
+  display: block;
+}
+.social-media-icons .block__content .right-label {
+  margin-left: 106px;
+  display: block;
+}
+.social-media-icons .block__content .icons-wrapper {
+  clear: left;
+}
+
+/*
+<div class="label-wrapper"><span class="left-label">Stay updated:</span> <span class="right-label">Keep connected:</span></div>
+<div class="icons-wrapper">
+<ul>
+	<li><a href="" target="_blank" title="email"><img alt="email" src="/sites/all/themes/site_frontend/images/icons/email.png" /></a></li>
+	<li><a href="" target="_blank" title="phone"><img alt="phone" src="/sites/all/themes/site_frontend/images/icons/phone.png" /></a></li>
+	<li class="extra-margin"><a href="" target="_blank" title="RSS"><img alt="RSS" src="/sites/all/themes/site_frontend/images/icons/rss.png" /></a></li>
+	<li><a href="http://www.facebook.com/FoodStandardsAgency" target="_blank" title="The Food Standards Agency Facebook page (opens in a new window)"><img alt="Find us on Facebook" src="/sites/all/themes/site_frontend/images/icons/facebook.png" /></a></li>
+	<li><a href="http://www.twitter.com/foodgov" target="_blank" title="twitter (opens in a new window)"><img alt="Follow us on twitter" src="/sites/all/themes/site_frontend/images/icons/twitter.png" /></a></li>
+	<li><a href="http://www.youtube.com/user/FoodStandardsAgency" target="_blank" title="you tube (opens in a new window)"><img alt="you tube" src="/sites/all/themes/site_frontend/images/icons/youtube.png" /></a></li>
+	<li><a href="http://www.pinterest.com/foodgov/" target="_blank" title="pinterest (opens in a new window)"><img alt="pinterest" src="/sites/all/themes/site_frontend/images/icons/pinterest.png" /></a></li>
+</ul>
+</div>
+*/
+/* print styling overrides */
+@media print {
+  .social-media-icons {
+    display: none;
+  }
+}
+/**
+ * Table of contents
+ * We use toc_node module to add a toc, and we override the css here
+ */
+/* toc block */
+#block-toc-node-toc-node {
+  clear: both;
+}
+#block-toc-node-toc-node h2.block__title {
+  color: #333;
+  margin-bottom: 0.45em;
+}
+
+/* wrapper */
+#table-of-contents-links ul, #table-of-contents-links li {
+  font-size: 1em;
+}
+#table-of-contents-links a {
+  color: #006f51;
+  text-decoration: none;
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+#table-of-contents-links a:hover {
+  text-decoration: underline;
+}
+#table-of-contents-links ul.toc-node-bullets li,
+#table-of-contents-links ul.toc-node-numbers li {
+  margin-bottom: 0.4em;
+}
+
+/* bullet list */
+ul.toc-node-bullets li.toc-node-level-1 {
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 0px 4px;
+  padding-left: 14px;
+}
+ul.toc-node-bullets li.toc-node-level-2 {
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 14px 4px;
+  padding-left: 28px;
+}
+ul.toc-node-bullets li.toc-node-level-3 {
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 28px 4px;
+  padding-left: 42px;
+}
+ul.toc-node-bullets li.toc-node-level-4 {
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 42px 4px;
+  padding-left: 56px;
+}
+ul.toc-node-bullets li.toc-node-level-5 {
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 56px 4px;
+  padding-left: 70px;
+}
+ul.toc-node-bullets li.toc-node-level-6 {
+  background-image: url("../images/sidebar-arrow-down.png");
+  background-repeat: no-repeat;
+  background-position: 70px 4px;
+  padding-left: 84px;
+}
+
+/* back to top links */
+.section-back-top {
+  text-align: right;
+  margin-bottom: 15px;
+  clear: both;
+}
+.section-back-top a {
+  color: #006f51;
+  text-decoration: none;
+  font-size: 1.2em;
+  line-height: 1.4em;
+  background-image: url("../images/arrow-up.png");
+  background-repeat: no-repeat;
+  background-position: left 4px;
+  padding-left: 14px;
+}
+.section-back-top a:hover {
+  text-decoration: underline;
+}
+
+@media (min-width: 0px) and (max-width: 480px) {
+  #table-of-contents-links ul.toc-node-bullets li,
+  #table-of-contents-links ul.toc-node-numbers li {
+    margin-bottom: 0.6em;
+  }
+}
+/* print styling overrides */
+@media print {
+  #block-toc-node-toc-node,
+  #table-of-contents-links,
+  .section-back-top {
+    display: none;
+  }
+}
+.field--name-field-fc-section-quote {
+  clear: both;
+  overflow: hidden;
+  width: 220px;
+  float: right;
+  margin-left: 10px;
+  margin-bottom: 10px;
+  font-size: 1.4em;
+  line-height: 1.3em;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  -o-border-radius: 8px;
+  -ms-border-radius: 8px;
+  border-radius: 8px;
+  background-color: #eef4e7;
+  color: #006f51;
+  overflow: hidden;
+}
+.field--name-field-fc-section-quote p {
+  margin-bottom: 0px;
+  font-size: 1em;
+}
+.field--name-field-fc-section-quote .field__items {
+  background-image: url("../images/quote-top-left.gif");
+  background-repeat: no-repeat;
+  background-position: top left;
+  margin-left: 11px;
+  margin-top: 11px;
+  padding-left: 36px;
+  overflow: hidden;
+}
+.field--name-field-fc-section-quote .field__items .field__item {
+  padding-top: 6px;
+  padding-right: 12px;
+  padding-bottom: 23px;
+  background-image: url("../images/quote-bottom-right.gif");
+  background-repeat: no-repeat;
+  background-position: bottom right;
+  margin-right: 11px;
+  margin-bottom: 11px;
+  overflow: hidden;
+}
+
+/* print styling overrides */
+@media print {
+  .field--name-field-fc-section-quote {
+    display: none;
+  }
+}
+/* summary field - when used directly on a content type */
+.field--name-field-summary {
+  font-size: 1.6em;
+  line-height: 1.4em;
+  color: #006f51;
+  margin-bottom: 20px;
+}
+.field--name-field-summary p {
+  margin-bottom: 11px;
+  font-size: 1em;
+  line-height: 1.4em;
+}
+
+/* summary field - when used in a view as a views field */
+.views-field-field-summary {
+  font-size: 1.6em;
+  line-height: 1.4em;
+  color: #006f51;
+  margin-bottom: 20px;
+}
+.views-field-field-summary p {
+  margin-bottom: 11px;
+  font-size: 1em;
+  line-height: 1.4em;
+}
+
+/* print styling overrides */
+@media print {
+  .field--name-field-summary,
+  .views-field-field-summary {
+    color: #000;
+  }
+}
+/* Book page titles 
+ * How they work: When book page has no parent, its title must be default appearance as per rest of the site
+ * and when book page has a parent, the parent title must look like the page title and the section title and book page
+ * title looks different. When parent page is present, all three titles get wrapped in div class="book-triple-title"
+*/
+.book-triple-title .book-parent-title {
+  font-size: 2.8em;
+  line-height: 1.2em;
+  font-weight: normal;
+  color: #4b800d;
+  margin-bottom: 0.5em;
+}
+.book-triple-title .book-section-title,
+.book-triple-title h1#page-title {
+  font-size: 2em;
+  line-height: 1.2em;
+  font-weight: normal;
+  color: #333;
+  margin-bottom: 0.5em;
+}
+
+/* print styling overrides */
+@media print {
+  .book-triple-title .book-parent-title {
+    color: #000;
+  }
+  .book-triple-title .book-section-title,
+  .book-triple-title h1#page-title {
+    color: #000;
+  }
+}
+/* hide front page title in an accessible way */
+.front h1#page-title {
+  position: absolute !important;
+  clip: rect(1px 1px 1px 1px);
+  /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+  color: #fff;
+}
+
+/* hide nation page titles
+ * note: the nation top banner duplicates the h1 and the title of the nation pages
+ * and we need to keep the banner, so we hiding the title with CSS
+ * Dependancy: body classes on nation front pages (added with Context), 
+ * these classes are: front-page-wales, front-page-scotland, front-page-northern-ireland
+ */
+.front-page-wales h1#page-title,
+.front-page-scotland h1#page-title,
+.front-page-northern-ireland h1#page-title {
+  display: none;
+}
+
+/* webform node */
+/* webform outer weapper */
+.custom-outer-wrapper.webfrom-node-template {
+  border: 1px solid #ccc;
+  -webkit-border-radius: 9px;
+  -moz-border-radius: 9px;
+  -o-border-radius: 9px;
+  -ms-border-radius: 9px;
+  border-radius: 9px;
+  overflow: hidden;
+}
+
+.webfrom-node-template {
+  /* inner wrapper */
+  /* content wrapper */
+  /* body field */
+  /* labels */
+  /* text fields */
+  /* submit button */
+}
+.webfrom-node-template .custom-inner-wrapper {
+  overflow: hidden;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNlNWU1ZTUiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(100%, #e5e5e5));
+  background: -webkit-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -o-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: -ms-linear-gradient(top, white 0, #e5e5e5 100%);
+  background: linear-gradient(top, #ffffff 0%, #e5e5e5 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#e5e5e5',GradientType=0);
+}
+.webfrom-node-template .custom-node-content {
+  overflow: hidden;
+  padding: 11px 9px 21px 11px;
+}
+.webfrom-node-template .field--name-body h2 {
+  margin: 0 0 0.5em 0;
+  padding: 0;
+  font-size: 1.4em;
+  color: #5d9711;
+  background: none;
+  font-weight: bold;
+}
+.webfrom-node-template label {
+  font-weight: normal;
+}
+.webfrom-node-template .webform-component-textfield label,
+.webfrom-node-template .webform-component-textarea label {
+  padding-bottom: 0.25em;
+  display: block;
+  padding-left: 3px;
+  font-weight: normal;
+  font-size: 1.2em;
+  line-height: 1.4em;
+}
+.webfrom-node-template input.form-text,
+.webfrom-node-template textarea.form-textarea {
+  padding: 2px 4px;
+  background: #fff;
+  font-size: 1.2em;
+  vertical-align: middle;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  font-family: Arial,Verdana,Helvetica,sans-serif;
+  font-size: 1.2em;
+  color: #333;
+  width: 100%;
+}
+.webfrom-node-template input.form-submit {
+  overflow: hidden;
+  border: 1px solid #fff;
+  line-height: 1em;
+  font-size: 1.2em;
+  font-weight: bold;
+  white-space: normal;
+  word-wrap: break-word;
+  display: block;
+  text-decoration: none;
+  color: #3d3d3d;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  -o-border-radius: 3px;
+  -ms-border-radius: 3px;
+  border-radius: 3px;
+  background: #fff;
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSI0NiUiIHN0b3AtY29sb3I9IiNmZmZmZmYiIHN0b3Atb3BhY2l0eT0iMSIvPgogICAgPHN0b3Agb2Zmc2V0PSI5OSUiIHN0b3AtY29sb3I9IiNjZGNkY2QiIHN0b3Atb3BhY2l0eT0iMSIvPgogIDwvbGluZWFyR3JhZGllbnQ+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEiIGhlaWdodD0iMSIgZmlsbD0idXJsKCNncmFkLXVjZ2ctZ2VuZXJhdGVkKSIgLz4KPC9zdmc+);
+  background: -moz-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(46%, white), color-stop(99%, #cdcdcd));
+  background: -webkit-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -o-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: -ms-linear-gradient(top, white 46%, #cdcdcd 99%);
+  background: linear-gradient(top, #ffffff 46%, #cdcdcd 99%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff',endColorstr='#cdcdcd',GradientType=0);
+  padding: 6px;
+  border: 1px solid #bbb;
+  float: right;
+}
+.webfrom-node-template input.form-submit:hover,
+.webfrom-node-template input.form-submit:focus {
+  text-decoration: underline;
+  border: 1px solid #f67f2a;
+}
+
+/*! normalize.css v1.1.0 | MIT License | git.io/normalize */
+/*! normalize.css v1.1.0 | HTML5 Display Definitions | MIT License | git.io/normalize */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section,
+summary {
+  display: block;
+}
+
+audio,
+canvas,
+video {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1;
+}
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+[hidden] {
+  display: none;
+}
+
+/*! normalize.css v1.1.0 | Base | MIT License | git.io/normalize */
+html {
+  font-size: 100%;
+  font-family: sans-serif;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+}
+
+html,
+button,
+input,
+select,
+textarea {
+  font-family: sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+/*! normalize.css v1.1.0 | Links | MIT License | git.io/normalize */
+a:focus {
+  outline: thin dotted;
+}
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/*! normalize.css v1.1.0 | Typography | MIT License | git.io/normalize */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+h2 {
+  font-size: 1.5em;
+  margin: 0.83em 0;
+}
+
+h3 {
+  font-size: 1.17em;
+  margin: 1em 0;
+}
+
+h4 {
+  font-size: 1em;
+  margin: 1.33em 0;
+}
+
+h5 {
+  font-size: 0.83em;
+  margin: 1.67em 0;
+}
+
+h6 {
+  font-size: 0.67em;
+  margin: 2.33em 0;
+}
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+b,
+strong {
+  font-weight: bold;
+}
+
+blockquote {
+  margin: 1em 40px;
+}
+
+dfn {
+  font-style: italic;
+}
+
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+p,
+pre {
+  margin: 1em 0;
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, serif;
+  font-size: 1em;
+}
+
+pre {
+  white-space: pre;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+q {
+  quotes: "\201C" "\201D" "\2018" "\2019";
+}
+
+q {
+  quotes: none;
+}
+
+q:before,
+q:after {
+  content: '';
+  content: none;
+}
+
+small {
+  font-size: 80%;
+}
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+dl,
+menu,
+ol,
+ul {
+  margin: 1em 0;
+}
+
+dd {
+  margin: 0 0 0 40px;
+}
+
+menu,
+ol,
+ul {
+  padding: 0 0 0 40px;
+}
+
+nav ul,
+nav ol {
+  list-style: none;
+  list-style-image: none;
+}
+
+/*! normalize.css v1.1.0 | Embedded Content | MIT License | git.io/normalize */
+img {
+  border: 0;
+  -ms-interpolation-mode: bicubic;
+}
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/*! normalize.css v1.1.0 | Figures | MIT License | git.io/normalize */
+figure {
+  margin: 0;
+}
+
+/*! normalize.css v1.1.0 | Forms | MIT License | git.io/normalize */
+form {
+  margin: 0;
+}
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+legend {
+  border: 0;
+  padding: 0;
+  white-space: normal;
+  *margin-left: -7px;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+  margin: 0;
+  vertical-align: baseline;
+  *vertical-align: middle;
+}
+
+button,
+input {
+  line-height: normal;
+}
+
+button,
+select {
+  text-transform: none;
+}
+
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  cursor: pointer;
+  *overflow: visible;
+}
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+  *height: 13px;
+  *width: 13px;
+}
+
+input[type="search"] {
+  -webkit-appearance: textfield;
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
+}
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+textarea {
+  overflow: auto;
+  vertical-align: top;
+}
+
+/*! normalize.css v1.1.0 | Tables | MIT License | git.io/normalize */
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+*, *:after, *:before {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  *behavior: url('../behaviors/box-sizing/boxsizing.php');
+}
+
+body {
+  margin: 0 auto;
+}
+
+.element-invisible {
+  position: absolute !important;
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+}
+
+.header-top {
+  overflow: hidden;
+}
+
+.l-breadcrumb-accessibility {
+  overflow: hidden;
+}
+
+.l-preface {
+  overflow: hidden;
+}
+
+.l-main {
+  overflow: hidden;
+}
+
+.bottom-menu-wrapper-inner {
+  overflow: hidden;
+}
+
+.l-footer {
+  overflow: hidden;
+}
+
+.footer-top {
+  overflow: hidden;
+}
+
+.footer-bottom {
+  overflow: hidden;
+}
+
+.footer-wrapper {
+  overflow: hidden;
+}
+
+.footer-wrapper-inner {
+  overflow: hidden;
+}
+
+.l-content {
+  width: 75%;
+  float: left;
+  margin-right: -100%;
+  margin-left: 0%;
+  clear: none;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+/* force wrappers to expand beyond browser window size when browser made smaller */
+.header-wrapper,
+.breadcrumb-accessibility-wrapper,
+.main-wrapper,
+.bottom-menu-wrapper,
+.footer-wrapper {
+  min-width: 960px;
+}
+
+/* layout - desktop first approach */
+.header-wrapper-inner,
+.l-breadcrumb-accessibility,
+.l-preface,
+.l-main,
+.bottom-menu-wrapper-inner,
+.l-footer {
+  width: 960px;
+  /* we are using border box plugin so padding will not increase the width of the box */
+  padding-left: 6px;
+  padding-right: 6px;
+  margin: 0 auto;
+}
+
+.l-header-branding {
+  width: 25%;
+  float: left;
+  margin-right: -100%;
+  margin-left: 0%;
+  clear: none;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.l-header-social-media {
+  width: 25%;
+  float: right;
+  margin-left: 0;
+  margin-right: 0;
+  clear: none;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+/* mobile layout */
+@media (min-width: 0px) and (max-width: 480px) {
+  .header-wrapper-inner,
+  .l-breadcrumb-accessibility,
+  .l-preface,
+  .l-main,
+  .bottom-menu-wrapper-inner,
+  .l-footer {
+    width: 100%;
+    padding-left: 6px;
+    padding-right: 6px;
+    margin: 0;
+  }
+
+  .l-main {
+    padding-bottom: 12px;
+  }
+
+  .l-header-branding {
+    width: 50%;
+    float: left;
+    margin-right: -100%;
+    margin-left: 0%;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    margin-bottom: 10px;
+  }
+
+  .header-bottom {
+    /* for IE 6/7 */
+    *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
+    /* non-JS fallback */
+    *zoom: 1;
+  }
+  .header-bottom:before, .header-bottom:after {
+    content: ".";
+    display: block;
+    height: 0;
+    overflow: hidden;
+  }
+  .header-bottom:after {
+    clear: both;
+  }
+
+  .l-header-main-menu {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .l-header-social-media {
+    width: 0%;
+    float: left;
+    margin-right: -100%;
+    margin-left: -8.33333%;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+    display: none;
+  }
+
+  .breadcrumb-accessibility-wrapper {
+    /* for IE 6/7 */
+    *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
+    /* non-JS fallback */
+    *zoom: 1;
+  }
+  .breadcrumb-accessibility-wrapper:before, .breadcrumb-accessibility-wrapper:after {
+    content: ".";
+    display: block;
+    height: 0;
+    overflow: hidden;
+  }
+  .breadcrumb-accessibility-wrapper:after {
+    clear: both;
+  }
+
+  .l-breadcrumb {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .l-accessibility {
+    width: 0%;
+    float: left;
+    margin-right: -100%;
+    margin-left: -8.33333%;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    display: none;
+  }
+
+  .l-preface {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .main-wrapper {
+    /* for IE 6/7 */
+    *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
+    /* non-JS fallback */
+    *zoom: 1;
+  }
+  .main-wrapper:before, .main-wrapper:after {
+    content: ".";
+    display: block;
+    height: 0;
+    overflow: hidden;
+  }
+  .main-wrapper:after {
+    clear: both;
+  }
+
+  .l-content {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .l-sidebar-second {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .bottom-menu-wrapper {
+    /* for IE 6/7 */
+    *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
+    /* non-JS fallback */
+    *zoom: 1;
+    display: none;
+  }
+  .bottom-menu-wrapper:before, .bottom-menu-wrapper:after {
+    content: ".";
+    display: block;
+    height: 0;
+    overflow: hidden;
+  }
+  .bottom-menu-wrapper:after {
+    clear: both;
+  }
+
+  .l-bottom-menu {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .footer-bottom {
+    /* for IE 6/7 */
+    *zoom: expression(this.runtimeStyle.zoom="1", this.appendChild(document.createElement("br")).style.cssText="clear:both;font:0/0 serif");
+    /* non-JS fallback */
+    *zoom: 1;
+  }
+  .footer-bottom:before, .footer-bottom:after {
+    content: ".";
+    display: block;
+    height: 0;
+    overflow: hidden;
+  }
+  .footer-bottom:after {
+    clear: both;
+  }
+
+  .l-footer-copyright {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .l-footer-menu {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .l-footer-buttons {
+    width: 100%;
+    float: right;
+    margin-left: 0;
+    margin-right: 0;
+    clear: none;
+    padding-left: 6px;
+    padding-right: 6px;
+    clear: both;
+    float: none;
+  }
+
+  .header-wrapper,
+  .breadcrumb-accessibility-wrapper,
+  .main-wrapper,
+  .bottom-menu-wrapper,
+  .footer-wrapper {
+    min-width: 0;
+  }
+}
+.maintenance-page.in-maintenance .contextual-links-wrapper {
+  display: none;
+}
+.maintenance-page.in-maintenance h1 {
+  font-size: 2.8em;
+}
+.maintenance-page.in-maintenance .social-media-icons {
+  top: initial;
+  margin-bottom: initial;
+  padding-top: 20px;
+}
+.maintenance-page.in-maintenance .social-media-icons .block__content li.last-item {
+  margin-right: 0;
+}
+.maintenance-page.in-maintenance .main-content-inner .social-media-icons {
+  margin-bottom: 3em;
+  padding-top: 0;
+}
+.maintenance-page.in-maintenance .main-content-inner .social-media-icons li {
+  margin-right: 8px;
+}
+.maintenance-page.in-maintenance .main-content-inner .social-media-icons li a img {
+  height: auto;
+  width: auto;
+}

--- a/docroot/sites/all/themes/site_frontend/sass/maintenance-page.scss
+++ b/docroot/sites/all/themes/site_frontend/sass/maintenance-page.scss
@@ -1,0 +1,237 @@
+@import "compass";
+@import "breakpoint";
+@import "singularitygs";
+@import "toolkit-no-css";
+
+// Globbing from within sub-folders only works with relative paths.
+@import "variables/**/*";
+@import "abstractions/**/*";
+@import "base/**/*";
+@import "components/**/*";
+
+// Generate normalize.css.
+@import "normalize";
+
+// Use 'border-box' for the box model.
+@import "toolkit/border-box";
+
+body {
+  margin: 0 auto;
+}
+
+.element-invisible {
+  position: absolute !important;
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+}
+
+.header-top {
+	overflow: hidden;
+}
+.l-breadcrumb-accessibility {
+	overflow: hidden;
+}
+.l-preface {
+	overflow: hidden;
+}
+.l-main {
+	overflow: hidden;
+}
+.bottom-menu-wrapper-inner {
+  overflow: hidden;
+}
+.l-footer {
+	overflow: hidden;
+}
+.footer-top {
+	overflow: hidden;
+}
+.footer-bottom {
+	overflow: hidden;
+}
+.footer-wrapper {
+	overflow: hidden;
+}
+.footer-wrapper-inner {
+	overflow: hidden;
+}
+.l-content {
+	@include grid-span(9,1);
+}
+
+/* force wrappers to expand beyond browser window size when browser made smaller */
+.header-wrapper,
+.breadcrumb-accessibility-wrapper,
+.main-wrapper,
+.bottom-menu-wrapper,
+.footer-wrapper {
+	min-width: 960px;
+}
+
+/* layout - desktop first approach */
+.header-wrapper-inner,
+.l-breadcrumb-accessibility,
+.l-preface,
+.l-main,
+.bottom-menu-wrapper-inner,
+.l-footer {
+	width: 960px;		/* we are using border box plugin so padding will not increase the width of the box */
+	padding-left: 6px;
+	padding-right: 6px;
+	margin: 0 auto;
+}
+
+.l-header-branding {
+	@include grid-span(3,1);
+}
+
+.l-header-social-media {
+	@include grid-span(3,10);
+}
+
+
+/* mobile layout */
+@include breakpoint($mobile) {
+	.header-wrapper-inner,
+	.l-breadcrumb-accessibility,
+	.l-preface,
+	.l-main,
+	.bottom-menu-wrapper-inner,
+	.l-footer {
+		width: 100%;		// we are using border box plugin so padding will not increase the width of the box
+		padding-left: 6px;
+		padding-right: 6px;
+		margin: 0;
+	}
+	.l-main {
+		padding-bottom: 12px;
+	}
+	.l-header-branding {
+		@include grid-span(6,1);
+    margin-bottom: 10px;
+	}
+	.header-bottom {
+		@include clearfix;
+	}
+	.l-header-main-menu {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.l-header-social-media {
+		@include grid-span(0,0);
+		clear: both;
+		float: none;
+		display: none;
+	}
+	.breadcrumb-accessibility-wrapper {
+		 @include clearfix;
+	}
+	.l-breadcrumb {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.l-accessibility {
+		@include grid-span(0,0);
+		display: none;
+	}
+	.l-preface {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.main-wrapper {
+		@include clearfix;
+	}
+	.l-content {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.l-sidebar-second {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.bottom-menu-wrapper {
+		@include clearfix;
+		display: none;
+	}
+	.l-bottom-menu {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.footer-bottom {
+		@include clearfix;
+	}
+	.l-footer-copyright {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.l-footer-menu {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.l-footer-buttons {
+		@include grid-span(12,1);
+		clear: both;
+		float: none;
+	}
+	.header-wrapper,
+	.breadcrumb-accessibility-wrapper,
+	.main-wrapper,
+	.bottom-menu-wrapper,
+	.footer-wrapper {
+		min-width: 0;	// note min-width: none has no effect (not valid), must be 0;
+	}
+}
+
+.maintenance-page.in-maintenance {
+  
+  // Hide contextual links wrappers
+  .contextual-links-wrapper {
+    display: none;
+  }
+
+  h1 {
+    font-size: 2.8em;
+  }
+  
+  .social-media-icons {
+    top: initial;
+    margin-bottom: initial;
+    padding-top: 20px;
+    
+    .block__content {
+      li {
+        &.last-item {
+          margin-right: 0;
+        }
+      } 
+    }
+  }
+  
+  .main-content-inner {
+    .social-media-icons {
+      margin-bottom: 3em;
+      padding-top: 0;
+      
+      li {
+        margin-right: 8px;
+        a {
+          img {
+            height: auto;
+            width: auto;
+          }
+        }
+      }
+    }
+  }
+  
+}

--- a/docroot/sites/all/themes/site_frontend/templates/system/maintenance-page.tpl.php
+++ b/docroot/sites/all/themes/site_frontend/templates/system/maintenance-page.tpl.php
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<?php if (omega_extension_enabled('compatibility') && omega_theme_get_setting('omega_conditional_classes_html', TRUE)): ?>
+<!--[if !IE]><!--><html class="no-js" lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"><!--<![endif]-->
+  <!--[if IEMobile 7]><html class="no-js ie iem7" lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"><![endif]-->
+  <!--[if lte IE 6]><html class="no-js ie lt-ie9 lt-ie8 lt-ie7" lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"><![endif]-->
+  <!--[if (IE 7)&(!IEMobile)]><html class="no-js ie lt-ie9 lt-ie8" lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"><![endif]-->
+  <!--[if IE 8]><html class="no-js ie lt-ie9" lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"><![endif]-->
+  <!--[if (gte IE 9)|(gt IEMobile 7)]><html class="no-js ie" lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"><![endif]-->
+<?php else: ?>
+  <html class="no-js" lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"<?php print $rdf_namespaces; ?>>
+<?php endif; ?>
+<head>
+  <title><?php print $head_title; ?></title>
+  <?php print $head; ?>
+  <?php print render($css_file); ?>
+</head>
+<body<?php print $attributes;?>>
+  <a href="#main-content" class="element-invisible element-focusable" accesskey="S"><?php print t('Skip to main content'); ?></a>
+  <?php if (!empty($page_top)): ?>
+    <?php print $page_top; ?>
+  <?php endif; ?>  
+  
+  <div class="header-wrapper">
+    <div class="header-wrapper-inner">
+      <header class="l-header" role="banner">
+        <div class="header-inner">
+          <div class="header-top">
+            <div class="l-header-branding">
+              <div class="header-branding-inner">
+
+                <?php if ($logo): ?>
+                  <a href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>" rel="home" class="site-logo"><img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" /></a>
+                <?php endif; ?>
+                <?php if ($site_name || $site_slogan): ?>
+                  <?php if ($site_name): ?>
+                    <h1 class="site-name">
+                      <a href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>" rel="home"><span><?php print $site_name; ?></span></a>
+                    </h1>
+                  <?php endif; ?>
+                  <?php if ($site_slogan): ?>
+                    <h2 class="site-slogan"><?php print $site_slogan; ?></h2>
+                  <?php endif; ?>
+                <?php endif; ?>
+                <?php print render($page['header_branding']); ?>
+
+              </div> <!-- end header-branding-inner -->
+            </div> <!-- end l-header-branding -->
+
+          <div class="header-bottom">
+            <div class="l-header-social-media">
+              <div class="header-social-media-inner">
+                <?php print render($page['header_social_media']); ?>
+              </div> <!-- end header-social-media-inner -->
+            </div> <!-- end l-header-social-media -->
+          </div> <!-- end header-bottom -->
+
+        </div> <!-- end header-inner -->
+      </header>
+    </div> <!-- end header-wrapper-inner -->
+  </div> <!-- end header-wrapper -->
+  
+  <div class="main-wrapper">
+    <div class="l-main">
+      <div class="main-inner">
+
+        <div id="main-content" class="l-content" role="main">
+          <div class="main-content-inner">
+
+            <?php if (!empty($page['content_top'])): ?>
+              <div class="content-top-wrapper">
+                <div class="content-top-wrapper-inner">
+                  <div class="content-top">
+                    <?php print render($page['content_top']); ?>
+                  </div> <!-- end content-top -->
+                </div> <!-- end content-top-wrapper-inner -->
+              </div> <!-- end content-top-wrapper -->
+            <?php endif; ?>
+
+            <?php print render($title_prefix); ?>
+            <?php if ($title): ?>
+              <h1 id="page-title"><?php print $title; ?></h1>
+            <?php endif; ?>
+            <?php print render($title_suffix); ?>
+            <?php print $messages; ?>
+            <?php print render($tabs); ?>
+            <?php print render($page['help']); ?>
+            <?php if (!empty($action_links)): ?>
+              <ul class="action-links"><?php print render($action_links); ?></ul>
+            <?php endif; ?>
+              <?php print render($content); ?>
+            <?php if (!empty($page['node_inline'])): ?>
+              <?php print render($page['node_inline']); ?>
+            <?php endif; ?>
+            <?php print $feed_icons; ?>
+
+          </div> <!-- end main-content-inner -->
+        </div> <!-- end l-content -->
+
+
+      </div> <!-- end main-inner -->
+    </div> <!-- end main -->
+  </div> <!-- end main-wrapper -->
+  
+  <div class="bottom-menu-wrapper">
+    <div class="bottom-menu-wrapper-inner">
+      <div class="l-bottom-menu">
+        <div class="bottom-menu-inner" role="navigation">
+          <?php print render($page['bottom_menu']); ?>
+        </div> <!-- end bottom-menu-inner -->
+      </div> <!-- end l-bottom-menu -->
+    </div> <!-- end bottom-menu-wrapper-inner -->
+  </div> <!-- end bottom-menu-wrapper -->
+
+  <div class="footer-social-media-wrapper">
+    <div class="footer-social-media-wrapper-inner">
+      <?php print render($page['footer_social_media']); ?>
+    </div>
+  </div>
+
+  <div class="footer-wrapper">
+    <div class="footer-wrapper-inner">
+      <footer class="l-footer" role="contentinfo">
+        <div class="footer-inner">
+          <div class="footer-top">
+            <div class="l-footer-copyright">
+              <div class="footer-copyright-inner">
+                <span class="copyright">&copy; Crown Copyright</span>
+                <?php print render($page['footer_copyright']); ?>
+              </div> <!-- end l-footer-copyright -->
+            </div> <!-- end footer-copyright-inner -->
+          </div> <!-- end footer-top -->
+
+          <div class="footer-bottom">
+            <div class="l-footer-menu">
+              <div class="footer-menu-inner">
+                <?php print render($page['footer_menu']); ?>
+              </div> <!-- end l-footer-menu -->
+            </div> <!-- end footer-menu-inner -->
+
+            <div class="l-footer-buttons">
+              <div class="footer-buttons-inner">
+                <?php print render($page['footer_buttons']); ?>
+              </div> <!-- end l-footer-buttons -->
+            </div> <!-- end footer-buttons-inner -->
+          </div> <!-- end footer-bottom -->
+
+        </div> <!-- end footer-inner -->
+      </footer>
+    </div> <!-- end footer-wrapper-inner -->
+  </div>  <!-- end footer-wrapper -->
+
+</div> <!-- end l-page -->
+
+  <?php print $page_bottom; ?>
+</body>
+</html>

--- a/docroot/sites/all/themes/site_frontend/templates/system/maintenance-page.tpl.php
+++ b/docroot/sites/all/themes/site_frontend/templates/system/maintenance-page.tpl.php
@@ -24,8 +24,8 @@
   <a href="#main-content" class="element-invisible element-focusable" accesskey="S"><?php print t('Skip to main content'); ?></a>
   <?php if (!empty($page_top)): ?>
     <?php print $page_top; ?>
-  <?php endif; ?>  
-  
+  <?php endif; ?>
+
   <div class="header-wrapper">
     <div class="header-wrapper-inner">
       <header class="l-header" role="banner">
@@ -64,7 +64,7 @@
       </header>
     </div> <!-- end header-wrapper-inner -->
   </div> <!-- end header-wrapper -->
-  
+
   <div class="main-wrapper">
     <div class="l-main">
       <div class="main-inner">
@@ -93,7 +93,7 @@
             <?php if (!empty($action_links)): ?>
               <ul class="action-links"><?php print render($action_links); ?></ul>
             <?php endif; ?>
-              <?php print render($content); ?>
+            <?php print render($content); ?>
             <?php if (!empty($page['node_inline'])): ?>
               <?php print render($page['node_inline']); ?>
             <?php endif; ?>
@@ -106,7 +106,7 @@
       </div> <!-- end main-inner -->
     </div> <!-- end main -->
   </div> <!-- end main-wrapper -->
-  
+
   <div class="bottom-menu-wrapper">
     <div class="bottom-menu-wrapper-inner">
       <div class="l-bottom-menu">

--- a/docroot/sites/all/themes/site_frontend/templates/system/maintenance-page.tpl.php
+++ b/docroot/sites/all/themes/site_frontend/templates/system/maintenance-page.tpl.php
@@ -1,3 +1,9 @@
+<?php
+/**
+ * @file
+ * Theme implementation for the site maintenance page.
+ */
+?>
 <!DOCTYPE html>
 <?php if (omega_extension_enabled('compatibility') && omega_theme_get_setting('omega_conditional_classes_html', TRUE)): ?>
 <!--[if !IE]><!--><html class="no-js" lang="<?php print $language->language; ?>" dir="<?php print $language->dir; ?>"><!--<![endif]-->


### PR DESCRIPTION
Created a custom site maintenance page. This involves:

* Adding a new template for the site maintenance page in the site frontend theme
* Adding new SASS/CSS files for the site maintenance page
* Adding a new custom module to enhance the maintenance mode functionality
* Making some amendments to the FSA Social media module

New module
-----------------
Once deployed, the new module will need enabling, and the caches will need clearing:

`drush en fsa_maintenance_page --y`
`drush cc all`

New URLs
--------------
The site maintenance page will be accessible here: http://dev.food.gov.uk/site-maintenance
The special CloudFlare page will be here: http://dev.food.gov.uk/site-maintenance/cf

@todo Use the CloudFlare API to reflect changes to the error page

[ Partial fix for #2015030610000017 ]