### PR TITLE
Develop: Change menu item type and weight for local authorities

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/views/local_authority_details.view
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/views/local_authority_details.view
@@ -204,10 +204,10 @@ $handler->display->display_options['filters']['email_overridden']['expose']['rem
 /* Display: Page */
 $handler = $view->new_display('page', 'Page', 'page');
 $handler->display->display_options['path'] = 'admin/config/foodproblems/authorities';
-$handler->display->display_options['menu']['type'] = 'normal';
+$handler->display->display_options['menu']['type'] = 'tab';
 $handler->display->display_options['menu']['title'] = 'Local authority data';
 $handler->display->display_options['menu']['description'] = 'Manage local authority data for use in the food problem reporting system';
-$handler->display->display_options['menu']['weight'] = '0';
+$handler->display->display_options['menu']['weight'] = 30;
 $handler->display->display_options['menu']['context'] = 0;
 $handler->display->display_options['menu']['context_only_inline'] = 0;
 


### PR DESCRIPTION
Changed to a menu tab and set weight to 30.

[ Partial fix for #10405 ]