### PR TITLE
Develop: Remove report date column from listing

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -22,13 +22,8 @@ function fsa_report_problem_view_reports($form, &$form_state) {
       'type' => 'property',
     ),
     array(
-      'data' => t('Submitted'),
+      'data' => t('Date submitted'),
       'specifier' => 'created',
-      'type' => 'property',
-    ),
-    array(
-      'data' => t('Problem date'),
-      'specifier' => 'problem_date',
       'type' => 'property',
     ),
     array(
@@ -64,7 +59,6 @@ function fsa_report_problem_view_reports($form, &$form_state) {
       l($report->rid, $uri['path']),
       is_callable('mb_strimwidth') ? mb_strimwidth($report->business_name, 0, 44, '...') : substr($report->business_name, 0, 44),
       !empty($report->created) ? format_date($report->created, 'custom', 'j F Y') : '',
-      !empty($report->problem_date) ? format_date($report->problem_date, 'custom', 'j F Y') : '',
       $report->local_authority_name,
       $report->local_authority_email,
     );


### PR DESCRIPTION
Removed the report date column from the food problem reports listing table as requested by Sally. Also update the column header of the submitted date.

[ Partial fix for #10351 ]