### PR TITLE
Translate local authority names

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
@@ -68,10 +68,17 @@ function fsa_report_problem_make_report_form($form, &$form_state, $manual = FALS
 
   // If it's not a manual entry report, display the local authority name
   if (empty($manual)) {
+    // Translate the local authority name if we're not on an English page
+    global $language;
+    $lang_code = !empty($language->language) ? $language->language : 'en';
+    $local_authority_name = !empty($local_authority['name']) ? $local_authority['name'] : NULL;
+    if ($lang_code != 'en' && !empty($local_authority_name)) {
+      $local_authority_name = locale($local_authority_name);
+    }
     $form['local_authority'] = array(
       '#type' => 'item',
       '#title' => t('Local authority'),
-      '#markup' => !empty($local_authority['name']) ? $local_authority['name'] : NULL,
+      '#markup' => $local_authority_name,
     );
   }
 

--- a/docroot/sites/all/modules/custom/fsa_report_problem/forms/report_complete_form.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/forms/report_complete_form.php
@@ -17,6 +17,14 @@ function fsa_report_problem_report_complete_form($form, &$form_state) {
   $local_authority_name = !empty($local_authority['name']) ? $local_authority['name'] : '';
   $local_authority_email = !empty($local_authority['email']) ? $local_authority['email'] : '';
 
+  // Translate the local authority name if we're not on an English page
+  global $language;
+  $lang_code = !empty($language->language) ? $language->language : 'en';
+  $local_authority_name = !empty($local_authority['name']) ? $local_authority['name'] : NULL;
+  if ($lang_code != 'en' && !empty($local_authority_name)) {
+    $local_authority_name = locale($local_authority_name);
+  }
+
   // Create a report object for use with tokens
   $report = (object) array('local_authority_name' => $local_authority_name, 'local_authority_email' => $local_authority_email);
 

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1761,7 +1761,7 @@ function _fsa_report_problem_text() {
       $text_content = variable_get("fsa_report_problem_text_${key}");
     }
     return new FsaReportProblemTextEntry(
-      $text_content['value'],
+      !empty($text_content['value']) ? $text_content['value'] : '',
       !empty($text[$key]['format']) ? $text[$key]['format'] : NULL,
       !empty($text[$key]['default']) ? $text[$key]['default'] : NULL,
       $data


### PR DESCRIPTION
Local authority names are now translated on the make report and report complete stages.

Also check that text entry values are not empty when returning `FsaReportProblemTextEntry` objects.

[ Partial fix for #10351 and #10352 ]