### PR TITLE
Develop: improve display of food problem reports

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -22,7 +22,12 @@ function fsa_report_problem_view_reports($form, &$form_state) {
       'type' => 'property',
     ),
     array(
-      'data' => t('Report date'),
+      'data' => t('Submitted'),
+      'specifier' => 'created',
+      'type' => 'property',
+    ),
+    array(
+      'data' => t('Problem date'),
       'specifier' => 'problem_date',
       'type' => 'property',
     ),
@@ -59,6 +64,7 @@ function fsa_report_problem_view_reports($form, &$form_state) {
       l($report->rid, $uri['path']),
       $report->business_name,
       !empty($report->problem_date) ? format_date($report->problem_date, 'medium') : '',
+      !empty($report->created) ? format_date($report->created, 'custom', 'j F Y') : '',
       $report->local_authority_name,
       $report->local_authority_email,
     );

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -62,7 +62,7 @@ function fsa_report_problem_view_reports($form, &$form_state) {
     $status = empty($report->email_sent) ? 'unsent' : 'sent';
     $report_list[$status][] = array(
       l($report->rid, $uri['path']),
-      $report->business_name,
+      is_callable('mb_strimwidth') ? mb_strimwidth($report->business_name, 0, 44, '...') : substr($report->business_name, 0, 44),
       !empty($report->created) ? format_date($report->created, 'custom', 'j F Y') : '',
       !empty($report->problem_date) ? format_date($report->problem_date, 'custom', 'j F Y') : '',
       $report->local_authority_name,

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -63,8 +63,8 @@ function fsa_report_problem_view_reports($form, &$form_state) {
     $report_list[$status][] = array(
       l($report->rid, $uri['path']),
       $report->business_name,
-      !empty($report->problem_date) ? format_date($report->problem_date, 'medium') : '',
       !empty($report->created) ? format_date($report->created, 'custom', 'j F Y') : '',
+      !empty($report->problem_date) ? format_date($report->problem_date, 'custom', 'j F Y') : '',
       $report->local_authority_name,
       $report->local_authority_email,
     );

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -761,6 +761,7 @@ function template_preprocess_problem_report(&$variables) {
     '#type' => 'item',
     '#markup' => implode(', ', $reporter_details),
     '#title' => t('Reported by'),
+    '#access' => count($reporter_details) > 0,
   );
 
   $variables['problem_date'] = array(

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -761,6 +761,12 @@ function template_preprocess_problem_report(&$variables) {
     '#markup' => format_date($report->problem_date, 'medium'),
   );
 
+  $variables['report_date'] = array(
+    '#type' => 'item',
+    '#title' => t('Date report submitted'),
+    '#markup' => format_date($report->created, 'medium'),
+  );
+
   $variables['problem_details'] = array(
     '#type' => 'item',
     '#title' => t('Problem details'),

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -748,10 +748,18 @@ function template_preprocess_problem_report(&$variables) {
     '#title' => t('Local authority'),
   );
 
+  // Build an array of reporter details - name and email address
+  $reporter_details = array();
+  if (!empty($variables['reporter_name'])) {
+    $reporter_details[] = $variables['reporter_name'];
+  }
+  if (!empty($variables['reporter_email'])) {
+    $reporter_details[] = l($variables['reporter_email'], 'mailto:' . $variables['reporter_email']);
+  }
 
   $variables['reporter_name'] = array(
     '#type' => 'item',
-    '#markup' => $variables['reporter_name'] . (!empty($variables['reporter_email']) ? ', ' . l($variables['reporter_email'], 'mailto:' . $variables['reporter_email']) : ''),
+    '#markup' => implode(', ', $reporter_details),
     '#title' => t('Reported by'),
   );
 

--- a/docroot/sites/all/modules/custom/fsa_report_problem/theme/problem-report.tpl.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/theme/problem-report.tpl.php
@@ -22,6 +22,7 @@
     <?php print render($local_authority); ?>
     <?php print render($reporter_name); ?>
     <?php print render($problem_date); ?>
+    <?php print render($report_date); ?>
   </div>
 
   <?php print render($problem_details); ?>


### PR DESCRIPTION
* On report listing page, show date report submitted
* On report listing page, shorten date format for problem date
* On report listing page, change column headings to reflect the different dates
* On report listing page, truncate the business name to make better use of space
* On report detail page, don't display reporter details item if no name or email provided

[ Partial fix for #10351 ]