### PR TITLE
Develop: Add CloudFlare config to maintenance page admin

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -408,7 +408,7 @@ function _fsa_maintenance_page_update_cloudflare_error_page() {
   $options['method'] = 'PUT';
   // Set request data
   $data = array(
-    'url' => $maintenance_page_url,
+    'url' => _fsa_maintenance_page_cloudflare_error_page_url(TRUE),
     'state' => 'customized',
   );
   $data = (object) $data;

--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -351,7 +351,9 @@ function _fsa_maintenance_page_social_media_icons($options = array()) {
  * Additional submit handler for the maintenance page admin form
  */
 function _fsa_maintenance_page_site_maintenance_form_submit($form, &$form_state) {
-  _fsa_maintenance_page_update_cloudflare_error_page();
+  if (!empty($form_state['values']['maintenance_mode_update_cloudflare'])) {
+    _fsa_maintenance_page_update_cloudflare_error_page();
+  }
 }
 
 

--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -295,6 +295,26 @@ function fsa_maintenance_page_form_system_site_maintenance_mode_alter(&$form, &$
   // Add Twitter config submit handler
   array_unshift($form['#submit'], '_fsa_maintenance_page_site_maintenance_form_twitter_config_submit');
 
+  // CloudFlare configuration
+  $form['cloudflare_config'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('CloudFlare configuration'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#weight' => 50,
+
+    'maintenance_mode_update_cloudflare' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Update CloudFlare error page'),
+      '#default_value' => variable_get('maintenance_mode_update_cloudflare', 1),
+    ),
+
+    'maintenance_mode_cloudflare_error_url' => array(
+      '#type' => 'textfield',
+      '#title' => t('CloudFlare error page URL'),
+      '#default_value' => _fsa_maintenance_page_cloudflare_error_page_url(FALSE),
+    ),
+  );
 
   // Add an additional submit handler for CloudFlare
   $form['#submit'][] = '_fsa_maintenance_page_site_maintenance_form_submit';

--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -480,3 +480,33 @@ function _fsa_maintenance_page_twitter_config($param = NULL, $default = NULL) {
     return $default;
   }
 }
+
+
+/**
+ * Helper function: returns the URL for the CloudFlare error page
+ *
+ * @param boolean $add_timestamp
+ *   (optional) If set to TRUE, adds a timestamp as a query string parameter
+ *   to the URL returned. This is useful for ensuring a cache miss when
+ *   CloudFlare scrapes the page. Defaults to FALSE.
+ *
+ * @return string
+ *   The full URL of the error page that CloudFlare will scrape and internalise
+ */
+function _fsa_maintenance_page_cloudflare_error_page_url($add_timestamp = FALSE) {
+  $options = array(
+    'absolute' => TRUE,
+  );
+  if ($add_timestamp) {
+    $options['query'] = array(
+      'ts' => REQUEST_TIME,
+    );
+  }
+  $url = variable_get('maintenance_mode_cloudflare_error_url');
+  if (empty($url)) {
+    $options['base_url'] = local_get_site_domain(FALSE, 'http');
+    $url = 'site-maintenance/cf';
+  }
+
+  return url($url, $options);
+}

--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -398,10 +398,6 @@ function _fsa_maintenance_page_update_cloudflare_error_page() {
     return;
   }
 
-  // Get the site domain
-  $domain = local_get_site_domain(FALSE, 'http');
-  $maintenance_page_url = url('site-maintenance/cf', array('absolute' => TRUE, 'base_url' => $domain, 'query' => array('ts' => REQUEST_TIME)));
-
   // Update the Always online custom page
   $url = "$endpoint/$zone/custom_pages/always_online";
   // Set request method to PUT

--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -362,7 +362,6 @@ function _fsa_maintenance_page_site_maintenance_form_submit($form, &$form_state)
  */
 function _fsa_maintenance_page_update_cloudflare_error_page() {
 
-
   if (!is_callable('_fsa_cache_clear_settings')) {
     watchdog('fsa_maintenance_page', 'No CloudFlare settings found', array(), WATCHDOG_ERROR);
     return;

--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -342,7 +342,7 @@ function _fsa_maintenance_page_update_cloudflare_error_page() {
 
 
   if (!is_callable('_fsa_cache_clear_settings')) {
-    // @todo Log a Watchdog message here
+    watchdog('fsa_maintenance_page', 'No CloudFlare settings found', array(), WATCHDOG_ERROR);
     return;
   }
 
@@ -372,7 +372,7 @@ function _fsa_maintenance_page_update_cloudflare_error_page() {
 
   // No zone? Exit now
   if (empty($zone)) {
-    // @todo Log a Watchdog message here
+    watchdog('fsa_maintenance_page', 'No CloudFlare zone information found', array(), WATCHDOG_ERROR);
     return;
   }
 
@@ -394,7 +394,7 @@ function _fsa_maintenance_page_update_cloudflare_error_page() {
   }
 
   if (!$custom_page) {
-    // @todo Log a Watchdog message here
+    watchdog('fsa_maintenance_page', 'No CloudFlare custom error page found', array(), WATCHDOG_ERROR);
     return;
   }
 
@@ -416,6 +416,15 @@ function _fsa_maintenance_page_update_cloudflare_error_page() {
   }
   else {
     drupal_set_message(t('Failed to update the CloudFlare Always Online custom error page'), 'error');
+    $errors = !empty($response->errors) ? $response->errors : array();
+    $err_message = t('There was a problem updating the CloudFlare Always Online custom error page.');
+    if (count($err_message) > 0) {
+      $err_message .= ' ' . t('The errors were: ');
+      foreach ($errors as $error) {
+        $err_message .= $error->code . ' - ' . $error->message . '; ';
+      }
+    }
+    watchdog('fsa_maintenance_page', $err_message, array(), WATCHDOG_ERROR);
   }
 }
 


### PR DESCRIPTION
It's now possible to configure CloudFlare error page from within the maintenance mode admin page.

[ Partial fix for #2015030610000017 ]