### PR TITLE
10421: Use drupal_encode_path(), not urlencode() (develop)

### DIFF
--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
@@ -301,7 +301,7 @@ function _cloudflare_cache_clear_purge_urls($urls, $wildcards = NULL, $object_ty
   foreach ($urls as $url) {
     if (!empty($url)) {
       foreach ($domains as $domain) {
-        $files[] = trim($domain) . '/' . urlencode(trim($url));
+        $files[] = trim($domain) . '/' . drupal_encode_path(trim($url));
       }
     }
   }


### PR DESCRIPTION
When encoding CloudFlare URLs, use `drupal_encode_path()` instead of `urlencode()`.

[ Partial fix for #10421 ]