### PR TITLE
Develop: Add text specific to search for local authority

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.install
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.install
@@ -489,3 +489,11 @@ function fsa_report_problem_update_7010() {
 function fsa_report_problem_update_7011() {
   _fsa_report_problem_variable_setup();
 }
+
+
+/**
+ * Makes new service-specific language entries translatable
+ */
+function fsa_report_problem_update_7012() {
+  _fsa_report_problem_variable_setup();
+}

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1830,6 +1830,24 @@ function _fsa_report_problem_text__find_food_safety_team() {
 }
 
 
+/**
+ * Helper function: provides text entries for search for local authority
+ */
+function _fsa_report_problem_text__local_authority_search() {
+  $text = array(
+    'postcode_search_intro' => array(
+    'title' => t('Postcode search form intro'),
+    'description' => t('Intro text for the search for authority by postcode lookup form as used in the Find a food safety officer service'),
+    'format' => 'full_html',
+    ),
+    'choose_business_intro' => array(
+      'title' => t('Business choice form intro'),
+      'description' => t('This text appears at the top of the screen where users can select a business'),
+    ),
+  );
+  return $text;
+}
+
 
 /**
  * Implements hook_token_info().


### PR DESCRIPTION
Added an additional helper function to provide text entries for the search for local authority service.

[ Partial fix for #10351 ]