### PR TITLE
Develop: Add install hook to make update hooks run

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
@@ -4,6 +4,14 @@
  * Install, update and uninstall hooks for the FSA revisioning module
  */
 
+/**
+* Implements hook_install().
+*/
+function fsa_revisioning_deploy_install() {
+  // Set an initial value for the schema version so updates will run on install.
+  drupal_set_installed_schema_version('fsa_revisioning', 7000);
+}
+
 
 /**
  * Sets the weight of the Revisioning schedule module to be greater than that of


### PR DESCRIPTION
In the FSA revisioning module, we need to ensure that the update hooks are run when the module is installed.

We therefore add an implementation of `hook_install()` and use this to set the schema_version to **7000**. This should result in updates **7001** and **7002** running immediately following the module being enabled.

[ Partial fix for #10354 ]