### PR TITLE
Develop: Create FSA GUID module

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
@@ -3,3 +3,4 @@ description = "Provides a globally unique identifier for a content item for use 
 core = 7.x
 package = FSA Custom
 dependencies[] = views
+files[] = views/handlers/fsa_guid_views_handler_field_guid.inc

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
@@ -1,0 +1,5 @@
+name = FSA GUID
+description = "Provides a globally unique identifier for a content item for use in RSS feeds that are consumed by GovDelivery."
+core = 7.x
+package = FSA Custom
+dependencies[] = views

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.install
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.install
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for the FSA GUID module
+ */

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.install
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.install
@@ -3,3 +3,54 @@
  * @file
  * Install, update and uninstall functions for the FSA GUID module
  */
+
+
+/**
+ * Implements hook_schema().
+ */
+function fsa_guid_schema() {
+  $schema['fsa_guid'] = array(
+    'description' => 'Table for storing FSA GUIDs for use in RSS feeds',
+    'fields' => array(
+      'gid' => array(
+        'description' => 'A unique ID for the GUID',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'nid' => array(
+        'description' => 'The Node ID of the node for which a GUID is stored',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'vid' => array(
+        'description' => 'The version ID of the node for which a GUID is stored',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'uid' => array(
+        'description' => 'The ID of the user creating this GUID',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'updated' => array(
+        'description' => 'The Unix timestamp when the GUID was last updated.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'guid_version' => array(
+        'description' => 'The version of the GUID - typically appended to the node ID',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'primary key' => array('gid'),
+  );
+  return $schema;
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -3,3 +3,224 @@
  * @file
  * Main module file for the FSA GUID module
  */
+
+
+/**
+ * Implements hook_permission().
+ */
+function fsa_guid_permission() {
+  return array(
+    'update fsa guid' => array(
+      'title' => t('Update GUID for RSS feeds'),
+      'description' => t('Allows the user to force the GUID for a node to be updated when saving, thereby changing it in RSS feeds.'),
+    ),
+  );
+}
+
+
+/**
+ * Implements hook_views_api().
+ */
+function fsa_guid_views_api() {
+  return array(
+    'api' => 3,
+    'path' => drupal_get_path('module', 'fsa_guid') . '/views',
+  );
+}
+
+
+/**
+ * Helper function: generates a GUID based on node ID and GUID version
+ *
+ * @param int $nid
+ *   A node ID
+ * @param int $guid_version
+ *   (optional) A GUID version - defaults to 0
+ *
+ * @return string
+ *   A GUID - currently of the form ${nid}-${guid_version}
+ */
+function _fsa_guid_generate_guid($nid, $guid_version = 0) {
+  $guid = "${nid}-${guid_version}";
+  // Give other modules the chance to modify the GUID
+  drupal_alter('fsa_guid', $guid, $nid, $guid_version);
+  return $guid;
+}
+
+
+/**
+ * Helper function: gets a GUID for the given Node ID
+ */
+function _fsa_guid_get_guid($nid) {
+  $guids = _fsa_guid_get_guids(array($nid));
+  return isset($guids[$nid]) ? $guids[$nid] : _fsa_guid_generate_guid($nid);
+}
+
+
+/**
+ * Helper function: generates GUIDs for an array of Node IDs
+ *
+ * @param array $nids
+ *   An array of node IDs
+ *
+ * @return array
+ *   An associative array of node IDs to GUIDs
+ */
+function _fsa_guid_get_guids($nids) {
+  $guids = _fsa_guid_get_guid_version_multiple($nids);
+  foreach ($guids as $nid => $guid) {
+    $guids[$nid] = _fsa_guid_generate_guid($nid, $guid);
+  }
+  return $guids;
+}
+
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function fsa_guid_form_node_form_alter(&$form, &$form_state) {
+  if (empty($form['additional_settings'])) {
+    return;
+  }
+  // Get the node
+  $node = !empty($form['#node']) ? $form['#node'] : NULL;
+  // Add a vertical tab
+  $form['additional_settings']['fsa_guid'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Update GUID'),
+    '#weight' => 50,
+    '#access' => user_access('update fsa guid'),
+  );
+  $form['additional_settings']['fsa_guid']['update_guid'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Update the GUID for this page'),
+    '#description' => t('Ticking this box will cause the globally unique identifier for this page to be updated. This will tell external services such as GovDelivery that the content has changed. Tick this ONLY if you want to trigger a change in such systems. If in doubt, leave unchecked.'),
+    '#access' => user_access('update fsa guid'),
+  );
+  $guid_details = _fsa_guid_get_guid_details($node->nid);
+  if (!empty($guid_details)) {
+    $form['additional_settings']['fsa_guid']['guid_settings'] = array(
+      '#type' => 'item',
+      '#markup' => t('Current GUID version is @guid_version. Last updated on @date by @user.', array('@guid_version' => $guid_details['guid_version'], '@date' => format_date($guid_details['updated'], 'long'), '@user' => user_load($guid_details['uid'])->name)),
+    );
+  }
+}
+
+
+/**
+ * Helper function: returns the GUID version for a given nid
+ *
+ * @param int $nid
+ *   The node ID for which we want to get a GUID version
+ * @return int
+ *   The GUID version for the given $nid - 0 if not set.
+ */
+function _fsa_guid_get_guid_version($nid) {
+  $nids = is_array($nid) ? $nid : array($nid);
+  $guids = _fsa_guid_get_guid_version_multiple($nids);
+  return !empty($guids[$nid]) ? $guids[$nid] : 0;
+}
+
+
+/**
+ * Helper function: gets multiple GUID versions based on an array of $nids
+ *
+ * @param array $nids
+ *   An array of node IDs
+ *
+ * @return array
+ *   An associative array of node IDs with their GUID versions. If there is no
+ *   GUID version set for a given node ID, 0 is assigned.
+ */
+function _fsa_guid_get_guid_version_multiple($nids) {
+  // Create an associative array of Node IDs, all with a value of 0
+  $return = array_combine($nids, array_fill(0, count($nids), 0));
+  // Get the GUIDs from the database
+  $query = db_select('fsa_guid', 'f');
+  $query->fields('f', array('nid', 'guid_version'));
+  $query->condition('nid', $nids, 'in');
+  $result = $query->execute()->fetchAllKeyed(0, 1);
+  // Combine the query result with the $return array to associate any GUIDs with
+  // their respective Node IDs, but leaving any unassociated node IDs set to 0
+  $result += $return;
+  // Sort the return array by node ID.
+  ksort($result);
+  return $result;
+}
+
+
+/**
+ * Implements hook_node_update().
+ */
+function fsa_guid_node_update($node) {
+  if (empty($node->update_guid)) {
+    return;
+  }
+  global $user;
+  _fsa_guid_set_guid_version($node->nid, $node->vid, $user->uid);
+}
+
+
+/**
+ * Helper function: returns GUID details for a node
+ *
+ * @param int $nid
+ *   Node ID for which we want to return GUID details
+ *
+ * @return array|NULL
+ *   If GUID details are found, an associative array of GUID details; NULL if
+ *   GUID is found.
+ */
+function _fsa_guid_get_guid_details($nid) {
+  $query = db_select('fsa_guid', 'f');
+  $query->fields('f');
+  $query->condition('nid', $nid);
+  $result = $query->execute()->fetchAssoc();
+  return !empty($result) && is_array($result) ? $result : NULL;
+}
+
+
+/**
+ * Helper function: sets the GUID version for the given node
+ *
+ * @param int $nid
+ *   The node ID of the node
+ * @param int $vid
+ *   The revision ID of the node
+ * @param int $uid
+ *   Ths ID of the user creating the GUID
+ *
+ * @return int
+ *   STATUS_UPDATE if an update query is run
+ *   STATUS_INSERT if an insert query is run
+ */
+function _fsa_guid_set_guid_version($nid, $vid, $uid) {
+  // First, get the current version, if any
+  $current_version = _fsa_guid_get_guid_version($nid);
+  // Now increment the number
+  $guid_version = $current_version + 1;
+  // Update the database table with the new credentials
+  $query = db_merge('fsa_guid')
+    ->key(array('nid' => $nid))
+    ->fields(array(
+      'nid' => $nid,
+      'vid' => $vid,
+      'uid' => $uid,
+      'updated' => REQUEST_TIME,
+      'guid_version' => $guid_version,
+    ));
+  $update = $query->execute();
+  return $update;
+}
+
+
+/**
+ * Implements hook_node_load().
+ */
+function fsa_guid_node_load($nodes, $types) {
+  // Get any GUIDs for the given nodes based on their node IDs
+  $guids = _fsa_guid_get_guids(array_keys($nodes));
+  foreach ($nodes as $nid => $node) {
+    $node->fsa_guid = isset($guids[$nid]) ? $guids[$nid] : NULL;
+  }
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @file
+ * Main module file for the FSA GUID module
+ */

--- a/docroot/sites/all/modules/custom/fsa_guid/views/fsa_guid.views.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/views/fsa_guid.views.inc
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * Views data and hooks for the FSA GUID module
+ */
+
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function fsa_guid_views_data_alter(&$data) {
+  $data['node']['fsa_guid'] = array(
+    'title' => t('FSA GUID'),
+    'help' => t('A special GUID for use with RSS feeds and GovDelivery'),
+    'field' => array(
+      'handler' => 'fsa_guid_views_handler_field_guid',
+    ),
+  );
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/views/handlers/fsa_guid_views_handler_field_guid.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/views/handlers/fsa_guid_views_handler_field_guid.inc
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file
+ * Views field handler for the FSA GUID field
+ */
+
+class fsa_guid_views_handler_field_guid extends views_handler_field_entity {
+
+  /**
+   * Get the value that's supposed to be rendered.
+   *
+   * This api exists so that other modules can easy set the values of the field
+   * without having the need to change the render method as well.
+   *
+   * @param $values
+   *   An object containing all retrieved values.
+   * @param $field
+   *   Optional name of the field where the value is stored.
+   */
+  function get_value($values, $field = NULL) {
+    // Get the node entity
+    $entity = parent::get_value($values);
+    // Return the node entity's fsa_guid property - if set; otherwise generate
+    return !empty($entity->fsa_guid) ? $entity->fsa_guid : _fsa_guid_get_guid($nid);
+  }
+
+}


### PR DESCRIPTION
Created a new custom module to provide special GUIDs that can be updated as required.

Module to enable
-----------------------
Once the code is deployed, the new module needs to be enabled:

`drush en fsa_guid --y`

Then clear the caches:

`drush cc all`

[ Partial fix for #10357 ]