### PR TITLE
Develop: Remove reporter details from sent reports

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -2322,6 +2322,9 @@ function _fsa_report_problem_update_fhrs_data() {
  */
 function fsa_report_problem_cron() {
 
+  // Remove reporter data from sent reports
+  _fsa_report_problem_remove_reporter_details();
+
   // Get the last time the FHRS data was updated
   $last_import = variable_get('fsa_report_problem_fhrs_last_import', 0);
 

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -766,7 +766,7 @@ function template_preprocess_problem_report(&$variables) {
     '#type' => 'item',
     '#markup' => implode(', ', $reporter_details),
     '#title' => t('Reported by'),
-    '#access' => count($reporter_details) > 0,
+    '#access' => FSA_REPORT_PROBLEM_SHOW_REPORTER_DETAILS ? count($reporter_details) > 0 : FALSE,
   );
 
   $variables['problem_date'] = array(

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -87,6 +87,11 @@ define('FSA_REPORT_PROBLEM_TEXT_CATEGORY_FIELD_LABEL', 'field_label');
 define('FSA_REPORT_PROBLEM_TEXT_CATEGORY_GENERAL', 'general');
 
 /**
+ * Determines whether reporter details are displayed in Drupal
+ */
+define('FSA_REPORT_PROBLEM_SHOW_REPORTER_DETAILS', FALSE);
+
+/**
  * Implements hook_permission().
  */
 function fsa_report_problem_permission() {

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -4581,3 +4581,70 @@ function template_preprocess_report_problem_block_content(&$variables) {
   // Set the service status based on the $delta
   $variables['service_status'] = _fsa_report_problem_service_status($variables['delta']);
 }
+
+
+/**
+ * Helper function: removes reporter name and email address once report sent
+ *
+ * This function is called by hook_cron()
+ */
+function _fsa_report_problem_remove_reporter_details() {
+  // Select all problem reports where the email has been sent
+  $query = db_select('problem_reports', 'pr')
+    ->fields('pr')
+    ->condition('email_sent', 1);
+  // Select only those reports for which we have a reporter name or email
+  $or = db_or();
+  $or->condition('reporter_email', '', '!=');
+  $or->condition('reporter_name', '', '!=');
+  $query->condition($or);
+  // Execute the query
+  $reports = $query->execute()->fetchAllAssoc('rid');
+  // If we have no reports with reporter details, exit now
+  if (count($reports) == 0) {
+    return;
+  }
+
+  // Clear the reporter_name and reporter_email fields for sent reports
+  // First get the IDs of the reports
+  $rids = array_keys($reports);
+  // Update the report entities
+  return _fsa_report_problem_remove_report_reporter_details($rids);
+}
+
+
+/**
+ * Helper function: removes reporter details from the specified reports
+ *
+ * @param array|integer $rids
+ *   The ID or IDs of the reports from which we want to remove the reporter
+ *   details.
+ *
+ * @return array
+ *   An array of the IDs of the reports from which the reporter details have
+ *   been removed.
+ */
+function _fsa_report_problem_remove_report_reporter_details($rids) {
+  // An array to return
+  $return_array = array();
+  // If $rids is not already an array, make it one now
+  $rids = !is_array($rids) ? array($rids) : $rids;
+  // Load the reports
+  $reports = entity_load('problem_report', $rids);
+  // If we have no reports, exit now.
+  if (empty($reports)) {
+    return $return_array;
+  }
+  foreach ($reports as $rid => $report) {
+    $report->reporter_name = '';
+    $report->reporter_email = '';
+    if($report->save() == SAVED_UPDATED) {
+      $return_array[] = $rid;
+      watchdog('fsa_report_problem', 'Removed reporter data for report @rid.', array('@rid' => $rid));
+    }
+    else {
+      watchdog('fsa_report_problem', 'Failed to remove reporter data for report @rid.', array('@rid' => $rid), WATCHDOG_NOTICE);
+    }
+  }
+  return $return_array;
+}


### PR DESCRIPTION
We now remove reporter details (name and email address) from any sent food problem reports.

This is done on cron.

We also hide the reporter details from the Drupal admin interface.

[ Partial fix for #10374 ]