### PR TITLE
Master: Create new FSA GUID module

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -38,7 +38,7 @@ function fsa_guid_admin_form($form, &$form_state) {
   $form['available_tokens']['tokens'] = array(
     '#theme' => 'token_tree',
     '#token_types' => array('fsa_guid'),
-    '#global_types' => FALSE,
+    '#global_types' => TRUE,
   );
   return system_settings_form($form);
 }

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @file
+ * Admin functions for the FSA GUID module
+ */
+
+
+/**
+ * Form builder: FSA GUID admin form
+ */
+function fsa_guid_admin_form($form, &$form_state) {
+
+  $form['intro'] = array(
+    '#markup' => t('Use this form to change the pattern for generating GUIDs as used in RSS feeds.'),
+  );
+
+  $form['warning'] = array(
+    '#prefix' => '<p>',
+    '#markup' => t('BEWARE: Changing the GUID pattern may result in SMS or email messages being sent to multiple subscribers. To avoid unforeseen issues, contact GovDelivery and ask for PageWatch to be suspended.'),
+    '#suffix' => '</p>',
+  );
+
+  $form['fsa_guid_pattern'] = array(
+    '#type' => 'textfield',
+    '#title' => t('GUID pattern'),
+    '#description' => t('Set the pattern for use when generating GUIDs. Replacement tokens are listed below.'),
+    '#default_value' => FSA_GUID_PATTERN,
+    '#required' => FALSE,
+  );
+
+  $form['available_tokens'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Available tokens'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  $form['available_tokens']['tokens'] = array(
+    '#theme' => 'token_tree',
+    '#token_types' => array('fsa_guid'),
+    '#global_types' => FALSE,
+  );
+  return system_settings_form($form);
+}
+
+
+/**
+ * Form validator: FSA GUID admin form
+ */
+function fsa_guid_admin_form_validate(&$form, &$form_state) {
+  $values = !empty($form_state['values']) ? $form_state['values'] : array();
+  $guid_pattern = !empty($values['fsa_guid_pattern']) ? $values['fsa_guid_pattern'] : '';
+  if (empty($guid_pattern)) {
+    form_set_error('fsa_guid_pattern', t('You must provide a GUID pattern.'));
+  }
+  $tokens = module_invoke('fsa_guid', 'token_info');
+  $tokens = !empty($tokens['tokens']['fsa_guid']) ? $tokens['tokens']['fsa_guid'] : array();
+  foreach ($tokens as $id => $details) {
+    if (!empty($details['required']) && strpos($guid_pattern, "[fsa_guid:${id}]") === FALSE) {
+      form_set_error('fsa_guid_pattern', t('You must include the token %token as part of the GUID pattern', array('%token' => "[fsa_guid:${id}]")));
+    }
+  }
+ }
+
+
+ /**
+  * Form builder: GUID reset confirm form
+  */
+function fsa_guid_reset_form($form, &$form_state) {
+ 	return confirm_form(
+		$form,
+		t('Are you sure you want to reset the GUIDs?'),
+		'admin/config/system/fsa-guid',
+		t('This action cannot be undone. Resetting GUIDs may result in unforeseen effects, including accidental triggering of SMS and email messages. Please be sure this is what you want to do.'),
+		t('Reset GUIDs'),
+		t('Cancel')
+	);
+}
+
+
+/**
+ * Submit handler: GUID reset confirm form
+ */
+function fsa_guid_reset_form_submit($form, &$form_state) {
+  if ($success = _fsa_guid_reset_guids()) {
+    drupal_set_message(t('GUIDs reset'));
+  }
+  else {
+    drupal_set_message(t('GUIDs were not reset'), 'error');
+  }
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
@@ -3,3 +3,4 @@ description = "Provides a globally unique identifier for a content item for use 
 core = 7.x
 package = FSA Custom
 dependencies[] = views
+files[] = views/handlers/fsa_guid_views_handler_field_guid.inc

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
@@ -4,3 +4,4 @@ core = 7.x
 package = FSA Custom
 dependencies[] = views
 files[] = views/handlers/fsa_guid_views_handler_field_guid.inc
+files[] = views/plugins/fsa_guid_views_plugin_row_node_rss.inc

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.info
@@ -1,0 +1,5 @@
+name = FSA GUID
+description = "Provides a globally unique identifier for a content item for use in RSS feeds that are consumed by GovDelivery."
+core = 7.x
+package = FSA Custom
+dependencies[] = views

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.install
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.install
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for the FSA GUID module
+ */

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.install
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.install
@@ -3,3 +3,54 @@
  * @file
  * Install, update and uninstall functions for the FSA GUID module
  */
+
+
+/**
+ * Implements hook_schema().
+ */
+function fsa_guid_schema() {
+  $schema['fsa_guid'] = array(
+    'description' => 'Table for storing FSA GUIDs for use in RSS feeds',
+    'fields' => array(
+      'gid' => array(
+        'description' => 'A unique ID for the GUID',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'nid' => array(
+        'description' => 'The Node ID of the node for which a GUID is stored',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'vid' => array(
+        'description' => 'The version ID of the node for which a GUID is stored',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'uid' => array(
+        'description' => 'The ID of the user creating this GUID',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'updated' => array(
+        'description' => 'The Unix timestamp when the GUID was last updated.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'guid_version' => array(
+        'description' => 'The version of the GUID - typically appended to the node ID',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'primary key' => array('gid'),
+  );
+  return $schema;
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -309,6 +309,12 @@ function fsa_guid_token_info() {
     'required' => TRUE,
   );
 
+  $guid['node_url'] = array(
+    'name' => t('Node URL'),
+    'description' => t('The absolute URL of the node'),
+    'required' => FALSE,
+  );
+
   return array(
     'types' => array('fsa_guid' => $type),
     'tokens' => array('fsa_guid' => $guid),
@@ -334,6 +340,9 @@ function fsa_guid_tokens($type, $tokens, array $data = array(), array $options =
         break;
       case 'gid':
         $replacements[$original] = $gid;
+        break;
+      case 'node_url':
+        $replacements[$original] = url(drupal_get_path_alias("node/$nid"), array('absolute' => TRUE));
         break;
     }
   }

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -6,6 +6,24 @@
 
 
 /**
+ * The default GUID pattern
+ */
+define('FSA_GUID_DEFAULT_PATTERN', '[fsa_guid:nid]-[fsa_guid:gid]');
+
+
+/**
+ * The pattern to user when generating GUIDs
+ */
+define('FSA_GUID_PATTERN', variable_get('fsa_guid_pattern', FSA_GUID_DEFAULT_PATTERN));
+
+
+/**
+ * Default GUID format for RSS feeds
+ */
+define('FSA_GUID_DEFAULT_FORMAT', 'drupal');
+
+
+/**
  * Implements hook_permission().
  */
 function fsa_guid_permission() {
@@ -13,6 +31,48 @@ function fsa_guid_permission() {
     'update fsa guid' => array(
       'title' => t('Update GUID for RSS feeds'),
       'description' => t('Allows the user to force the GUID for a node to be updated when saving, thereby changing it in RSS feeds.'),
+      'restrict access' => TRUE,
+      'warning' => t('Functionality accessible using this permission can trigger mass emails or texts via GovDelivery. Give to trusted roles only.'),
+    ),
+    'administer fsa guid' => array(
+      'title' => t('Administer FSA GUID for RSS feeds'),
+      'description' => t('Allows the user to perform administrative functions on GUIDs, including modifying the GUID pattern and resetting GUIDs.'),
+      'restrict access' => TRUE,
+      'warning' => t('Functionality accessible using this permission can trigger mass emails or texts via GovDelivery. Give to trusted roles only.'),
+    ),
+  );
+}
+
+
+/**
+ * Implements hook_menu().
+ */
+function fsa_guid_menu() {
+  return array(
+    'admin/config/system/fsa-guid' => array(
+      'title' => 'FSA GUID',
+      'description'=> 'Administer the FSA GUID',
+      'access arguments' => array('administer fsa guid'),
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('fsa_guid_admin_form'),
+      'file' => 'fsa_guid.admin.inc',
+      'type' => MENU_NORMAL_ITEM,
+    ),
+    'admin/config/system/fsa-guid/admin' => array(
+      'title' => 'Set the GUID pattern',
+      'description' => 'Amend the pattern used to generate GUIDs',
+      'type' => MENU_DEFAULT_LOCAL_TASK,
+      'weight' => 10,
+    ),
+    'admin/config/system/fsa-guid/reset' => array(
+      'title' => 'Reset GUIDs',
+      'description'=> 'Reset all FSA GUID values',
+      'access arguments' => array('administer fsa guid'),
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('fsa_guid_reset_form'),
+      'file' => 'fsa_guid.admin.inc',
+      'type' => MENU_LOCAL_TASK,
+      'weight' => 20,
     ),
   );
 }
@@ -41,7 +101,8 @@ function fsa_guid_views_api() {
  *   A GUID - currently of the form ${nid}-${guid_version}
  */
 function _fsa_guid_generate_guid($nid, $guid_version = 0) {
-  $guid = "${nid}-${guid_version}";
+  $pattern = FSA_GUID_PATTERN;
+  $guid = token_replace($pattern, array('nid' => $nid, 'gid' => $guid_version));
   // Give other modules the chance to modify the GUID
   drupal_alter('fsa_guid', $guid, $nid, $guid_version);
   return $guid;
@@ -223,5 +284,87 @@ function fsa_guid_node_load($nodes, $types) {
   $guids = _fsa_guid_get_guids(array_keys($nodes));
   foreach ($nodes as $nid => $node) {
     $node->fsa_guid = isset($guids[$nid]) ? $guids[$nid] : NULL;
+  }
+}
+
+
+/**
+ * Implements hook_token_info().
+ */
+function fsa_guid_token_info() {
+  $type = array(
+    'name' => t('FSA GUID'),
+    'description' => t('Tokens used for generating GUIDs'),
+  );
+
+  $guid['nid'] = array(
+    'name' => t('Node ID'),
+    'description' => t('The ID of the node for which we are generating a GUID'),
+    'required' => TRUE,
+  );
+
+  $guid['gid'] = array(
+    'name' => t('GUID version'),
+    'description' => t('The version number of the GUID'),
+    'required' => TRUE,
+  );
+
+  return array(
+    'types' => array('fsa_guid' => $type),
+    'tokens' => array('fsa_guid' => $guid),
+  );
+
+}
+
+
+/**
+ * Implements hook_tokens().
+ */
+function fsa_guid_tokens($type, $tokens, array $data = array(), array $options = array()) {
+  $replacements = array();
+  if ($type != 'fsa_guid') {
+    return $replacements;
+  }
+  $nid = !empty($data['nid']) ? $data['nid'] : 0;
+  $gid = !empty($data['gid']) ? $data['gid'] : 0;
+  foreach ($tokens as $name => $original) {
+    switch ($name) {
+      case 'nid':
+        $replacements[$original] = $nid;
+        break;
+      case 'gid':
+        $replacements[$original] = $gid;
+        break;
+    }
+  }
+  return $replacements;
+}
+
+
+/**
+ * Helper function: resets all GUIDs
+ */
+function _fsa_guid_reset_guids() {
+  $deleted = db_delete('fsa_guid')->execute();
+  if (!empty($deleted)) {
+    watchdog('fsa_guid', 'GUIDs reset');
+  }
+  return $deleted;
+}
+
+
+/**
+ * Implements hook_views_plugins_alter().
+ */
+function fsa_guid_views_plugins_alter(&$plugins) {
+  if (!empty($plugins['row']['node_rss'])) {
+    // We substitute our own views row style plugin for RSS items for the
+    // standard Drupal version so that we can alter the GUID format.
+    $properties = array(
+      'handler' => 'fsa_guid_views_plugin_row_node_rss',
+      'path' => drupal_get_path('module', 'fsa_guid') . '/views/plugins',
+      'file' => 'fsa_guid_views_plugin_row_node_rss.inc',
+    );
+    $plugins['row']['node_rss'] = $properties + $plugins['row']['node_rss'];
   }
 }

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -85,13 +85,14 @@ function fsa_guid_form_node_form_alter(&$form, &$form_state) {
   // Get the node
   $node = !empty($form['#node']) ? $form['#node'] : NULL;
   // Add a vertical tab
-  $form['additional_settings']['fsa_guid'] = array(
+  $form['fsa_guid'] = array(
     '#type' => 'fieldset',
     '#title' => t('Update GUID'),
-    '#weight' => 50,
+    '#weight' => !empty($form['options']['#weight']) ? $form['options']['#weight'] - 1 : 50,
     '#access' => user_access('update fsa guid'),
+    '#group' => 'additional_settings',
   );
-  $form['additional_settings']['fsa_guid']['update_guid'] = array(
+  $form['fsa_guid']['update_guid'] = array(
     '#type' => 'checkbox',
     '#title' => t('Update the GUID for this page'),
     '#description' => t('Ticking this box will cause the globally unique identifier for this page to be updated. This will tell external services such as GovDelivery that the content has changed. Tick this ONLY if you want to trigger a change in such systems. If in doubt, leave unchecked.'),

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -3,3 +3,224 @@
  * @file
  * Main module file for the FSA GUID module
  */
+
+
+/**
+ * Implements hook_permission().
+ */
+function fsa_guid_permission() {
+  return array(
+    'update fsa guid' => array(
+      'title' => t('Update GUID for RSS feeds'),
+      'description' => t('Allows the user to force the GUID for a node to be updated when saving, thereby changing it in RSS feeds.'),
+    ),
+  );
+}
+
+
+/**
+ * Implements hook_views_api().
+ */
+function fsa_guid_views_api() {
+  return array(
+    'api' => 3,
+    'path' => drupal_get_path('module', 'fsa_guid') . '/views',
+  );
+}
+
+
+/**
+ * Helper function: generates a GUID based on node ID and GUID version
+ *
+ * @param int $nid
+ *   A node ID
+ * @param int $guid_version
+ *   (optional) A GUID version - defaults to 0
+ *
+ * @return string
+ *   A GUID - currently of the form ${nid}-${guid_version}
+ */
+function _fsa_guid_generate_guid($nid, $guid_version = 0) {
+  $guid = "${nid}-${guid_version}";
+  // Give other modules the chance to modify the GUID
+  drupal_alter('fsa_guid', $guid, $nid, $guid_version);
+  return $guid;
+}
+
+
+/**
+ * Helper function: gets a GUID for the given Node ID
+ */
+function _fsa_guid_get_guid($nid) {
+  $guids = _fsa_guid_get_guids(array($nid));
+  return isset($guids[$nid]) ? $guids[$nid] : _fsa_guid_generate_guid($nid);
+}
+
+
+/**
+ * Helper function: generates GUIDs for an array of Node IDs
+ *
+ * @param array $nids
+ *   An array of node IDs
+ *
+ * @return array
+ *   An associative array of node IDs to GUIDs
+ */
+function _fsa_guid_get_guids($nids) {
+  $guids = _fsa_guid_get_guid_version_multiple($nids);
+  foreach ($guids as $nid => $guid) {
+    $guids[$nid] = _fsa_guid_generate_guid($nid, $guid);
+  }
+  return $guids;
+}
+
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function fsa_guid_form_node_form_alter(&$form, &$form_state) {
+  if (empty($form['additional_settings'])) {
+    return;
+  }
+  // Get the node
+  $node = !empty($form['#node']) ? $form['#node'] : NULL;
+  // Add a vertical tab
+  $form['additional_settings']['fsa_guid'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Update GUID'),
+    '#weight' => 50,
+    '#access' => user_access('update fsa guid'),
+  );
+  $form['additional_settings']['fsa_guid']['update_guid'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Update the GUID for this page'),
+    '#description' => t('Ticking this box will cause the globally unique identifier for this page to be updated. This will tell external services such as GovDelivery that the content has changed. Tick this ONLY if you want to trigger a change in such systems. If in doubt, leave unchecked.'),
+    '#access' => user_access('update fsa guid'),
+  );
+  $guid_details = _fsa_guid_get_guid_details($node->nid);
+  if (!empty($guid_details)) {
+    $form['additional_settings']['fsa_guid']['guid_settings'] = array(
+      '#type' => 'item',
+      '#markup' => t('Current GUID version is @guid_version. Last updated on @date by @user.', array('@guid_version' => $guid_details['guid_version'], '@date' => format_date($guid_details['updated'], 'long'), '@user' => user_load($guid_details['uid'])->name)),
+    );
+  }
+}
+
+
+/**
+ * Helper function: returns the GUID version for a given nid
+ *
+ * @param int $nid
+ *   The node ID for which we want to get a GUID version
+ * @return int
+ *   The GUID version for the given $nid - 0 if not set.
+ */
+function _fsa_guid_get_guid_version($nid) {
+  $nids = is_array($nid) ? $nid : array($nid);
+  $guids = _fsa_guid_get_guid_version_multiple($nids);
+  return !empty($guids[$nid]) ? $guids[$nid] : 0;
+}
+
+
+/**
+ * Helper function: gets multiple GUID versions based on an array of $nids
+ *
+ * @param array $nids
+ *   An array of node IDs
+ *
+ * @return array
+ *   An associative array of node IDs with their GUID versions. If there is no
+ *   GUID version set for a given node ID, 0 is assigned.
+ */
+function _fsa_guid_get_guid_version_multiple($nids) {
+  // Create an associative array of Node IDs, all with a value of 0
+  $return = array_combine($nids, array_fill(0, count($nids), 0));
+  // Get the GUIDs from the database
+  $query = db_select('fsa_guid', 'f');
+  $query->fields('f', array('nid', 'guid_version'));
+  $query->condition('nid', $nids, 'in');
+  $result = $query->execute()->fetchAllKeyed(0, 1);
+  // Combine the query result with the $return array to associate any GUIDs with
+  // their respective Node IDs, but leaving any unassociated node IDs set to 0
+  $result += $return;
+  // Sort the return array by node ID.
+  ksort($result);
+  return $result;
+}
+
+
+/**
+ * Implements hook_node_update().
+ */
+function fsa_guid_node_update($node) {
+  if (empty($node->update_guid)) {
+    return;
+  }
+  global $user;
+  _fsa_guid_set_guid_version($node->nid, $node->vid, $user->uid);
+}
+
+
+/**
+ * Helper function: returns GUID details for a node
+ *
+ * @param int $nid
+ *   Node ID for which we want to return GUID details
+ *
+ * @return array|NULL
+ *   If GUID details are found, an associative array of GUID details; NULL if
+ *   GUID is found.
+ */
+function _fsa_guid_get_guid_details($nid) {
+  $query = db_select('fsa_guid', 'f');
+  $query->fields('f');
+  $query->condition('nid', $nid);
+  $result = $query->execute()->fetchAssoc();
+  return !empty($result) && is_array($result) ? $result : NULL;
+}
+
+
+/**
+ * Helper function: sets the GUID version for the given node
+ *
+ * @param int $nid
+ *   The node ID of the node
+ * @param int $vid
+ *   The revision ID of the node
+ * @param int $uid
+ *   Ths ID of the user creating the GUID
+ *
+ * @return int
+ *   STATUS_UPDATE if an update query is run
+ *   STATUS_INSERT if an insert query is run
+ */
+function _fsa_guid_set_guid_version($nid, $vid, $uid) {
+  // First, get the current version, if any
+  $current_version = _fsa_guid_get_guid_version($nid);
+  // Now increment the number
+  $guid_version = $current_version + 1;
+  // Update the database table with the new credentials
+  $query = db_merge('fsa_guid')
+    ->key(array('nid' => $nid))
+    ->fields(array(
+      'nid' => $nid,
+      'vid' => $vid,
+      'uid' => $uid,
+      'updated' => REQUEST_TIME,
+      'guid_version' => $guid_version,
+    ));
+  $update = $query->execute();
+  return $update;
+}
+
+
+/**
+ * Implements hook_node_load().
+ */
+function fsa_guid_node_load($nodes, $types) {
+  // Get any GUIDs for the given nodes based on their node IDs
+  $guids = _fsa_guid_get_guids(array_keys($nodes));
+  foreach ($nodes as $nid => $node) {
+    $node->fsa_guid = isset($guids[$nid]) ? $guids[$nid] : NULL;
+  }
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @file
+ * Main module file for the FSA GUID module
+ */

--- a/docroot/sites/all/modules/custom/fsa_guid/views/fsa_guid.views.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/views/fsa_guid.views.inc
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * Views data and hooks for the FSA GUID module
+ */
+
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function fsa_guid_views_data_alter(&$data) {
+  $data['node']['fsa_guid'] = array(
+    'title' => t('FSA GUID'),
+    'help' => t('A special GUID for use with RSS feeds and GovDelivery'),
+    'field' => array(
+      'handler' => 'fsa_guid_views_handler_field_guid',
+    ),
+  );
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/views/handlers/fsa_guid_views_handler_field_guid.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/views/handlers/fsa_guid_views_handler_field_guid.inc
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file
+ * Views field handler for the FSA GUID field
+ */
+
+class fsa_guid_views_handler_field_guid extends views_handler_field_entity {
+
+  /**
+   * Get the value that's supposed to be rendered.
+   *
+   * This api exists so that other modules can easy set the values of the field
+   * without having the need to change the render method as well.
+   *
+   * @param $values
+   *   An object containing all retrieved values.
+   * @param $field
+   *   Optional name of the field where the value is stored.
+   */
+  function get_value($values, $field = NULL) {
+    // Get the node entity
+    $entity = parent::get_value($values);
+    // Return the node entity's fsa_guid property - if set; otherwise generate
+    return !empty($entity->fsa_guid) ? $entity->fsa_guid : _fsa_guid_get_guid($nid);
+  }
+
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/views/plugins/fsa_guid_views_plugin_row_node_rss.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/views/plugins/fsa_guid_views_plugin_row_node_rss.inc
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @file
+ * Views row plugin override for node RSS items
+ *
+ * This row plugin allows us to use the FSA GUID in place of the standard
+ * Drupal GUID. It enables users to choose which GUID to use in the feed, but
+ * defaults to the FSA GUID.
+ */
+
+class fsa_guid_views_plugin_row_node_rss extends views_plugin_row_node_rss {
+
+  /**
+   * Add an option for GUID format
+   */
+  function option_definition() {
+    $options = parent::option_definition();
+    $options['guid_format'] = array('default' => FSA_GUID_DEFAULT_FORMAT);
+    return $options;
+  }
+
+
+  /**
+   * Add GUID format to the options form
+   */
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $form['guid_format'] = array(
+      '#type' => 'select',
+      '#title' => t('GUID format'),
+      '#default_value' => $this->options['guid_format'],
+      '#options' => array(
+        'fsa_guid' => t('FSA GUID'),
+        'drupal' => t('Standard Drupal format'),
+      ),
+    );
+  }
+
+
+  /**
+   * Override the parent item's render method. Allows us to modify the GUID.
+   *
+   * This is very close to the parent item's method, with only subtle
+   * differences.
+   */
+  function render($row) {
+
+    // If the standard Drupal GUID format is chosen, just use the parent class's
+    // render() method.
+    if ($this->options['guid_format'] != 'fsa_guid') {
+      return parent::render($row);
+    }
+
+    // This is the render method for the FSA GUID. It's a direct copy of the
+    // parent class's method, with the exception of the GUID.
+
+    // For the most part, this code is taken from node_feed() in node.module
+    global $base_url;
+
+    $nid = $row->{$this->field_alias};
+    if (!is_numeric($nid)) {
+      return;
+    }
+
+    $display_mode = $this->options['item_length'];
+    if ($display_mode == 'default') {
+      $display_mode = variable_get('feed_item_length', 'teaser');
+    }
+
+    // Load the specified node:
+    $node = $this->nodes[$nid];
+    if (empty($node)) {
+      return;
+    }
+
+    $item_text = '';
+
+    $uri = entity_uri('node', $node);
+    $node->link = url($uri['path'], $uri['options'] + array('absolute' => TRUE));
+    $node->rss_namespaces = array();
+    $node->rss_elements = array(
+      array(
+        'key' => 'pubDate',
+        'value' => gmdate('r', $node->created),
+      ),
+      array(
+        'key' => 'dc:creator',
+        'value' => $node->name,
+      ),
+      array(
+        'key' => 'guid',
+        // Use the FSA GUID instead of the standard Drupal GUID
+        'value' => _fsa_guid_get_guid($node->nid),
+        'attributes' => array('isPermaLink' => 'false'),
+      ),
+    );
+
+    // The node gets built and modules add to or modify $node->rss_elements
+    // and $node->rss_namespaces.
+
+    $build_mode = $display_mode;
+
+    $build = node_view($node, $build_mode);
+    unset($build['#theme']);
+
+    if (!empty($node->rss_namespaces)) {
+      $this->view->style_plugin->namespaces = array_merge($this->view->style_plugin->namespaces, $node->rss_namespaces);
+    }
+    elseif (function_exists('rdf_get_namespaces')) {
+      // Merge RDF namespaces in the XML namespaces in case they are used
+      // further in the RSS content.
+      $xml_rdf_namespaces = array();
+      foreach (rdf_get_namespaces() as $prefix => $uri) {
+        $xml_rdf_namespaces['xmlns:' . $prefix] = $uri;
+      }
+      $this->view->style_plugin->namespaces += $xml_rdf_namespaces;
+    }
+
+    // Hide the links if desired.
+    if (!$this->options['links']) {
+      hide($build['links']);
+    }
+
+    if ($display_mode != 'title') {
+      // We render node contents and force links to be last.
+      $build['links']['#weight'] = 1000;
+      $item_text .= drupal_render($build);
+    }
+
+    $item = new stdClass();
+    $item->description = $item_text;
+    $item->title = $node->title;
+    $item->link = $node->link;
+    $item->elements = $node->rss_elements;
+    $item->nid = $node->nid;
+
+    return theme($this->theme_functions(), array(
+      'view' => $this->view,
+      'options' => $this->options,
+      'row' => $item
+    ));
+
+  }
+}


### PR DESCRIPTION
Created a new custom module to provide special GUIDs that can be updated as required.

Module to enable
-----------------------
Once the code is deployed, the new module needs to be enabled:

`drush en fsa_guid --y`

Then clear the caches:

`drush cc all`

[ Partial fix for #10357 ]