### PR TITLE
Don't show reporter details on food problem reports

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
@@ -85,16 +85,22 @@ function fsa_report_problem_make_report_form($form, &$form_state, $manual = FALS
     );
   }
 
+  // Are reporter name ane email address required?
+  $reporter_name_required = variable_get('fsa_report_problem_reporter_name_required', FALSE);
+  $reporter_email_required = variable_get('fsa_report_problem_reporter_email_required', FALSE);
+
   $form['reporter_name'] = array(
     '#type' => 'textfield',
-    '#title' => t('Your name (optional)'),
+    '#title' => $reporter_name_required ? t('Your name') : t('Your name (optional)'),
     '#description' => t('The local authority would only use this when contacting you about your issue.'),
+    '#required' => $reporter_name_required,
   );
 
   $form['reporter_email'] = array(
     '#type' => 'textfield',
-    '#title' => t('Your email address (optional)'),
+    '#title' => $reporter_email_required ? t('Your email address') : t('Your email address (optional)'),
     '#description' => t('This would only be used by the local authority to contact you about your issue.'),
+    '#required' => $reporter_email_required,
   );
 
   // @todo Change this to a single date field and add a free-text field for the

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -555,6 +555,26 @@ function fsa_food_report_admin_form($form, &$form_state) {
   // If all the pages are set, collapse the fieldset
   $form['node']['#collapsed'] = $all_pages_set;
 
+  $form['data_capture_settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Data capture'),
+    '#collapsible' => TRUE,
+  );
+
+  $form['data_capture_settings']['fsa_report_problem_reporter_name_required'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Reporter name required'),
+    '#description' => t('Tick this box to make the reporter name field mandatory.'),
+    '#default_value' => variable_get('fsa_report_problem_reporter_name_required', 'FALSE'),
+  );
+
+  $form['data_capture_settings']['fsa_report_problem_reporter_email_required'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Reporter email address required'),
+    '#description' => t('Tick this box to make the reporter email address field mandatory.'),
+    '#default_value' => variable_get('fsa_report_problem_reporter_email_required', 'FALSE'),
+  );
+
   $form['service_status'] = array(
     '#type' => 'fieldset',
     '#collapsible' => TRUE,

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -2322,6 +2322,9 @@ function _fsa_report_problem_update_fhrs_data() {
  */
 function fsa_report_problem_cron() {
 
+  // Remove reporter data from sent reports
+  _fsa_report_problem_remove_reporter_details();
+
   // Get the last time the FHRS data was updated
   $last_import = variable_get('fsa_report_problem_fhrs_last_import', 0);
 

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1280,10 +1280,6 @@ function fsa_report_problem_mail($key, &$message, $params) {
         $message['headers']['Return-Path'] = $message_details['reply_to_email'];
       }
 
-      // Set the Sender header - this should avoid issues where email clients
-      // such as Outlook show 'on behalf of' in the from address.
-      $message['headers']['Sender'] = $message['from'];
-
       $message['subject'] = '';
       $message['subject'] .= empty($report->local_authority_email) ? t('ACTION REQUIRED:') . ' ' : '';
 
@@ -1317,14 +1313,6 @@ function fsa_report_problem_mail($key, &$message, $params) {
       //$message['body'][] = drupal_render($message_body);
       $message_details = _fsa_report_problem_email('acknowledgement');
       $message['subject'] .= token_replace($message_details['subject'], array('report' => $params['report']));
-
-      // Set the From address
-      $message['from'] = !empty($message_details['sender_email']) ? $message_details['sender_email'] : $message['from'];
-      $message['headers']['From'] = $message['from'];
-
-      // Set the Sender header - this should avoid issues where email clients
-      // such as Outlook show 'on behalf of' in the from address.
-      $message['headers']['Sender'] = $message['from'];
 
       // If we have a reply-to header for this email, use it
       if (!empty($message_details['reply_to_email'])) {

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -766,7 +766,7 @@ function template_preprocess_problem_report(&$variables) {
     '#type' => 'item',
     '#markup' => implode(', ', $reporter_details),
     '#title' => t('Reported by'),
-    '#access' => count($reporter_details) > 0,
+    '#access' => FSA_REPORT_PROBLEM_SHOW_REPORTER_DETAILS ? count($reporter_details) > 0 : FALSE,
   );
 
   $variables['problem_date'] = array(

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -87,6 +87,11 @@ define('FSA_REPORT_PROBLEM_TEXT_CATEGORY_FIELD_LABEL', 'field_label');
 define('FSA_REPORT_PROBLEM_TEXT_CATEGORY_GENERAL', 'general');
 
 /**
+ * Determines whether reporter details are displayed in Drupal
+ */
+define('FSA_REPORT_PROBLEM_SHOW_REPORTER_DETAILS', FALSE);
+
+/**
  * Implements hook_permission().
  */
 function fsa_report_problem_permission() {

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -4581,3 +4581,70 @@ function template_preprocess_report_problem_block_content(&$variables) {
   // Set the service status based on the $delta
   $variables['service_status'] = _fsa_report_problem_service_status($variables['delta']);
 }
+
+
+/**
+ * Helper function: removes reporter name and email address once report sent
+ *
+ * This function is called by hook_cron()
+ */
+function _fsa_report_problem_remove_reporter_details() {
+  // Select all problem reports where the email has been sent
+  $query = db_select('problem_reports', 'pr')
+    ->fields('pr')
+    ->condition('email_sent', 1);
+  // Select only those reports for which we have a reporter name or email
+  $or = db_or();
+  $or->condition('reporter_email', '', '!=');
+  $or->condition('reporter_name', '', '!=');
+  $query->condition($or);
+  // Execute the query
+  $reports = $query->execute()->fetchAllAssoc('rid');
+  // If we have no reports with reporter details, exit now
+  if (count($reports) == 0) {
+    return;
+  }
+
+  // Clear the reporter_name and reporter_email fields for sent reports
+  // First get the IDs of the reports
+  $rids = array_keys($reports);
+  // Update the report entities
+  return _fsa_report_problem_remove_report_reporter_details($rids);
+}
+
+
+/**
+ * Helper function: removes reporter details from the specified reports
+ *
+ * @param array|integer $rids
+ *   The ID or IDs of the reports from which we want to remove the reporter
+ *   details.
+ *
+ * @return array
+ *   An array of the IDs of the reports from which the reporter details have
+ *   been removed.
+ */
+function _fsa_report_problem_remove_report_reporter_details($rids) {
+  // An array to return
+  $return_array = array();
+  // If $rids is not already an array, make it one now
+  $rids = !is_array($rids) ? array($rids) : $rids;
+  // Load the reports
+  $reports = entity_load('problem_report', $rids);
+  // If we have no reports, exit now.
+  if (empty($reports)) {
+    return $return_array;
+  }
+  foreach ($reports as $rid => $report) {
+    $report->reporter_name = '';
+    $report->reporter_email = '';
+    if($report->save() == SAVED_UPDATED) {
+      $return_array[] = $rid;
+      watchdog('fsa_report_problem', 'Removed reporter data for report @rid.', array('@rid' => $rid));
+    }
+    else {
+      watchdog('fsa_report_problem', 'Failed to remove reporter data for report @rid.', array('@rid' => $rid), WATCHDOG_NOTICE);
+    }
+  }
+  return $return_array;
+}

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1275,6 +1275,10 @@ function fsa_report_problem_mail($key, &$message, $params) {
         $message['headers']['Return-Path'] = $message_details['reply_to_email'];
       }
 
+      // Set the Sender header - this should avoid issues where email clients
+      // such as Outlook show 'on behalf of' in the from address.
+      $message['headers']['Sender'] = $message['from'];
+
       $message['subject'] = '';
       $message['subject'] .= empty($report->local_authority_email) ? t('ACTION REQUIRED:') . ' ' : '';
 
@@ -1308,6 +1312,14 @@ function fsa_report_problem_mail($key, &$message, $params) {
       //$message['body'][] = drupal_render($message_body);
       $message_details = _fsa_report_problem_email('acknowledgement');
       $message['subject'] .= token_replace($message_details['subject'], array('report' => $params['report']));
+
+      // Set the From address
+      $message['from'] = !empty($message_details['sender_email']) ? $message_details['sender_email'] : $message['from'];
+      $message['headers']['From'] = $message['from'];
+
+      // Set the Sender header - this should avoid issues where email clients
+      // such as Outlook show 'on behalf of' in the from address.
+      $message['headers']['Sender'] = $message['from'];
 
       // If we have a reply-to header for this email, use it
       if (!empty($message_details['reply_to_email'])) {


### PR DESCRIPTION
* We no longer display reporter details on food problem reports
* Once a report has been sent, a cron job will delete the reporter details but retain the rest of the report data
* The mandatory status of the reporter details fields can now be controlled via the admin UI

[ Partial fix for #10374 ]