### PR TITLE
Develop: Tweak email address labels

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -1474,7 +1474,7 @@ function fsa_report_problem_authority_view_form($form, &$form_state, $aid = 0) {
 
   $form['fhrs']['email'] = array(
     '#type' => 'item',
-    '#title' => t('Email address'),
+    '#title' => t('Report a food problem email address'),
     '#markup' => $authority->email,
   );
 
@@ -1603,7 +1603,7 @@ function fsa_report_problem_authority_edit_form($form, &$form_state, $aid = 0) {
 
   $form['local_authority_details']['email'] = array(
     '#type' => 'textfield',
-    '#title' => t('Email address'),
+    '#title' => t('Report a food problem email address'),
     '#default_value' => !empty($authority) ? $authority->email : NULL,
   );
 

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -3920,6 +3920,7 @@ function _fsa_report_problem_block_content__local_authority_search($delta = '') 
       $content['local_authority_details'] = array(
         '#theme' => 'local_authority_details',
         '#local_authority' => $local_authority,
+        '#delta' => $delta,
       );
 
       // Embed the rating widget - if set


### PR DESCRIPTION
Changed labels for email address field in report a food problem admin interface to 'Report a food problem email address', as requested by Sally.

[ Partial fix for #10351 ]