### PR TITLE
Develop: Fix typo in function name

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
@@ -7,7 +7,7 @@
 /**
 * Implements hook_install().
 */
-function fsa_revisioning_deploy_install() {
+function fsa_revisioning_install() {
   // Set an initial value for the schema version so updates will run on install.
   drupal_set_installed_schema_version('fsa_revisioning', 7000);
 }


### PR DESCRIPTION
Name of install hook was wrong, so it didn't get called.

[ Partial fix for #10354 ]