### PR TITLE
Develop: Add additional validation for GUID pattern form

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -64,12 +64,12 @@ function fsa_guid_admin_form_validate(&$form, &$form_state) {
   }
   // Check for any invalid tokens.
   $pattern = "/\[.*?:.*?\]/";
-  $check = preg_match_all($pattern, $guid_pattern, $matches);
   // First, get anything that looks like a token
+  $check = preg_match_all($pattern, $guid_pattern, $matches);
   if (!empty($matches)) {
     $guids = !empty($matches[0]) ? $matches[0] : NULL;
   }
-  // Nowcheck that all tokens are valid
+  // Now check that all tokens are valid
   if (is_array($guids) && !empty($guids)) {
     foreach ($guids as $guid) {
       $tok = preg_match("/\[(.*)\:(.*?)\]/", $guid, $matches);

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -50,14 +50,32 @@ function fsa_guid_admin_form($form, &$form_state) {
 function fsa_guid_admin_form_validate(&$form, &$form_state) {
   $values = !empty($form_state['values']) ? $form_state['values'] : array();
   $guid_pattern = !empty($values['fsa_guid_pattern']) ? $values['fsa_guid_pattern'] : '';
+  // Check that a GUID pattern has been provided
   if (empty($guid_pattern)) {
     form_set_error('fsa_guid_pattern', t('You must provide a GUID pattern.'));
   }
+  // Check that required tokens are included
   $tokens = module_invoke('fsa_guid', 'token_info');
   $tokens = !empty($tokens['tokens']['fsa_guid']) ? $tokens['tokens']['fsa_guid'] : array();
   foreach ($tokens as $id => $details) {
-    if (!empty($details['required']) && strpos($guid_pattern, "[fsa_guid:${id}]") === FALSE) {
+    if (!empty($details['required']) && strpos($guid_pattern, "[" . FSA_GUID_TOKEN_BASE . ":${id}]") === FALSE) {
       form_set_error('fsa_guid_pattern', t('You must include the token %token as part of the GUID pattern', array('%token' => "[fsa_guid:${id}]")));
+    }
+  }
+  // Check for any invalid tokens.
+  $pattern = "/\[.*?:.*?\]/";
+  $check = preg_match_all($pattern, $guid_pattern, $matches);
+  // First, get anything that looks like a token
+  if (!empty($matches)) {
+    $guids = !empty($matches[0]) ? $matches[0] : NULL;
+  }
+  // Nowcheck that all tokens are valid
+  if (is_array($guids) && !empty($guids)) {
+    foreach ($guids as $guid) {
+      $tok = preg_match("/\[(.*)\:(.*?)\]/", $guid, $matches);
+      if (count($matches) > 2 && ($matches[1] != FSA_GUID_TOKEN_BASE || !array_key_exists($matches[2], $tokens))) {
+        form_set_error('fsa_guid_pattern', t('Sorry, %token is not a valid token. Please check and re-submit.', array('%token' => "[" . $matches[1] . ":" . $matches[2] . "]")));
+      }
     }
   }
 }

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -60,7 +60,7 @@ function fsa_guid_admin_form_validate(&$form, &$form_state) {
       form_set_error('fsa_guid_pattern', t('You must include the token %token as part of the GUID pattern', array('%token' => "[fsa_guid:${id}]")));
     }
   }
- }
+}
 
 
  /**

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -24,6 +24,12 @@ define('FSA_GUID_DEFAULT_FORMAT', 'drupal');
 
 
 /**
+ * Base for token patterns
+ */
+define('FSA_GUID_TOKEN_BASE', 'fsa_guid');
+
+
+/**
  * Implements hook_permission().
  */
 function fsa_guid_permission() {

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -409,7 +409,7 @@ function _fsa_guid_token_replace($pattern, $data) {
     $nid = $data['nid'];
     $data['node_url'] = url(drupal_get_path_alias("node/$nid"), array('absolute' => TRUE));
   }
-  $token_base = 'fsa_guid';
+  $token_base = FSA_GUID_TOKEN_BASE;
   $return = $pattern;
   // Look through each data element and attempt to replace any tokens using it
   // in the $pattern string.


### PR DESCRIPTION
When editing the GUID pattern for RSS feeds, invalid tokens, including those defined by other modules, can no longer be entered.

[ Partial fix for #10866 ]