### PR TITLE
Develop: Change button verb based on block $delta

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/forms/business_results_form.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/forms/business_results_form.php
@@ -68,7 +68,7 @@ function fsa_report_problem_business_results_form($form, &$form_state, $next_sta
     );
 
     // Set the verb to appear on the buttons to select a business.
-    $button_verb = _fsa_report_problem_capture_user_data() ? t('Report') : t('Choose');
+    $button_verb = $delta == 'report_problem_form' ? t('Report') : t('Choose');
 
     $form['business_wrapper_' . $id][$id] = array(
       '#type' => 'submit',


### PR DESCRIPTION
For the report a food problem block, the verb on the button should be 'Report', but for all other situations, it should be 'Choose'.

Set this based on block `$delta`.

[ Partial fix for #10351 ]