### PR TITLE
10506: Don't remove manager from groups.

### DIFF
--- a/docroot/sites/all/modules/custom/commitees_custom/commitees_custom.module
+++ b/docroot/sites/all/modules/custom/commitees_custom/commitees_custom.module
@@ -277,6 +277,11 @@ function commitees_custom_user_role_change($account, $roles_added, $roles_remove
     // Get all organic groups
     $groups = og_get_all_group();
     foreach ($groups as $gid) {
+      $group = entity_load_single('node', $gid);
+      // If the user is the manager of the group, move on
+      if (!empty($group->uid) && $group->uid == $account->uid) {
+        continue;
+      }
       og_ungroup('node', $gid, 'user', $account->uid);
     }
     drupal_set_message(t('Access to all committee sites has been removed for user %username.', array('%username' => $account->name)));


### PR DESCRIPTION
When removing group memberships from users who are having the All committee memberhip role taken away, don't remove those for which the user is the manager.

[ Partial fix for #10506 ]