### PR TITLE
10421: Clear committee URLs from CloudFlare (develop)

### DIFF
--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
@@ -633,12 +633,12 @@ function _cloudflare_cache_clear_check_account_details($key, $email) {
 /**
  * Helper function: Determines whether CloudFlare account details are correct
  */
-function _cloudflare_cache_clear_account_authenticated($authenticated = NULL) {
+function _cloudflare_cache_clear_account_authenticated($authenticated = FALSE) {
   $variable_name = CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'account_authenticated';
   if (func_num_args() > 0) {
     variable_set($variable_name, $authenticated);
   }
-  return variable_get($variable_name);
+  return variable_get($variable_name, FALSE);
 }
 
 
@@ -713,4 +713,18 @@ function _cloudflare_cache_clear_load_file_by_url($url) {
     return $file;
   }
   return NULL;
+}
+
+
+/**
+ * Returns the chosen protocols for clearing from the CloudFlare cache
+ */
+function cloudflare_cache_clear_get_protocols() {
+  $return = array();
+  foreach(array_values(_cloudflare_cache_clear_get_setting('protocols')) as $protocol) {
+    if (!empty($protocol)) {
+      $return[] = $protocol;
+    }
+  }
+  return $return;
 }

--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -499,6 +499,8 @@ function _local_committee_domains() {
  *
  * We do this using this hook, rather than the path-based one as we need to add
  * domains to the resulting array.
+ *
+ * We also need to clear URLs for standard pages based on the committee domains.
  */
 function local_cloudflare_cache_clear_urls_alter(&$urls, $wildcards, $object_type, $object) {
   $temp_urls = $urls;
@@ -512,6 +514,16 @@ function local_cloudflare_cache_clear_urls_alter(&$urls, $wildcards, $object_typ
       foreach (array_keys($committee_domains) as $committee_domain) {
         foreach (cloudflare_cache_clear_get_protocols() as $protocol) {
           $urls[] = $protocol . '://' . $committee_domain . '/' . $path;
+        }
+      }
+    }
+    // For pages, if they have a path that looks like a committee path, make
+    // sure the URL based on the relevant committee domain also gets cleared
+    foreach ($committee_domains as $committee_domain => $committee_path) {
+      if (strpos($path, $committee_path) === 0) {
+        foreach (cloudflare_cache_clear_get_protocols() as $protocol) {
+          $new_path = trim($protocol . '://' . $committee_domain . '/' . preg_replace("@^" . $committee_path . "/?(.*)$@", '$1', $path));
+          $urls[] = $new_path;
         }
       }
     }

--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -469,3 +469,51 @@ function local_national_archives_site_url_alter(&$site_url, &$url) {
  function local_form_node_form_alter(&$form, &$form_state) {
  	$form['#attached']['css'][] = drupal_get_path('module', 'local') . '/css/local.css';
  }
+
+
+ /**
+ * Returns an array of committee domains and their associated paths.
+ *
+ * @return array
+ *   Array of committee domains and their associated paths.
+ */
+function _local_committee_domains() {
+  $committee_domains = array(
+    'cot.food.gov.uk' => 'committee/committee-on-toxicity',
+    'acmsf.food.gov.uk' => 'committee/acmsf',
+    'acnfp.food.gov.uk'=> 'committee/acnfp',
+    'acaf.food.gov.uk' => 'committee/acaf',
+    'gacs.food.gov.uk'=> 'committee/gacs',
+    'ssrc.food.gov.uk'=> 'committee/social-science-research-committee-ssrc',
+  );
+  return $committee_domains;
+}
+
+
+/**
+ * Implements hook_cloudflare_cache_clear_urls_alter().
+ *
+ * Since files can be used in any committee site, we need to make sure that when
+ * we clear the CloudFlare cache for a file, we also do so for every committee
+ * domain.
+ *
+ * We do this using this hook, rather than the path-based one as we need to add
+ * domains to the resulting array.
+ */
+function local_cloudflare_cache_clear_urls_alter(&$urls, $wildcards, $object_type, $object) {
+  $temp_urls = $urls;
+  // Get the local committee domains
+  $committee_domains = _local_committee_domains();
+  foreach ($temp_urls as $url) {
+    // Extract the path part from the URL
+    $path = preg_replace("@^http(?:s)://.*?/(.*)$@", '$1', $url);
+    // Determine whether it's a file type based on the path
+    if (_cloudflare_cache_clear_get_object_type_from_path($path) == 'file') {
+      foreach (array_keys($committee_domains) as $committee_domain) {
+        foreach (cloudflare_cache_clear_get_protocols() as $protocol) {
+          $urls[] = $protocol . '://' . $committee_domain . '/' . $path;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We now clear committee-based URLs for files and pages from CloudFlare.

[ Partial fix for #10421 ]