### PR TITLE
Develop: enable administrator to control required status of reporter details fields

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
@@ -85,16 +85,22 @@ function fsa_report_problem_make_report_form($form, &$form_state, $manual = FALS
     );
   }
 
+  // Are reporter name ane email address required?
+  $reporter_name_required = variable_get('fsa_report_problem_reporter_name_required', FALSE);
+  $reporter_email_required = variable_get('fsa_report_problem_reporter_email_required', FALSE);
+
   $form['reporter_name'] = array(
     '#type' => 'textfield',
-    '#title' => t('Your name (optional)'),
+    '#title' => $reporter_name_required ? t('Your name') : t('Your name (optional)'),
     '#description' => t('The local authority would only use this when contacting you about your issue.'),
+    '#required' => $reporter_name_required,
   );
 
   $form['reporter_email'] = array(
     '#type' => 'textfield',
-    '#title' => t('Your email address (optional)'),
+    '#title' => $reporter_email_required ? t('Your email address') : t('Your email address (optional)'),
     '#description' => t('This would only be used by the local authority to contact you about your issue.'),
+    '#required' => $reporter_email_required,
   );
 
   // @todo Change this to a single date field and add a free-text field for the

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -555,6 +555,26 @@ function fsa_food_report_admin_form($form, &$form_state) {
   // If all the pages are set, collapse the fieldset
   $form['node']['#collapsed'] = $all_pages_set;
 
+  $form['data_capture_settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Data capture'),
+    '#collapsible' => TRUE,
+  );
+
+  $form['data_capture_settings']['fsa_report_problem_reporter_name_required'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Reporter name required'),
+    '#description' => t('Tick this box to make the reporter name field mandatory.'),
+    '#default_value' => variable_get('fsa_report_problem_reporter_name_required', 'FALSE'),
+  );
+
+  $form['data_capture_settings']['fsa_report_problem_reporter_email_required'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Reporter email address required'),
+    '#description' => t('Tick this box to make the reporter email address field mandatory.'),
+    '#default_value' => variable_get('fsa_report_problem_reporter_email_required', 'FALSE'),
+  );
+
   $form['service_status'] = array(
     '#type' => 'fieldset',
     '#collapsible' => TRUE,


### PR DESCRIPTION
Whether or not the reporter name and email fields are mandatory can now be set via the admin UI.

[ Partial fix for #10374 ]