### PR TITLE
Develop: Don't set return-path header in RAFP

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1277,7 +1277,9 @@ function fsa_report_problem_mail($key, &$message, $params) {
       if (!empty($message_details['reply_to_email'])) {
         $message['headers']['Reply-to'] = $message_details['reply_to_email'];
         // Also set Return-Path so that bouncebacks go here as well
-        $message['headers']['Return-Path'] = $message_details['reply_to_email'];
+        // We're commenting this out now as it appears to be causing problems
+        // with email delivery via MessageLabs - see #10383
+        //$message['headers']['Return-Path'] = $message_details['reply_to_email'];
       }
 
       $message['subject'] = '';
@@ -1318,7 +1320,9 @@ function fsa_report_problem_mail($key, &$message, $params) {
       if (!empty($message_details['reply_to_email'])) {
         $message['headers']['Reply-to'] = $message_details['reply_to_email'];
         // Also set Return-Path so that bouncebacks go here as well
-        $message['headers']['Return-Path'] = $message_details['reply_to_email'];
+        // We're commenting this out now as it appears to be causing problems
+        // with email delivery via MessageLabs - see #10383
+        //$message['headers']['Return-Path'] = $message_details['reply_to_email'];
       }
 
       if (!empty($message_details['include_dev_message'])) {


### PR DESCRIPTION
In the Report a food problem module, we no longer set the `Reply-to` header for the emails generated when a report is submitted as this appears to be preventing delivery via MessageLabs.

[ Partial fix for #10383 ]