### PR TITLE
Master: Fix/10354 auto signoff in drupal

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_revisioning/README.txt
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/README.txt
@@ -1,0 +1,54 @@
+DESCRIPTION
+===========
+This module provides some enhancements to the contributed Revisioning and
+Revisioning Scheduler modules as used on the FSA website.
+
+www.drupal.org/project/revisioning
+
+
+CURRENT ENHANCEMENTS
+====================
+Current enhancements include:
+
+1. A fix for a bug whereby scheduled publication dates aren't always saved the
+   first time they're added. This bug has been reported on Drupal.org:
+   https://www.drupal.org/node/2445469. Although a patch has been provided, it
+   was deemed easier for the upgrade path if we fixed it in this custom module.
+   The fix involves adding an update hook that sets the weight of the
+   revisioning_scheduler module as greater than the revisioning module.
+2. Use a date popup field when setting publication dates. If the Date API
+   module is available, we replace the standard text field for publication date
+   with a more user-friendly calendar popup.
+3. Better validation for publication dates. Drupal now checks to see whether
+   the publication date entered by the user is valid before saving the node.
+4. Enhanced JavaScript. Because publication dates are saved only if the option
+   Create new revision and moderate is selected, we hide the publication date
+   field otherwise.
+
+
+FUTURE ENHANCEMENTS
+===================
+* Change the wording of the options in the Revision information field set on the
+  node edit page to be a little more intuitive.
+
+
+INSTALLATION & CONFIGURATION
+============================
+* Install as you would any other Drupal module.
+* This module does not provide any configuration options
+* Database schema updates must be run following installation. This should happen
+  as part of the installation process, but it's worth making sure.
+
+
+REQUIREMENTS
+============
+* This module requires the revisioning and revisioning_scheduler modules.
+* For the date popup field to work, the Date API module must be installed and
+  enabled, though this isn't a strict requirement.
+
+
+AUTHOR
+======
+Matt Farrow, Sirius Open Source, Stress Free Technology
+https://www.drupal.org/u/mattfarrow
+http://www.siriusopensource.com

--- a/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.info
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.info
@@ -1,0 +1,6 @@
+name = FSA revisioning
+description = "Provides some enhancements and fixes for the Revisioning module"
+core = 7.x
+package = FSA Custom
+dependencies[] = revisioning
+dependencies[] = revisioning_scheduler

--- a/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
@@ -4,6 +4,14 @@
  * Install, update and uninstall hooks for the FSA revisioning module
  */
 
+/**
+* Implements hook_install().
+*/
+function fsa_revisioning_deploy_install() {
+  // Set an initial value for the schema version so updates will run on install.
+  drupal_set_installed_schema_version('fsa_revisioning', 7000);
+}
+
 
 /**
  * Sets the weight of the Revisioning schedule module to be greater than that of

--- a/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall hooks for the FSA revisioning module
+ */
+
+
+/**
+ * Sets the weight of the Revisioning schedule module to be greater than that of
+ * the Revisioning module.
+ */
+function fsa_revisioning_update_7001() {
+  // In order to work properly, the node_presave() hook of the
+  // revisioning_scheduler module should be called after the same hook for the
+  // revisioning module. To ensure this, we need to adjust the weights in the
+  // system table.
+
+  // Get the weight of the Revisioning module
+  $weight = db_select('system', 's')
+    ->fields('s', array('weight'))
+    ->condition('name', 'revisioning')
+    ->execute()->fetchField();
+
+  // Add 1 to the Revisioning module's weight
+  $new_weight = is_numeric($weight) ? $weight + 1 : NULL;
+
+  // Assign the new weight to the Revisioning scheduler module
+  if (!is_null($new_weight)) {
+    db_update('system')
+      ->fields(array('weight' => $new_weight))
+      ->condition('name', 'revisioning_scheduler')
+      ->execute();
+  }
+}
+
+
+/**
+ * Sets the weight of this module to be greater than that of the Revisioning
+ * scheduler module
+ */
+function fsa_revisioning_update_7002() {
+
+  // Get the weight of the Revisioning scheduler
+  $weight = db_select('system', 's')
+    ->fields('s', array('weight'))
+    ->condition('name', 'revisioning_scheduler')
+    ->execute()->fetchField();
+
+  // Add 1 to the Revisioning scheduler module's weight
+  $new_weight = is_numeric($weight) ? $weight + 1 : NULL;
+
+  // Assign the new weight to this module
+  if (!is_null($new_weight)) {
+    db_update('system')
+      ->fields(array('weight' => $new_weight))
+      ->condition('name', 'fsa_revisioning')
+      ->execute();
+  }
+}

--- a/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.install
@@ -7,7 +7,7 @@
 /**
 * Implements hook_install().
 */
-function fsa_revisioning_deploy_install() {
+function fsa_revisioning_install() {
   // Set an initial value for the schema version so updates will run on install.
   drupal_set_installed_schema_version('fsa_revisioning', 7000);
 }

--- a/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.module
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.module
@@ -39,6 +39,11 @@ function fsa_revisioning_form_node_form_alter(&$form, &$form_state, $form_id) {
       $publication_date_field['#element_validate'] = array('_fsa_revisioning_publication_date_validate');
       // Replace the existing publication_date field with our new version
       $form['revision_information']['publication_date'] = $publication_date_field;
+      // If the publication date field is populated, then default the
+      // 'revision_operation' radio button to the third option
+      if (!empty($form['revision_information']['publication_date']['#default_value'])) {
+        $form['revision_information']['revision_operation']['#default_value'] = REVISIONING_NEW_REVISION_WITH_MODERATION;
+      }
     }
 
     // Attach our little JavaScript file to supplement existing functionality

--- a/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.module
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/fsa_revisioning.module
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @file
+ * Module file for the FSA revisioning module
+ */
+
+
+/**
+ * Implements hook_form_BASEFORMID_alter().
+ *
+ * We use this to modify the node edit form.
+ *
+ */
+function fsa_revisioning_form_node_form_alter(&$form, &$form_state, $form_id) {
+
+  // Make sure we're on the right form
+  if (!empty($form['#node_edit_form']) && variable_get('revisioning_scheduler_on_edit_form', TRUE)) {
+
+    // Use a date popup, rather than a standard textfield - if available
+    if (!empty($form['revision_information']['publication_date']) && module_exists('date')) {
+      // Get the existing publication date field
+      $publication_date_field = $form['revision_information']['publication_date'];
+      // Change its type to date_popup
+      $publication_date_field['#type'] = 'date_popup';
+      // Set the date format to use 24-hour clock
+      $publication_date_field['#date_format'] = 'j F Y - H:i';
+      // Set the year range
+      $publication_date_field['#date_year_range'] = '0:+3';
+      // Unset size and maxlength as they cause validation issues
+      unset($publication_date_field['#size']);
+      unset($publication_date_field['#maxlength']);
+      // Get the publication date - if set
+      $publication_date = $publication_date_field['#default_value'];
+      // Format the publication date in a way suitable for date_popup
+      $publication_date_field['#default_value'] = !empty($publication_date) ? format_date(strtotime($publication_date), 'custom', 'Y-m-d H:i:s') : NULL;
+      // Change the description text
+      $publication_date_field['#description'] = t('Enter the date and time on which you want this content to be published. If you do not wish to schedule publication, leave the field blank.');
+      // Add a validation handler
+      $publication_date_field['#element_validate'] = array('_fsa_revisioning_publication_date_validate');
+      // Replace the existing publication_date field with our new version
+      $form['revision_information']['publication_date'] = $publication_date_field;
+    }
+
+    // Attach our little JavaScript file to supplement existing functionality
+    $form['#attached']['js'][] = array(
+      'data' => drupal_get_path('module', 'fsa_revisioning') . '/js/fsa-revision-schedule.js',
+      'type' => 'file',
+      'weight' => 100,
+    );
+  }
+}
+
+
+/**
+ * Validation function for review date
+ *
+ * We use this to ensure that:
+ * 1. If publication date has been set, we have both a date and a time
+ * 2. Publication date is not in the past
+ *
+ * The check for publication dates in the past is taken directly from
+ * _revisioning_scheduler_schedule_publication()
+ *
+ * @see revisioning_scheduler_node_presave().
+ * @see _revisioning_scheduler_schedule_publication().
+ */
+function _fsa_revisioning_publication_date_validate($element, &$form_state, $form) {
+  // Get the value
+  $value = !empty($element['#value']) && is_array($element['#value']) ? $element['#value'] : array('date' => '', 'time' => '');
+  // Split the value into date and time elements
+  list($date, $time) = array_values($value);
+  // If date and time are both empty, we need go no further.
+  if (empty($date) && empty($time)) {
+    return;
+  }
+  // If either date or time is empty (but not both), set an error. We need both.
+  if (empty($date) xor empty($time)) {
+    form_set_error('publication_date', t('You must include both a date and a time when scheduling publication.'));
+    return;
+  }
+  // Now make sure that our publication date isn't in the past. This replicates
+  // functionality found in _revisioning_scheduler_schedule_publication(), but
+  // it allows us to inform the user before the node is updated.
+  $scheduled_time = strtotime($date . $time);
+  if (empty($scheduled_time) || !($scheduled_time > time() - REVISIONING_SCHEDULER_SLACK)) {
+    form_set_error('publication_date', t('Publication cannot be scheduled at this date and time: %date %time.', array('%date' => $date, '%time' => $time)));
+  }
+  // Set a message to say that publication will be scheduled immediately. The
+  // logic for this is taken directly from revisioning_scheduler_node_presave().
+  if ($scheduled_time > time() - REVISIONING_SCHEDULER_SLACK && $scheduled_time <= time()) {
+    drupal_set_message(t('Publication of this content will be scheduled immediately.'));
+  }
+}

--- a/docroot/sites/all/modules/custom/fsa_revisioning/js/fsa-revision-schedule.js
+++ b/docroot/sites/all/modules/custom/fsa_revisioning/js/fsa-revision-schedule.js
@@ -1,0 +1,35 @@
+(function ($) {
+
+  /**
+   * This file supplements the functionality provided in
+   * revision-schedule.js as included in the revisioning_scheduler module.
+   * Given that the only situation in which the publication date is actually
+   * saved is when the radio button 'Create new revision and moderate' is
+   * selected, it makes sense to hide the publication date field in all other
+   * circumstances to avoid confusion.
+   */
+  Drupal.behaviors.hidePublicationDateTimeField = {
+    attach: function (context) {
+      var newRevisionInModerationRadio = $('#edit-revision-operation-2');
+      var publicationDate = $('.form-item-publication-date');
+
+      // Page-load: hide the publication date textbox unless the third radio
+      // button is selected
+      if (!newRevisionInModerationRadio.is(':checked')) {
+        publicationDate.hide();
+      }
+
+      // The publication date field is used ONLY if the
+      // 'Create new revision and moderate' radio button is selected. In all
+      // other circumstances, its value gets ignored during hook_node_presave()
+      // @see revisioning_scheduler_node_presave().
+      // So let's hide it under other circumstances.
+      $('#edit-revision-operation input').click(function() {
+        if (!newRevisionInModerationRadio.is(':checked')) {
+          publicationDate.hide();
+        }
+      });
+    }
+  };
+
+})(jQuery);


### PR DESCRIPTION
Master: Fix/10354 auto signoff in drupal
Ticket: 10354 

Create new custom revisioning module
Created a new custom module to supplement and improve some of the functionality provided by the contributed Revisioning and Revisioning Scheduler modules.

Enhancements include:

1. A fix for a bug whereby scheduled publication dates aren't always saved the
   first time they're added. This bug has been reported on Drupal.org:
   https://www.drupal.org/node/2445469. Although a patch has been provided, it
   was deemed easier for the upgrade path if we fixed it in this custom module.
   The fix involves adding an update hook that sets the weight of the
   revisioning_scheduler module as greater than the revisioning module.
2. Use a date popup field when setting publication dates. If the Date API
   module is available, we replace the standard text field for publication date
   with a more user-friendly calendar popup.
3. Better validation for publication dates. Drupal now checks to see whether
   the publication date entered by the user is valid before saving the node.
4. Enhanced JavaScript. Because publication dates are saved only if the option
   Create new revision and moderate is selected, we hide the publication date
   field otherwise.

Enabling the module
-------------------
Following deployment of the code, the new module needs to be enabled:

`drush en fsa_revisioning --y`

[ Fixes #10354 ]