### PR TITLE
Update CKEditor feature

### DIFF
--- a/docroot/sites/all/modules/features/base/ckeditor___editor/ckeditor___editor.features.ckeditor_profile.inc
+++ b/docroot/sites/all/modules/features/base/ckeditor___editor/ckeditor___editor.features.ckeditor_profile.inc
@@ -94,18 +94,6 @@ function ckeditor___editor_ckeditor_profile_defaults() {
             ),
             'default' => 't',
           ),
-          'media' => array(
-            'name' => 'media',
-            'desc' => 'Plugin for inserting images from Drupal media module',
-            'path' => '%plugin_dir%media/',
-            'buttons' => array(
-              'Media' => array(
-                'label' => 'Media',
-                'icon' => 'images/icon.gif',
-              ),
-            ),
-            'default' => 'f',
-          ),
         ),
       ),
       'input_formats' => array(
@@ -123,7 +111,7 @@ function ckeditor___editor_ckeditor_profile_defaults() {
         'toolbar' => '[
     [\'PasteText\',\'PasteFromWord\'],
     [\'RemoveFormat\'],
-    [\'Media\',\'Table\',\'SpecialChar\'],
+    [\'Table\',\'SpecialChar\'],
     [\'Link\',\'Unlink\',\'Anchor\'],
     [\'Source\'],
     [\'Maximize\'],
@@ -184,18 +172,6 @@ function ckeditor___editor_ckeditor_profile_defaults() {
             'desc' => 'Plugin file: div',
             'path' => '%plugin_dir_extra%div/',
             'buttons' => FALSE,
-            'default' => 'f',
-          ),
-          'media' => array(
-            'name' => 'media',
-            'desc' => 'Plugin for inserting images from Drupal media module',
-            'path' => '%plugin_dir%media/',
-            'buttons' => array(
-              'Media' => array(
-                'label' => 'Media',
-                'icon' => 'images/icon.gif',
-              ),
-            ),
             'default' => 'f',
           ),
           'token_insert_ckeditor' => array(
@@ -286,18 +262,6 @@ function ckeditor___editor_ckeditor_profile_defaults() {
             'desc' => 'Plugin file: div',
             'path' => '%plugin_dir_extra%div/',
             'buttons' => FALSE,
-            'default' => 'f',
-          ),
-          'media' => array(
-            'name' => 'media',
-            'desc' => 'Plugin for inserting images from Drupal media module',
-            'path' => '%plugin_dir%media/',
-            'buttons' => array(
-              'Media' => array(
-                'label' => 'Media',
-                'icon' => 'images/icon.gif',
-              ),
-            ),
             'default' => 'f',
           ),
           'token_insert_ckeditor' => array(

--- a/docroot/sites/all/modules/features/base/ckeditor___editor/ckeditor___editor.features.user_permission.inc
+++ b/docroot/sites/all/modules/features/base/ckeditor___editor/ckeditor___editor.features.user_permission.inc
@@ -14,7 +14,6 @@ function ckeditor___editor_user_default_permissions() {
   $permissions['access ckeditor link'] = array(
     'name' => 'access ckeditor link',
     'roles' => array(
-      'About Us' => 'About Us',
       'Administrator' => 'Administrator',
       'Business' => 'Business',
       'Committee' => 'Committee',


### PR DESCRIPTION
Updated the configuration for the CKEditor WYSIWYG editor within the feature CKEditor.

* Removed permission for the **About us** role as it no longer exists
* Removed the insert media button as it no longer works with the latest version of the module

[ Partial fix for #1084 ]