### PR TITLE
Master: Allow administrators to specify Welsh language paths

### DIFF
--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.admin.inc
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.admin.inc
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Admin settings for the FSA language negotiation module
+ */
+
+
+/**
+ * Form builder: Language negotiation admin/configuration form
+ */
+function FSA_language_negotiation_admin_form($form, &$form_state) {
+  $form['FSA_language_negotiation_paths'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Paths to trigger Welsh language'),
+    '#description' => t('Enter paths in this box to trigger Welsh language. Place each path on a new line. To include all paths starting with a path, add an asterisk at the end. If you leave this field blank, the default paths will be used.'),
+    '#default_value' => _FSA_language_negotiation_get_paths(),
+  );
+  $form['FSA_language_negotiation_default_paths'] = array(
+    '#type' => 'item',
+    '#title' => t('Default paths'),
+    '#description' => t('These are the default paths that will be used if no others are specified. You should include them in the field above unless you actually want them removed.'),
+    '#markup' => '<pre>' . _FSA_language_negotiation_default_paths() . '</pre>',
+  );
+  return system_settings_form($form);
+}

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
@@ -27,3 +27,18 @@ function FSA_language_negotiation_wales($languages) {
 
   return $language;
 }
+
+
+/**
+ * Helper function: defines default paths to trigger Welsh language
+ *
+ * @return string
+ *   A list of default paths for Welsh language, separated by new lines
+ */
+function _FSA_language_negotiation_default_paths() {
+  $paths = array(
+    'wales/about-fsa-wales/cymru*',
+    'wales/cymru*',
+  );
+  return implode(PHP_EOL, $paths);
+}

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
@@ -1,9 +1,7 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: Peter
- * Date: 04/07/14
- * Time: 20:21
+ * @file
+ * Language negotiation functions for the FSA language negotiation module
  */
 
 /**

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
@@ -30,6 +30,18 @@ function FSA_language_negotiation_wales($languages) {
 
 
 /**
+ * Helper function: gets paths assigned to Welsh language
+ *
+ * @return string
+ *   A list of paths for Welsh language separated by new lines
+ */
+function _FSA_language_negotiation_get_paths() {
+  // Return the value of the variable or the defaults
+  return variable_get('FSA_language_negotiation_paths', _FSA_language_negotiation_default_paths());
+}
+
+
+/**
  * Helper function: defines default paths to trigger Welsh language
  *
  * @return string

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
@@ -10,21 +10,22 @@
  * @return string
  */
 function FSA_language_negotiation_wales($languages) {
+
+  // Require path.inc from Core as we need it for drupal_match_path()
+  require_once DRUPAL_ROOT . '/' . variable_get('path_inc', 'includes/path.inc');
+
+  // Set the default language to English
   $language = 'en';
 
-  // force all pages within the Cymru to be in Welsh
-  // specify all the paths that could denote the welsh section
-  $paths = array(
-      'wales/about-fsa-wales/cymru',
-      'wales/cymru',
-  );
+  // Get the paths for Welsh language
+  $paths = _FSA_language_negotiation_get_paths();
 
-  foreach ($paths as $path) {
-    if (substr($_GET['q'], 0, strlen($path)) == $path)  {
-      $language = 'cy';
-    }
+  // If any of the paths match the current path, set language code to cy.
+  if (drupal_match_path($_GET['q'], $paths)) {
+    $language = 'cy';
   }
 
+  // Return the language code
   return $language;
 }
 

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.inc
@@ -52,6 +52,7 @@ function _FSA_language_negotiation_default_paths() {
   $paths = array(
     'wales/about-fsa-wales/cymru*',
     'wales/cymru*',
+    'wales/wales',
   );
   return implode(PHP_EOL, $paths);
 }

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.install
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.install
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for FSA language netotiation module
+ *
+ * Note that due to a 'bug' in Drupal Core, update functions for modules that
+ * contain uppercase letters don't get run. The functions in this file are here
+ * for the sake of completeness, but they will NOT work on current versions of
+ * Drupal.
+ *
+ * The only apparent solution is to rename the module to lowercase or to patch
+ * Drupal Core, but since these functions aren't essential, that's more trouble
+ * than it's currently worth.
+ *
+ * @see https://www.drupal.org/node/854360
+ * @see https://www.drupal.org/node/150215
+ */
+
+/**
+ * Implements hook_install();
+ */
+function FSA_language_negotiation_install() {
+  // Set the default paths variable.
+  variable_set('FSA_language_negotiation_paths', _FSA_language_negotiation_default_paths());
+}
+
+
+/**
+ * Sets the Welsh language paths variable to the default paths
+ */
+function FSA_language_negotiation_update_7001() {
+  // Set the default paths variable
+  variable_set('FSA_language_negotiation_paths', _FSA_language_negotiation_default_paths());
+}
+
+
+/**
+ * Implements hook_uninstall().
+ */
+function FSA_language_negotiation_uninstall() {
+  // Delete the variable for default paths
+  variable_del('FSA_language_negotiation_paths');
+}

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.module
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.module
@@ -26,6 +26,10 @@ function FSA_language_negotiation_menu() {
   return $items;
 }
 
+
+/**
+ * Implements hook_language_negotiation_info().
+ */
 function FSA_language_negotiation_language_negotiation_info() {
   return array(
     'site_version' => array(

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.module
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.module
@@ -1,9 +1,11 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: Peter
- * Date: 04/07/14
- * Time: 20:20
+ * @file
+ * Module file for the FSA language negotiation module.
+ *
+ * This module allows path-based language negotiation that can be modified by
+ * administrators with the appropriate permissions. It is used primarily to set
+ * the paths that are to be displayed in Welsh.
  */
 
 function FSA_language_negotiation_language_negotiation_info() {

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.module
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.module
@@ -8,6 +8,24 @@
  * the paths that are to be displayed in Welsh.
  */
 
+
+/**
+ * Implements hook_menu().
+ */
+function FSA_language_negotiation_menu() {
+  $items = array();
+  // Admin page for configuring Welsh language paths
+  $items['admin/config/regional/language/configure/welsh-site-section'] = array(
+    'title' => 'Welsh site section language negotation',
+    'description' => 'Configure settings for Welsh site section language negotiation',
+    'access arguments' => array('administer languages'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('FSA_language_negotiation_admin_form'),
+    'file' => 'FSA_language_negotiation.admin.inc',
+  );
+  return $items;
+}
+
 function FSA_language_negotiation_language_negotiation_info() {
   return array(
     'site_version' => array(

--- a/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.module
+++ b/docroot/sites/all/modules/custom/FSA_language_negotiation/FSA_language_negotiation.module
@@ -39,6 +39,7 @@ function FSA_language_negotiation_language_negotiation_info() {
       // Language detection runs before Drupal Bootstrap completes.
       'file'        => drupal_get_path('module', 'FSA_language_negotiation') . '/FSA_language_negotiation.inc',
       'description' => t('Determine the language from the welsh section of the site.'),
+      'config' => 'admin/config/regional/language/configure/welsh-site-section',
     ),
   );
 }


### PR DESCRIPTION
Modified the existing FSA Language negotiation module to enable admin users with the correct permission to specify the paths that Drupal will consider to be Welsh.

By default, the current settings are retained, and the new path `wales/wales` is added.

[ Partial fix for #10395 ]