### PR TITLE
Develop: Allow Twitter widget to be embedded in maintenance page

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -16,6 +16,11 @@ define('FSA_MAINTENANCE_PAGE_CSS_FILE', 'maintenance-page.css');
 define('FSA_MAINTENANCE_PAGE_DEFAULT_PAGE_TITLE', t('Site under maintenance'));
 
 /**
+ * Twitter configuration prefix
+ */
+define('FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX', 'maintenance_mode_twitter_config');
+
+/**
  * Implements hook_menu().
  */
 function fsa_maintenance_page_menu() {
@@ -119,6 +124,47 @@ function fsa_maintenance_page_preprocess_maintenance_page(&$variables) {
     );
   }
 
+  // Embed a Twitter widget - if required
+  $variables['content']['twitter_feed'] = array(
+    '#type' => 'container',
+    '#attributes' => array(
+      'class' => array(
+        'twitter-widget',
+      ),
+    ),
+    '#access' => _fsa_maintenance_page_embed_twitter(),
+    'heading' => array(
+      '#type' => 'html_tag',
+      '#tag' => 'h2',
+      '#value' => _fsa_maintenance_page_twitter_config('title'),
+    ),
+    'link' => array(
+      '#type' => 'link',
+      '#title' => _fsa_maintenance_page_twitter_config('title', t('Tweets from foodgov')),
+      '#href' => _fsa_maintenance_page_twitter_config('url', 'https://twitter.com/foodgov'),
+      '#attributes' => array(
+        'data-widget-id' => _fsa_maintenance_page_twitter_config('widget_id'),
+        'data-tweet-limit' => _fsa_maintenance_page_twitter_config('tweet_limit', 5),
+        'data-chrome' => array(
+          'noheader',
+          'nofooter',
+          'noborders',
+        ),
+        'class' => array('twitter-timeline'),
+        'height' => _fsa_maintenance_page_twitter_config('height', 300),
+      ),
+    ),
+    // Since we're not using Drupal's standard head content functions, we need
+    // to add the Twitter JavaScript in a slightly unorthodox way, via an
+    // HTML tag render array. Remember to escape any quotes!
+    'js' => array(
+      '#type' => 'html_tag',
+      '#tag' => 'script',
+      '#value' => '!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?\'http\':\'https\';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");',
+    ),
+    '#weight' => 110,
+  );
+
   // Add the CloudFlare token if required
   if (!empty($variables['cf'])) {
     $variables['content']['cf_token'] = array(
@@ -193,12 +239,74 @@ function fsa_maintenance_page_form_system_site_maintenance_mode_alter(&$form, &$
     '#weight' => 30,
   );
 
-  // Add an additional submit handler
+  // Twitter widget configuration
+  // Configuration URL - where the widget can be modified
+  $widget_id = _fsa_maintenance_page_twitter_config('widget_id');
+  $twitter_config_url = !empty($widget_id) ? url('https://twitter.com/settings/widgets/' . _fsa_maintenance_page_twitter_config('widget_id') . '/edit', array('absolute' => TRUE)) : NULL;
+  $form['twitter_configuration'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Twitter widget configuration'),
+    '#description' => t('You can embed a Twitter feed widget in the site maintenance page.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#weight' => 40,
+
+    'maintenance_mode_embed_twitter' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Embed Twitter widget'),
+      '#default_value' => variable_get('maintenance_mode_embed_twitter'),
+    ),
+
+    FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX . '_title' => array(
+      '#type' => 'textfield',
+      '#title' => t('Title'),
+      '#description' => t('Title to be displayed above the Twitter feed'),
+      '#default_value' => _fsa_maintenance_page_twitter_config('title'),
+    ),
+
+    FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX . '_url' => array(
+      '#type' => 'textfield',
+      '#title' => t('Twitter URL'),
+      '#description' => t('The URL for the Twitter feed.'),
+      '#default_value' => _fsa_maintenance_page_twitter_config('url', 'https://twitter.com/foodgov'),
+    ),
+
+    FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX . '_widget_id' => array(
+      '#type' => 'textfield',
+      '#title' => t('Widget ID'),
+      '#description' => t('The ID of the widget to be embedded') . (!empty($twitter_config_url) ? '. ' . l(t('Configure widget'), $twitter_config_url) : NULL),
+      '#default_value' => _fsa_maintenance_page_twitter_config('widget_id'),
+    ),
+
+    FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX . '_tweet_limit' => array(
+      '#type' => 'textfield',
+      '#title' => t('Number of tweets'),
+      '#description' => t('Set the number of tweets to display. If you don\'t want to limit them, leave blank.'),
+      '#default_value' => _fsa_maintenance_page_twitter_config('tweet_limit'),
+    ),
+
+    FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX . '_height' => array(
+      '#type' => 'textfield',
+      '#title' => t('Widget height'),
+      '#description' => t('Set the height of the widget in pixels'),
+      '#default_value' => _fsa_maintenance_page_twitter_config('height', 300),
+    ),
+  );
+  // Add Twitter config submit handler
+  array_unshift($form['#submit'], '_fsa_maintenance_page_site_maintenance_form_twitter_config_submit');
+
+
+  // Add an additional submit handler for CloudFlare
   $form['#submit'][] = '_fsa_maintenance_page_site_maintenance_form_submit';
 }
 
 
-// Helper function - returns social media icons block render array
+/**
+ * Helper function - returns social media icons block render array
+ *
+ * @param array $options
+ * @return string
+ */
 function _fsa_maintenance_page_social_media_icons($options = array()) {
   $module = 'fsa_social_media';
   $delta = 'social_media_icons';
@@ -312,5 +420,63 @@ function _fsa_maintenance_page_update_cloudflare_error_page() {
   }
   else {
     drupal_set_message(t('Failed to update the CloudFlare Always Online custom error page'), 'error');
+  }
+}
+
+
+/**
+ * Additional submit handler for maintenance config form - Twitter config
+ */
+function _fsa_maintenance_page_site_maintenance_form_twitter_config_submit($form, &$form_state) {
+  $twitter_config = array();
+  foreach($form_state['values'] as $name => $value) {
+    if (strpos($name, FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX) === 0) {
+      $twitter_config[str_replace(FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX . '_', '', $name)] = $value;
+      unset($form_state['values'][$name]);
+    }
+  }
+  $form_state['values'][FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX] = $twitter_config;
+}
+
+
+/**
+ * Helper function: Determines whether to embed Twitter widget
+ */
+function _fsa_maintenance_page_embed_twitter() {
+  $embed = variable_get('maintenance_mode_embed_twitter');
+  return !empty($embed);
+}
+
+
+/**
+ * Helper function: Gets Twitter configuration
+ *
+ * @param string $param
+ *   (optional) Name of the specific parameter to return. If omitted, the full
+ *   array of values will be returned.
+ * @param string $default
+ *   (optional) The default value to return in case the requested $param is
+ *   not set.
+ * @return array|string|NULL
+ *   Either the full array of configuration parameters or, if a specific
+ *   parameter is requested via the $param argument, the value of this
+ *   parameter. If the $default parameter is specified, this is returned, but
+ *   only if $param is specified too. If no matching parameter is specified,
+ *   the default value of $default (NULL) is returned.
+ */
+function _fsa_maintenance_page_twitter_config($param = NULL, $default = NULL) {
+  // Get the variable
+  $twitter_config = variable_get(FSA_MAINTENANCE_PAGE_TWITTER_CONFIG_PREFIX, array());
+  // If no $param is specified, return the full array.
+  if (empty($param)) {
+    return $twitter_config;
+  }
+  // If a $param is specified and it exists in the array, return it, otherwise
+  // return the default value (which by default is NULL).
+  if (isset($twitter_config[$param])) {
+    return $twitter_config[$param];
+  }
+  else {
+    return $default;
   }
 }

--- a/docroot/sites/all/themes/site_frontend/css/maintenance-page.css
+++ b/docroot/sites/all/themes/site_frontend/css/maintenance-page.css
@@ -9059,6 +9059,11 @@ body {
 .maintenance-page.in-maintenance .always_online {
   display: none;
 }
+.maintenance-page.in-maintenance .twitter-widget {
+  border-top: 1px solid #ddd;
+  padding-top: 1em;
+  margin-bottom: 3em;
+}
 .maintenance-page.in-maintenance .contextual-links-wrapper {
   display: none;
 }

--- a/docroot/sites/all/themes/site_frontend/sass/maintenance-page.scss
+++ b/docroot/sites/all/themes/site_frontend/sass/maintenance-page.scss
@@ -198,6 +198,13 @@ body {
   .always_online {
     display: none;
   }
+  
+  // Formatting for the Twitter widget
+  .twitter-widget {
+    border-top: 1px solid #ddd;
+    padding-top: 1em;
+    margin-bottom: 3em;
+  }
 
   // Hide contextual links wrappers
   .contextual-links-wrapper {


### PR DESCRIPTION
Added the ability to embed a Twitter widget in the site maintenance page, configured via the admin interface.

[ Partial fix for #2015030610000017 ]