### PR TITLE
Amend styling for carousel text box

### DIFF
--- a/docroot/sites/all/themes/site_frontend/css/ie/ie8.css
+++ b/docroot/sites/all/themes/site_frontend/css/ie/ie8.css
@@ -6,3 +6,7 @@
   min-height: 0;
   height: 3.5em;
 }
+
+.home-page-carousel img {
+  max-width: inherit;
+}

--- a/docroot/sites/all/themes/site_frontend/css/site-frontend.no-query.css
+++ b/docroot/sites/all/themes/site_frontend/css/site-frontend.no-query.css
@@ -2034,7 +2034,6 @@ ul.breadcrumb {
 }
 .home-page-carousel .slide-content-wrapper {
   z-index: 2;
-  width: 400px;
   max-height: 169px;
   overflow: hidden;
   position: absolute;

--- a/docroot/sites/all/themes/site_frontend/css/site-frontend.styles.css
+++ b/docroot/sites/all/themes/site_frontend/css/site-frontend.styles.css
@@ -2055,7 +2055,6 @@ ul.breadcrumb {
 }
 .home-page-carousel .slide-content-wrapper {
   z-index: 2;
-  width: 400px;
   max-height: 169px;
   overflow: hidden;
   position: absolute;

--- a/docroot/sites/all/themes/site_frontend/sass/components/_carousel.scss
+++ b/docroot/sites/all/themes/site_frontend/sass/components/_carousel.scss
@@ -26,7 +26,8 @@
 	/* slide content wrapper */
 	.slide-content-wrapper {
 		z-index: 2;
-		width: 400px;
+    // Allow text box to fit text
+		//width: 400px;
 		max-height: 169px;
 		overflow: hidden;
 		position: absolute;

--- a/docroot/sites/all/themes/site_frontend/sass/ie/ie8.scss
+++ b/docroot/sites/all/themes/site_frontend/sass/ie/ie8.scss
@@ -8,3 +8,11 @@
 	height: 3.5em;
 }
 
+// Homepage carousel tweaks
+.home-page-carousel {
+  // For the carousel fix the image display issue. Setting max-width seems to
+  // break images in the carousel.
+  img {
+    max-width: inherit;
+  }
+}


### PR DESCRIPTION
* Changed width for homepage carousel text box from fixed (400px) to automatic
* For IE8 browser, set image width in carousel to `inherit`

[ Fixes #10345 ]