### PR TITLE
Develop: fix problem with Google Places search results

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -1768,10 +1768,12 @@ function fsa_report_problem_api_admin_form($form, &$form_state) {
       $variable_name = 'fsa_report_problem_' . $api . '_api_' . $key;
       $field_type = !empty($properties['type']) ? $properties['type'] : 'textfield';
       $field_title = !empty($properties['title']) ? $properties['title'] : $key;
+      $description = !empty($properties['description']) ? $properties['description'] : NULL;
       $options = !empty($properties['options']) ? $properties['options'] : NULL;
       $form['global_apis']["${api}_settings"][$variable_name] = array(
         '#type' => $field_type,
         '#title' => $field_title,
+        '#description' => $description,
         '#default_value' => _fsa_report_problem_api_setting($api, $key, NULL),
       );
       if (!empty($options)) {
@@ -1808,10 +1810,12 @@ function fsa_report_problem_api_admin_form($form, &$form_state) {
         $variable_name = 'fsa_report_problem_' . "${delta}_" . $machine_name . '_api_' . $key;
         $field_type = !empty($properties['type']) ? $properties['type'] : 'textfield';
         $field_title = !empty($properties['title']) ? $properties['title'] : $key;
+        $description = !empty($properties['description']) ? $properties['description'] : NULL;
         $options = !empty($properties['options']) ? $properties['options'] : NULL;
         $form['apis'][$delta . '_container'][$delta . '_' . $machine_name][$variable_name] = array(
           '#type' => $field_type,
           '#title' => $field_title,
+          '#description' => $description,
           '#default_value' => _fsa_report_problem_api_setting($machine_name, $key, $delta)
         );
       }

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -2938,6 +2938,11 @@ function _fsa_report_problem_api_settings($delta = NULL) {
         'title' => t('API endpoint'),
         'default_value' => 'https://maps.googleapis.com/maps/api/place/textsearch/json',
       ),
+      'query_suffix' => array(
+        'title' => t('Query suffix'),
+        'default_value' => 'UK',
+        'description' => t('Enter any terms you wish to add automatcially to Google Places search queries to help restrict search results, eg \'UK\''),
+      ),
       'delay' => array(
         'title' => t('Time between requests'),
         'default_value' => 2,

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -822,6 +822,13 @@ function fsa_report_problem_get_google_results($name, $location = '', $user_loca
 
   // Build query parameters
   $query = "$name $location";
+  // Add a suffix to the search query. This comes from an API setting that can
+  // be amended on the API configuration page for this module in Drupal. Adding
+  // 'UK' to the search results helps to restrict results to UK-based businesses
+  $query_suffix = _fsa_report_problem_api_setting('google_places', 'query_suffix');
+  if (!empty($query_suffix)) {
+    $query .= " $query_suffix";
+  }
   $options = array(
     'query' => array(
       'key' => $api_key,


### PR DESCRIPTION
Added a query suffix field to help restrict Google Places search results to UK establishments only, thereby ensuring that searches without locations, such as 'pizza hut' and those with ambiguous locations such as 'pizza hut bristol' (there are Bristols in other countries) return results.

[ Fixes #10356 ]