### PR TITLE
Master: Hide time field on report a food problem

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
@@ -105,16 +105,23 @@ function fsa_report_problem_make_report_form($form, &$form_state, $manual = FALS
 
   // @todo Change this to a single date field and add a free-text field for the
   // time as some users find the time selector confusing
-  $today = date("Y-m-d H:i:s");
+  $today = date('Y-m-d H:i:s');
+  $issue_date_label = t('Date the food issue happened');
+  $issue_date_format = 'd F Y';
+  if (FSA_REPORT_PROBLEM_CAPTURE_PROBLEM_TIME) {
+    $issue_date_format = 'd F Y H:i';
+    $issue_date_label = t('Date and approximate time the food issue happened');
+  }
   $form['issue_date'] = array(
     '#type' => 'date_popup',
-    '#title' => t('Date and approximate time the food issue happened'),
+    '#title' => $issue_date_label,
     '#default_value' => $today,
     '#date_type' => DATE_UNIX,
     '#date_timezone' => date_default_timezone(),
-    '#date_format' => 'd/m/Y h:i a',
+    '#date_format' => $issue_date_format,
     '#date_increment' => 1,
     '#date_year_range' => '-1:+1',
+    '#date_label_position' => FSA_REPORT_PROBLEM_CAPTURE_PROBLEM_TIME ? 'above' : 'invisible',
   );
 
   $form['issue_details'] = array(

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -2115,7 +2115,7 @@ function fsa_report_problem_tokens($type, $tokens, array $data = array(), array 
           break;
         case 'report_date':
           if (!empty($report->problem_date)) {
-            $replacements[$original] = format_date($report->problem_date, 'medium');
+            $replacements[$original] = FSA_REPORT_PROBLEM_CAPTURE_PROBLEM_TIME ? format_date($report->problem_date, 'medium') : format_date($report->problem_date, 'custom', 'd F Y');
           }
           break;
         case 'problem_details':

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -92,6 +92,12 @@ define('FSA_REPORT_PROBLEM_TEXT_CATEGORY_GENERAL', 'general');
 define('FSA_REPORT_PROBLEM_SHOW_REPORTER_DETAILS', FALSE);
 
 /**
+ * Determines whether to capture the time the food problem occurred or just date
+ */
+define('FSA_REPORT_PROBLEM_CAPTURE_PROBLEM_TIME', FALSE);
+
+
+/**
  * Implements hook_permission().
  */
 function fsa_report_problem_permission() {

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -795,7 +795,7 @@ function template_preprocess_problem_report(&$variables) {
   $variables['problem_date'] = array(
     '#type' => 'item',
     '#title' => t('Date the problem occurred'),
-    '#markup' => format_date($report->problem_date, 'medium'),
+    '#markup' => FSA_REPORT_PROBLEM_CAPTURE_PROBLEM_TIME ? format_date($report->problem_date, 'medium') : format_date($report->problem_date, 'custom', 'd F Y'),
   );
 
   $variables['report_date'] = array(

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -774,6 +774,7 @@ function template_preprocess_problem_report(&$variables) {
     '#type' => 'item',
     '#markup' => $variables['local_authority_name'] . (!empty($variables['local_authority_email']) ? ', ' . $variables['local_authority_email'] : ''),
     '#title' => t('Local authority'),
+    '#access' => !empty($variables['local_authority_name']),
   );
 
   // Build an array of reporter details - name and email address


### PR DESCRIPTION
Hid the problem time field on the form and in the admin system. Also in the emails.

[ Fixes #10400 ]