### PR TITLE
Develop: Add local authority contact to email via tokens

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1289,12 +1289,19 @@ function fsa_report_problem_mail($key, &$message, $params) {
         $message['body'][] = t('Dear Sir or Madam');
       }
 
-      $message['body'][] = token_replace($message_details['message'], array('report' => $params['report']));
+      // Create a local authority object and get the contact statement
+      $local_authority = (object) array(
+        'contact_statement' => !empty($params['report']->local_authority_email) ? strip_tags(_fsa_report_problem_text('contact_local_authority', array('report' => $params['report']))) : NULL,
+      );
 
-      if (!empty($params['report']->local_authority_email)) {
-        $contact = _fsa_report_problem_text('contact_local_authority', array('report' => $params['report']));
-        $message['body'][] = "\r\n\r\n" . $contact['value'];
-      }
+      $message_body = token_replace($message_details['message'], array('report' => $params['report'], 'local_authority' => $local_authority));
+      // Normalise the line breaks by changing all to Linux types
+      $message_body = preg_replace("/\r\n?/", "\n", $message_body);
+      // Replace any examples of more than two line breaks with exactly two
+      $message_body = preg_replace("/\n{2,}/", "\n\n", $message_body);
+
+      $message['body'][] = $message_body;
+
       break;
   }
 }

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1930,6 +1930,9 @@ function fsa_report_problem_tokens($type, $tokens, array $data = array(), array 
 
     if (!empty($data['local_authority'])) {
       $local_authority = $data['local_authority'];
+      if (!is_object($local_authority)) {
+        $local_authority = new stdClass();
+      }
     }
     elseif (!empty($data['report'])) {
       $report = $data['report'];
@@ -1949,6 +1952,14 @@ function fsa_report_problem_tokens($type, $tokens, array $data = array(), array 
         case 'email':
           if (!empty($local_authority->email)) {
             $replacements[$original] = $local_authority->email;
+          }
+          break;
+        case 'contact_statement':
+          if (!empty($local_authority->contact_statement)) {
+            $replacements[$original] = $local_authority->contact_statement;
+          }
+          else {
+            $replacements[$original] = '';
           }
           break;
       }


### PR DESCRIPTION
The local authority contact details are now added to the acknowledgement emails via a new token that can be entered via the Drupal admin user interface.

The new token is: `[local_authority:contact_statement]`

[ Partial fix for #10351 ]