### PR TITLE
Master: Don't use Drupal token API in GUIDs

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -38,7 +38,7 @@ function fsa_guid_admin_form($form, &$form_state) {
   $form['available_tokens']['tokens'] = array(
     '#theme' => 'token_tree',
     '#token_types' => array('fsa_guid'),
-    '#global_types' => TRUE,
+    '#global_types' => FALSE,
   );
   return system_settings_form($form);
 }

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -64,12 +64,12 @@ function fsa_guid_admin_form_validate(&$form, &$form_state) {
   }
   // Check for any invalid tokens.
   $pattern = "/\[.*?:.*?\]/";
-  $check = preg_match_all($pattern, $guid_pattern, $matches);
   // First, get anything that looks like a token
+  $check = preg_match_all($pattern, $guid_pattern, $matches);
   if (!empty($matches)) {
     $guids = !empty($matches[0]) ? $matches[0] : NULL;
   }
-  // Nowcheck that all tokens are valid
+  // Now check that all tokens are valid
   if (is_array($guids) && !empty($guids)) {
     foreach ($guids as $guid) {
       $tok = preg_match("/\[(.*)\:(.*?)\]/", $guid, $matches);

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -50,14 +50,32 @@ function fsa_guid_admin_form($form, &$form_state) {
 function fsa_guid_admin_form_validate(&$form, &$form_state) {
   $values = !empty($form_state['values']) ? $form_state['values'] : array();
   $guid_pattern = !empty($values['fsa_guid_pattern']) ? $values['fsa_guid_pattern'] : '';
+  // Check that a GUID pattern has been provided
   if (empty($guid_pattern)) {
     form_set_error('fsa_guid_pattern', t('You must provide a GUID pattern.'));
   }
+  // Check that required tokens are included
   $tokens = module_invoke('fsa_guid', 'token_info');
   $tokens = !empty($tokens['tokens']['fsa_guid']) ? $tokens['tokens']['fsa_guid'] : array();
   foreach ($tokens as $id => $details) {
-    if (!empty($details['required']) && strpos($guid_pattern, "[fsa_guid:${id}]") === FALSE) {
+    if (!empty($details['required']) && strpos($guid_pattern, "[" . FSA_GUID_TOKEN_BASE . ":${id}]") === FALSE) {
       form_set_error('fsa_guid_pattern', t('You must include the token %token as part of the GUID pattern', array('%token' => "[fsa_guid:${id}]")));
+    }
+  }
+  // Check for any invalid tokens.
+  $pattern = "/\[.*?:.*?\]/";
+  $check = preg_match_all($pattern, $guid_pattern, $matches);
+  // First, get anything that looks like a token
+  if (!empty($matches)) {
+    $guids = !empty($matches[0]) ? $matches[0] : NULL;
+  }
+  // Nowcheck that all tokens are valid
+  if (is_array($guids) && !empty($guids)) {
+    foreach ($guids as $guid) {
+      $tok = preg_match("/\[(.*)\:(.*?)\]/", $guid, $matches);
+      if (count($matches) > 2 && ($matches[1] != FSA_GUID_TOKEN_BASE || !array_key_exists($matches[2], $tokens))) {
+        form_set_error('fsa_guid_pattern', t('Sorry, %token is not a valid token. Please check and re-submit.', array('%token' => "[" . $matches[1] . ":" . $matches[2] . "]")));
+      }
     }
   }
 }

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.admin.inc
@@ -60,7 +60,7 @@ function fsa_guid_admin_form_validate(&$form, &$form_state) {
       form_set_error('fsa_guid_pattern', t('You must include the token %token as part of the GUID pattern', array('%token' => "[fsa_guid:${id}]")));
     }
   }
- }
+}
 
 
  /**

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -377,3 +377,41 @@ function fsa_guid_views_plugins_alter(&$plugins) {
     $plugins['row']['node_rss'] = $properties + $plugins['row']['node_rss'];
   }
 }
+
+
+/**
+ * Helper function: alternative token replacement function
+ *
+ * This function takes the same parameters as Drupal Core's token_replace(), but
+ * is much simpler. It can replace only tokens provided by this module, and it
+ * does not use any form of caching.
+ *
+ * This function has been created in response to a strange issue whereby tokens
+ * in the RSS feed GUIDs were not replaced. This appears to be an aberration,
+ * and no explanation has been found, but clearing the caches fixed it, so we
+ * assume a caching issue was the root of the problem. See #10866.
+ */
+function _fsa_guid_token_replace($pattern, $data) {
+  // If we have a nid, we can derive the node URL in case anyone wants to
+  // include it.
+  if (!empty($data['nid'])) {
+    $nid = $data['nid'];
+    $data['node_url'] = url(drupal_get_path_alias("node/$nid"), array('absolute' => TRUE));
+  }
+  $token_base = 'fsa_guid';
+  $return = $pattern;
+  // Look through each data element and attempt to replace any tokens using it
+  // in the $pattern string.
+  foreach ($data as $key => $value) {
+    if (!is_null($value)) {
+      $return = str_replace("[$token_base:$key]", $value, $return);
+    }
+  }
+  // Check for the presence of anything that looks like a token, and if present,
+  // log a Watchdog error. The presence of an unmatched token would be a strong
+  // indication that something has gone wrong with the GUIDs.
+  if (preg_match("/\[.*?:.*?]/", $return, $matches)) {
+    watchdog('fsa_guid', 'Unmatched token %token in pattern @pattern for GUID: @guid', array('@guid' => $return, '%token' => implode(', ', $matches), '@pattern' => $pattern), WATCHDOG_ALERT);
+  }
+  return $return;
+}

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -99,10 +99,15 @@ function fsa_guid_views_api() {
  *
  * @return string
  *   A GUID - currently of the form ${nid}-${guid_version}
+ *
+ * @see _fsa_guid_token_replace()
  */
 function _fsa_guid_generate_guid($nid, $guid_version = 0) {
   $pattern = FSA_GUID_PATTERN;
-  $guid = token_replace($pattern, array('nid' => $nid, 'gid' => $guid_version));
+  // Replace the tokens in the GUID pattern with their actual values. Note that
+  // we're not using Drupal's built-in token_replace() function in order to
+  // avoid any potential caching issues - see #10866.
+  $guid = _fsa_guid_token_replace($pattern, array('nid' => $nid, 'gid' => $guid_version));
   // Give other modules the chance to modify the GUID
   drupal_alter('fsa_guid', $guid, $nid, $guid_version);
   return $guid;

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -24,6 +24,12 @@ define('FSA_GUID_DEFAULT_FORMAT', 'drupal');
 
 
 /**
+ * Base for token patterns
+ */
+define('FSA_GUID_TOKEN_BASE', 'fsa_guid');
+
+
+/**
  * Implements hook_permission().
  */
 function fsa_guid_permission() {

--- a/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
+++ b/docroot/sites/all/modules/custom/fsa_guid/fsa_guid.module
@@ -409,7 +409,7 @@ function _fsa_guid_token_replace($pattern, $data) {
     $nid = $data['nid'];
     $data['node_url'] = url(drupal_get_path_alias("node/$nid"), array('absolute' => TRUE));
   }
-  $token_base = 'fsa_guid';
+  $token_base = FSA_GUID_TOKEN_BASE;
   $return = $pattern;
   // Look through each data element and attempt to replace any tokens using it
   // in the $pattern string.


### PR DESCRIPTION
In order to avoid issues with tokens not being replaced properly in RSS GUIDs, we now use an alternative token replacement function to Drupal's built-in token API.

[ Fixes #10866 ]