### PR TITLE
Develop: Allow additional tokens in FSA GUIDs

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -38,7 +38,7 @@ function fsa_guid_admin_form($form, &$form_state) {
   $form['available_tokens']['tokens'] = array(
     '#theme' => 'token_tree',
     '#token_types' => array('fsa_guid'),
-    '#global_types' => FALSE,
+    '#global_types' => TRUE,
   );
   return system_settings_form($form);
 }

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -309,6 +309,12 @@ function fsa_guid_token_info() {
     'required' => TRUE,
   );
 
+  $guid['node_url'] = array(
+    'name' => t('Node URL'),
+    'description' => t('The absolute URL of the node'),
+    'required' => FALSE,
+  );
+
   return array(
     'types' => array('fsa_guid' => $type),
     'tokens' => array('fsa_guid' => $guid),
@@ -334,6 +340,9 @@ function fsa_guid_tokens($type, $tokens, array $data = array(), array $options =
         break;
       case 'gid':
         $replacements[$original] = $gid;
+        break;
+      case 'node_url':
+        $replacements[$original] = url(drupal_get_path_alias("node/$nid"), array('absolute' => TRUE));
         break;
     }
   }


### PR DESCRIPTION
* We now allow global tokens such as site name within the GUID
* Node URL is now available as a token for use in the GUID

[ Partial fix for #10357 ]