### PR TITLE
Change variable name for default text entries

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -626,11 +626,12 @@ function fsa_food_report_text_form($form, &$form_state) {
             '#title' => filter_xss($entry['title']),
             '#description' => filter_xss($entry['description']),
           );
-          $form[$service][$cat][$service . '_text']["fsa_report_problem_text_${key}_container"]["fsa_report_problem_text_${service}_${key}"] = array(
+          $variable_name = $service != 'default' ? "fsa_report_problem_text_${service}_${key}" : "fsa_report_problem_text_${key}";
+          $form[$service][$cat][$service . '_text']["fsa_report_problem_text_${key}_container"][$variable_name] = array(
             '#type' => 'text_format',
             '#title' => $entry['title'],
             '#title_display' => 'invisible',
-            '#default_value' => $entry['value'],
+            '#default_value' => !empty($entry['value']) ? $entry['value'] : NULL,
             '#format' => empty($entry['format']) ? 'full_html' : $entry['format'],
           );
         }

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1733,7 +1733,7 @@ function _fsa_report_problem_text() {
 
     // Get the values for the text entries
     foreach ($text as $key => $entry) {
-      $variable_name = !empty($service) ? "fsa_report_problem_text_${service}_${key}" : "fsa_report_problem_text_${key}";
+      $variable_name = empty($service) || $service == 'default' ? "fsa_report_problem_text_${key}" : "fsa_report_problem_text_${service}_${key}";
       $variable_value = variable_get($variable_name);
       $default_value = variable_get("fsa_report_problem_text_${key}");
       $text[$key]['value'] = is_array($default_value) && !empty($default_value['value']) ? $default_value['value'] : NULL;


### PR DESCRIPTION
For default text entries in the report a food problem module, change the variable names so they match the existing text entries - ie drop the `_default_` prefix.

[ Partial fix for #10352 ]