### PR TITLE
10421: Upgrade CloudFlare cache clearing to version 4

### DIFF
--- a/docroot/sites/all/modules/contrib/httprl/LICENSE.txt
+++ b/docroot/sites/all/modules/contrib/httprl/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/docroot/sites/all/modules/contrib/httprl/README.txt
+++ b/docroot/sites/all/modules/contrib/httprl/README.txt
@@ -1,0 +1,112 @@
+
+------------------------------------------------
+HTTP PARALLEL REQUEST & THREADING LIBRARY MODULE
+------------------------------------------------
+
+
+CONTENTS OF THIS FILE
+---------------------
+
+ * About HTTPRL
+ * Requirements
+ * Configuration
+ * API Overview
+ * Technical Details
+ * Code Examples
+
+
+ABOUT HTTPRL
+------------
+
+http://drupal.org/project/httprl
+
+HTTPRL is a flexible and powerful HTTP client implementation. Correctly handles
+GET, POST, PUT or any other HTTP requests & the sending of data. Issue blocking
+or non-blocking requests in parallel. Set timeouts, max simultaneous connection
+limits, chunk size, and max redirects to follow. Can handle data with
+content-encoding and transfer-encoding headers set. Correctly follows
+redirects. Option to forward the referrer when a redirect is found. Cookie
+extraction and parsing into key value pairs. Can multipart encode data so files
+can easily be sent in a HTTP request. Will emulate a range request if the server
+does not support range requests.
+
+
+REQUIREMENTS
+------------
+
+Requires PHP 5. The following functions must be available on the server:
+ * stream_socket_client
+ * stream_select
+ * stream_set_blocking
+ * stream_get_meta_data
+ * stream_socket_get_name
+Some hosting providers disable these functions; but they do come standard with
+PHP 5.
+
+
+CONFIGURATION
+-------------
+
+Settings page is located at:
+6.x: admin/settings/httprl
+7.x: admin/config/development/httprl
+
+ * IP Address to send all self server requests to. If left blank it will use the
+   same server as the request. If set to -1 it will use the host name instead of
+   an IP address. This controls the output of httprl_build_url_self().
+ * Enable background callbacks. If disabled all background_callback keys will
+   be turned into callback & httprl_queue_background_callback will return NULL
+   and not queue up the request. Note that background callbacks will
+   automatically be disabled if the site is in maintenance mode.
+
+
+API OVERVIEW
+------------
+
+Issue HTTP Requests:
+httprl_build_url_self()
+ - Helper function to build an URL for asynchronous requests to self. Note that
+   you should set the Host name in the headers when using this.
+httprl_request()
+ - Queue up a HTTP request in httprl_send_request().
+httprl_send_request()
+ - Perform many HTTP requests.
+
+Create and use a thread:
+httprl_queue_background_callback()
+ - Queue a special HTTP request (used for threading) in httprl_send_request().
+
+Other Functions:
+httprl_is_background_callback_capable()
+ - See if httprl can issue a background callback.
+httprl_background_processing()
+ - Output text, close connection, continue processing in the background.
+httprl_strlen()
+ - Get the length of a string in bytes.
+httprl_glue_url()
+ - Alt to http_build_url().
+httprl_get_server_schema()
+ - Return the server schema (http or https).
+httprl_pr()
+ - Pretty print data.
+httprl_fast403()
+ - Issue a 403 and exit.
+
+
+TECHNICAL DETAILS
+-----------------
+
+Using stream_select() HTTPRL will send http requests out in parallel. These
+requests can be made in a blocking or non-blocking way. Blocking will wait for
+the http response; Non-Blocking will close the connection not waiting for the
+response back. The API for httprl is similar to the Drupal 7 version of
+drupal_http_request().
+
+HTTPRL can be used independent of drupal. For basic operations it doesn't
+require any built in drupal functions.
+
+
+CODE EXAMPLES
+-------------
+
+See examples/httprl.examples.php for code examples.

--- a/docroot/sites/all/modules/contrib/httprl/examples/httprl.examples.php
+++ b/docroot/sites/all/modules/contrib/httprl/examples/httprl.examples.php
@@ -1,0 +1,829 @@
+<?php
+/**
+ * @file
+ * HTTP Parallel Request Library code examples.
+ */
+?>
+
+**Simple HTTP**
+Request http://drupal.org/.
+
+<?php
+// Queue up the request.
+httprl_request('http://drupal.org/');
+// Execute request.
+$request = httprl_send_request();
+
+// Echo out the results.
+echo httprl_pr($request);
+?>
+
+
+Request http://drupal.org/robots.txt and save it to tmp folder.
+
+<?php
+// Queue up the request.
+httprl_request('http://drupal.org/robots.txt');
+// Execute request.
+$request = httprl_send_request();
+
+// Save file if we got a 200 back.
+if ($request['http://drupal.org/robots.txt']->code == 200) {
+  file_put_contents('/tmp/robots.txt', $request['http://drupal.org/robots.txt']->data);
+}
+?>
+
+
+Request this servers own front page & the node page.
+
+<?php
+$options = array(
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Build URL to point to front page of this server.
+$url_front = httprl_build_url_self();
+// Build URL to point to /node on this server.
+$url_node = httprl_build_url_self('node');
+// Queue up the requests.
+httprl_request($url_front, $options);
+httprl_request($url_node, $options);
+// Execute requests.
+$request = httprl_send_request();
+
+// Echo out the results.
+echo httprl_pr($request);
+?>
+
+
+**Non Blocking HTTP Operations**
+
+Request 10 URLs in a non blocking manner on this server. Checkout watchdog as
+this should generate 10 404s and the $request object won't contain much info.
+
+<?php
+// Set the blocking mode.
+$options = array(
+  'blocking' => FALSE,
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Queue up the requests.
+$max = 10;
+for ($i=1; $i <= $max; $i++) {
+  // Build URL to a page that doesn't exist.
+  $url = httprl_build_url_self('asdf-asdf-asdf-' . $i);
+  httprl_request($url, $options);
+}
+// Execute requests.
+$request = httprl_send_request();
+
+// Echo out the results.
+echo httprl_pr($request);
+?>
+
+
+Request 10 URLs in a non blocking manner with one httprl_request() call. These
+URLs will all have the same options.
+
+<?php
+// Set the blocking mode.
+$options = array(
+  'method' => 'HEAD',
+  'blocking' => FALSE,
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Queue up the requests.
+$max = 10;
+$urls = array();
+for ($i=1; $i <= $max; $i++) {
+  // Build URL to a page that doesn't exist.
+  $urls[] = httprl_build_url_self('asdf-asdf-asdf-' . $i);
+}
+// Queue up the requests.
+httprl_request($urls, $options);
+// Execute requests.
+$request = httprl_send_request();
+
+// Echo out the results.
+echo httprl_pr($request);
+?>
+
+
+Request 1000 URLs in a non blocking manner with one httprl_request() call. These
+URLs will all have the same options. This will saturate the server and any
+connections that couldn't be made will be dropped.
+
+<?php
+// Set the blocking mode.
+$options = array(
+  'method' => 'HEAD',
+  'blocking' => FALSE,
+  'domain_connections' => 1000,
+  'global_connections' => 1000,
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Queue up the requests.
+$max = 1000;
+$urls = array();
+for ($i=1; $i <= $max; $i++) {
+  // Build URL to a page that doesn't exist.
+  $urls[] = httprl_build_url_self('asdf-asdf-asdf-' . $i);
+}
+// Queue up the requests.
+httprl_request($urls, $options);
+// Execute requests.
+$request = httprl_send_request();
+
+// Echo out the results.
+echo httprl_pr($request);
+?>
+
+
+Request 1000 URLs in a non blocking manner with one httprl_request() call. These
+URLs will all have the same options. This will saturate the server. Usually all
+1000 requests will eventually hit the server due to it waiting for the
+connection to be established; `async_connect` is FALSE.
+
+<?php
+// Set the blocking mode.
+$options = array(
+  'method' => 'HEAD',
+  'blocking' => FALSE,
+  'async_connect' => FALSE,
+  // domain_connections must be smaller than the servers max number of
+  // clients.
+  'domain_connections' => 32,
+  'global_connections' => 1000,
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Queue up the requests.
+$max = 1000;
+$urls = array();
+for ($i=1; $i <= $max; $i++) {
+  // Build URL to a page that doesn't exist.
+  $urls[] = httprl_build_url_self('asdf-asdf-asdf-' . $i);
+}
+// Queue up the requests.
+httprl_request($urls, $options);
+// Execute requests.
+$request = httprl_send_request();
+
+// Echo out the results.
+echo httprl_pr($request);
+?>
+
+
+**HTTP Operations and Callbacks**
+
+Use a callback in the event loop to do processing on the request. In this case
+we are going to use httprl_pr() as the callback function.
+
+<?php
+// Setup return variable.
+$x = '';
+// Setup options array.
+$options = array(
+  'method' => 'HEAD',
+  'callback' => array(
+    array(
+      'function' => 'httprl_pr',
+      'return' => &$x,
+    ),
+  ),
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Build URL to point to front page of this server.
+$url_front = httprl_build_url_self();
+// Queue up the request.
+httprl_request($url_front, $options);
+// Execute request.
+$request = httprl_send_request();
+
+// Echo returned value from function callback.
+echo $x;
+?>
+
+
+Use a background callback in the event loop to do processing on the request.
+In this case we are going to use httprl_pr() as the callback function. A
+background callback creates a new thread to run this function in.
+
+<?php
+// Setup return variable.
+$x = '';
+// Setup options array.
+$options = array(
+  'method' => 'HEAD',
+  'background_callback' => array(
+    array(
+      'function' => 'httprl_pr',
+      'return' => &$x,
+    ),
+  ),
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Build URL to point to front page of this server.
+$url_front = httprl_build_url_self();
+// Queue up the request.
+httprl_request($url_front, $options);
+// Execute request.
+$request = httprl_send_request();
+
+// Echo returned value from function callback.
+echo $x;
+?>
+
+
+Use a background callback in the event loop to do processing on the request.
+In this case we are going to use print_r() as the callback function. A
+background callback creates a new thread to run this function in. The first
+argument passed in is the request object, the FALSE tells print_r to echo out
+instead of returning a value.
+
+<?php
+// Setup return & print variable.
+$x = '';
+$y = '';
+// Setup options array.
+$options = array(
+  'method' => 'HEAD',
+  'background_callback' => array(
+    array(
+      'function' => 'print_r',
+      'return' => &$x,
+      'printed' => &$y,
+    ),
+    FALSE,
+  ),
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Build URL to point to front page of this server.
+$url_front = httprl_build_url_self();
+// Queue up the request.
+httprl_request($url_front, $options);
+// Execute request.
+$request = httprl_send_request();
+
+// Echo what was returned and printed from function callback.
+echo $x . "<br />\n";
+echo $y;
+?>
+
+
+**More Advanced HTTP Operations**
+
+Hit 5 different URLs, Using at least 2 that has a status code of 200 and
+erroring out the others that didn't return fast. Using the Range header so only
+the first and last 128 bytes are returned.
+
+<?php
+// Array of URLs to get.
+$urls = array(
+  'http://google.com/',
+  'http://bing.com/',
+  'http://yahoo.com/',
+  'http://www.duckduckgo.com/',
+  'http://www.drupal.org/',
+);
+
+// Process list of URLs.
+$options = array(
+  'alter_all_streams_function' => 'need_two_good_results',
+  'headers' => array('Range' => 'bytes=0-127,-128'),
+);
+// Queue up the requests.
+httprl_request($urls, $options);
+
+// Execute requests.
+$requests = httprl_send_request();
+
+// Print what was done.
+echo httprl_pr($requests);
+
+function need_two_good_results($id, &$responses) {
+  static $counter = 0;
+  foreach ($responses as $id => &$result) {
+    // Skip if we got a 200 or 206.
+    if ($result->code == 200 || $result->code == 206) {
+      $counter += 1;
+      continue;
+    }
+    if ($result->status == 'Done.') {
+      continue;
+    }
+
+    if ($counter >= 2) {
+      // Set the code to request was aborted.
+      $result->code = HTTPRL_REQUEST_ABORTED;
+      $result->error = 'Software caused connection abort.';
+      // Set status to done and set timeout.
+      $result->status = 'Done.';
+      $result->options['timeout'] -= $result->running_time;
+
+      // Close the file pointer and remove from the stream from the array.
+      fclose($result->fp);
+      unset($result->fp);
+    }
+  }
+}
+?>
+
+
+Send 2 files in one field via a POST request.
+
+<?php
+// Set options.
+$options = array(
+  'method' => 'POST',
+  'data' => array(
+    'x' => 1,
+    'y' => 2,
+    'z' => 3,
+    'files' => array(
+      'core_js' => array(
+        'misc/form.js',
+        'misc/batch.js',
+      ),
+    ),
+  ),
+  'headers' => array(
+    // Set the Host header to self.
+    'Host' => $_SERVER['HTTP_HOST'],
+  ),
+);
+// Send request to front page.
+$url_front = httprl_build_url_self();
+
+// Queue up the request.
+httprl_request($url_front, $options);
+// Execute request.
+$request = httprl_send_request();
+// Echo what was returned.
+echo httprl_pr($request);
+?>
+
+
+Send out 8 requests. In this example we are going to stall the call to fread()
+`'stall_fread' => TRUE,`. By doing this we can issue a bunch of requests, do
+some other stuff and then get the results later on in the PHP process. A useful
+example would be for ESI emulation. Issue a bunch of requests at the start of
+the request, generate the main content and then add in the ESI-ed components at
+the end of the request.
+
+<?php
+// Queue up the request.
+$urls = array(
+  'http://www.google.com/',
+  'http://www.bing.com/',
+  'http://www.yahoo.com/',
+  'http://duckduckgo.com/',
+  'http://drupal.org/',
+  'http://drupal.org/robots.txt',
+  'http://drupal.org/CHANGELOG.txt',
+  'http://drupal.org/MAINTAINERS.txt',
+);
+$options = array(
+  // Do fread in a second request.
+  'stall_fread' => TRUE,
+  'headers' => array(
+    // Only grab the last 128 bytes of the request.
+    'Range' => 'bytes=-128',
+    // Accept Compression.
+    'Accept-Encoding' => 'gzip, deflate',
+  ),
+  // Increase the read chunk size to 512KB.
+  'chunk_size_read' => 524288,
+  // Increase domain_connections to 4 (drupal.org).
+  'domain_connections' => 4,
+  // If we can't connect quick (0.5 seconds), bail out.
+  'connect_timeout' => 0.5,
+  'dns_timeout' => 0.5,
+);
+httprl_request($urls, $options);
+// Execute request.
+echo round(timer_read('page')/1000, 3) . " - Time taken to get requests ready.<br> \n";
+$request = httprl_send_request();
+echo strtoupper(var_export($request, TRUE)) . " - Output from first httprl_send_request() call<br> \n";
+
+echo round(timer_read('page')/1000, 3) . " - Time taken to send out all fwrites().<br> \n";
+sleep(2);
+echo round(timer_read('page')/1000, 3) . " - Time taken for sleep(2).<br> \n";
+
+$request = httprl_send_request();
+echo round(timer_read('page')/1000, 3) . " - Time taken for all freads().<br> \n";
+echo "Output from second httprl_send_request() below:<br> \n<br> \n";
+echo httprl_pr($request);
+?>
+
+
+**Threading Examples**
+
+Use 2 threads to load up 4 different nodes.
+
+<?php
+// Bail out here if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  return FALSE;
+}
+
+// List of nodes to load; 241-244.
+$nodes = array(241 => '', 242 => '', 243 => '', 244 => '');
+foreach ($nodes as $nid => &$node) {
+  // Setup callback options array.
+  $callback_options = array(
+    array(
+      'function' => 'node_load',
+      'return' => &$node,
+      // Setup options array.
+      'options' => array(
+        'domain_connections' => 2, // Only use 2 threads for this request.
+      ),
+    ),
+    $nid,
+  );
+  // Queue up the request.
+  httprl_queue_background_callback($callback_options);
+}
+// Execute request.
+httprl_send_request();
+
+// Echo what was returned.
+echo httprl_pr($nodes);
+?>
+
+
+
+Load nodes 50-100 using httprl_batch_callback and node_load_multiple.
+
+<?php
+// List of nodes to load; 50-100.
+$nids = range(50, 100);
+// Run not parallel if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  $results = node_load_multiple($nids);
+}
+else {
+  // Queue & Execute requests.
+  $results = httprl_batch_callback('node_load_multiple', $nids);
+}
+// Echo what was returned.
+echo httprl_pr($results);
+?>
+
+
+
+Load nodes 50-100 using httprl_batch_callback and node_load.
+
+<?php
+// List of nodes to load; 50-100.
+$nids = range(50, 100);
+// Run not parallel if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  // httprl_run_multiple does a foreach on $nids running every $value through
+  // the given callback.
+  $results = httprl_run_multiple('node_load', $nids);
+}
+else {
+  // Set options.
+  $options = array(
+    'multiple_helper' => TRUE,
+  );
+  // Queue & Execute requests.
+  $results = httprl_batch_callback('node_load', $nids, $options);
+}
+// Echo what was returned.
+echo httprl_pr($results);
+?>
+
+
+Load nodes 50-100 using httprl_batch_callback and node_load_multiple as user 1.
+
+<?php
+// List of nodes to load; 50-100.
+$nids = range(50, 100);
+// Run not parallel if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  // Run node_load_multiple as user 1
+  $current_account = $GLOBALS['user']->uid;
+  $GLOBALS['user'] = user_load(1);
+  $results = node_load_multiple($nids);
+  // Set global user back.
+  $GLOBALS['user'] = $current_account;
+}
+else {
+  // Set options.
+  $options = array(
+    'context' => array(
+      'uid' => 1,
+    ),
+  );
+  // Queue & Execute requests.
+  $results = httprl_batch_callback('node_load_multiple', $nids, $options);
+}
+// Echo what was returned.
+echo httprl_pr($results);
+?>
+
+
+
+Run a function in the background. Notice that there is no return or printed key
+in the callback options.
+
+<?php
+// Bail out here if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  return FALSE;
+}
+
+// Setup callback options array; call watchdog in the background.
+$callback_options = array(
+  array(
+    'function' => 'watchdog',
+  ),
+  'httprl-test', 'background watchdog call done', array(), WATCHDOG_DEBUG,
+);
+// Queue up the request.
+httprl_queue_background_callback($callback_options);
+
+// Execute request.
+httprl_send_request();
+?>
+
+
+Pass by reference example. Example is D7 only; pass by reference works in
+D6 & D7.
+
+<?php
+// Code from system_rebuild_module_data().
+$modules = _system_rebuild_module_data();
+ksort($modules);
+
+// Show first module before running system_get_files_database().
+echo httprl_pr(current($modules));
+
+// Bail out here if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  return FALSE;
+}
+
+$callback_options = array(
+  array(
+    'function' => 'system_get_files_database',
+    'return' => '',
+  ),
+  &$modules, 'module'
+);
+httprl_queue_background_callback($callback_options);
+
+// Execute requests.
+httprl_send_request();
+
+// Show first module after running system_get_files_database().
+echo httprl_pr(current($modules));
+?>
+
+
+Get 2 results from 2 different queries at the hook_boot bootstrap level in D6.
+
+<?php
+// Run 2 queries and get the result.
+$x = db_result(db_query_range("SELECT filename FROM {system} ORDER BY filename ASC", 0, 1));
+$y = db_result(db_query_range("SELECT filename FROM {system} ORDER BY filename DESC", 0, 1));
+echo $x . "<br \>\n" . $y . "<br \>\n";
+unset($x, $y);
+
+
+// Bail out here if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  return FALSE;
+}
+
+// Run above 2 queries and get the result via a background callback.
+$args = array(
+  // First query.
+  array(
+    'type' => 'function',
+    'call' => 'db_query_range',
+    'args' => array('SELECT filename FROM {system} ORDER BY filename ASC', 0, 1),
+  ),
+  array(
+    'type' => 'function',
+    'call' => 'db_result',
+    'args' => array('last' => NULL),
+    'return' => &$x,
+  ),
+
+  // Second Query.
+  array(
+    'type' => 'function',
+    'call' => 'db_query_range',
+    'args' => array('SELECT filename FROM {system} ORDER BY filename DESC', 0, 1),
+  ),
+  array(
+    'type' => 'function',
+    'call' => 'db_result',
+    'args' => array('last' => NULL),
+    'return' => &$y,
+  ),
+);
+$callback_options = array(array('return' => ''), &$args);
+// Queue up the request.
+httprl_queue_background_callback($callback_options);
+// Execute request.
+httprl_send_request();
+
+// Echo what was returned.
+echo httprl_pr($x, $y);
+?>
+
+
+Get 2 results from 2 different queries at the hook_boot bootstrap level in D7.
+
+<?php
+$x = db_select('system', 's')
+  ->fields('s', array('filename'))
+  ->orderBy('filename', 'ASC')
+  ->range(0, 1)
+  ->execute()
+  ->fetchField();
+$y = db_select('system', 's')
+  ->fields('s', array('filename'))
+  ->orderBy('filename', 'DESC')
+  ->range(0, 1)
+  ->execute()
+  ->fetchField();
+echo $x . "<br \>\n" . $y . "<br \>\n";
+unset($x, $y);
+
+
+// Bail out here if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  return FALSE;
+}
+
+// Run above 2 queries and get the result via a background callback.
+$args = array(
+  // First query.
+  array(
+    'type' => 'function',
+    'call' => 'db_select',
+    'args' => array('system', 's',),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'fields',
+    'args' => array('s', array('filename')),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'orderBy',
+    'args' => array('filename', 'ASC'),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'range',
+    'args' => array(0, 1),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'execute',
+    'args' => array(),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'fetchField',
+    'args' => array(),
+    'return' => &$x,
+  ),
+
+  // Second Query.
+  array(
+    'type' => 'function',
+    'call' => 'db_select',
+    'args' => array('system', 's',),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'fields',
+    'args' => array('s', array('filename')),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'orderBy',
+    'args' => array('filename', 'DESC'),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'range',
+    'args' => array(0, 1),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'execute',
+    'args' => array(),
+  ),
+  array(
+    'type' => 'method',
+    'call' => 'fetchField',
+    'args' => array(),
+    'return' => &$y,
+  ),
+);
+$callback_options = array(array('return' => ''), &$args);
+// Queue up the request.
+httprl_queue_background_callback($callback_options);
+// Execute request.
+httprl_send_request();
+
+// Echo what was returned.
+echo httprl_pr($x, $y);
+?>
+
+
+Run a cache clear at the DRUPAL_BOOTSTRAP_FULL level as the current user in a
+non blocking background request.
+
+<?php
+// Normal way to do this.
+drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
+module_load_include('inc', 'system', 'system.admin');
+system_clear_cache_submit();
+
+
+// Bail out here if background callbacks are disabled.
+if (!httprl_is_background_callback_capable()) {
+  return FALSE;
+}
+
+// How to do it in a non blocking background request.
+$args = array(
+  array(
+    'type' => 'function',
+    'call' => 'drupal_bootstrap',
+    'args' => array(DRUPAL_BOOTSTRAP_FULL),
+  ),
+  array(
+    'type' => 'function',
+    'call' => 'module_load_include',
+    'args' => array('inc', 'system', 'system.admin'),
+  ),
+  array(
+    'type' => 'function',
+    'call' => 'system_clear_cache_submit',
+    'args' => array('', ''),
+  ),
+  array(
+    'type' => 'function',
+    'call' => 'watchdog',
+    'args' => array('httprl-test', 'background cache clear done', array(), WATCHDOG_DEBUG),
+  ),
+);
+
+// Pass the current session to the sub request.
+if (!empty($_COOKIE[session_name()])) {
+  $options = array('headers' => array('Cookie' => session_name() . '=' . $_COOKIE[session_name()] . ';'));
+}
+else {
+  $options = array();
+}
+$callback_options = array(array('options' => $options), &$args);
+
+// Queue up the request.
+httprl_queue_background_callback($callback_options);
+// Execute request.
+httprl_send_request();
+?>
+
+
+print 'My Text'; cut the connection by sending the data over the wire and do
+processing in the background.
+
+<?php
+httprl_background_processing('My Text');
+// Everything after this point does not affect page load time.
+sleep(5);
+echo 'You should not see this text';
+?>

--- a/docroot/sites/all/modules/contrib/httprl/httprl.admin.inc
+++ b/docroot/sites/all/modules/contrib/httprl/httprl.admin.inc
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * @file
+ * Administrative page callbacks for the httprl module.
+ */
+
+/**
+ * Form definition; general settings.
+ */
+function httprl_admin_settings_form() {
+  $form['httprl_server_addr'] = array(
+    '#type' => 'textfield',
+    '#title' => t('IP Address to send all self server requests to'),
+    '#default_value' => variable_get('httprl_server_addr', FALSE),
+    '#description' => t('If left blank it will use the same server as the request. If set to -1 it will use the host name instead of an IP address. This controls the output of httprl_build_url_self()'),
+  );
+  $form['httprl_background_callback'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable background callbacks'),
+    '#default_value' => variable_get('httprl_background_callback', HTTPRL_BACKGROUND_CALLBACK),
+    '#description' => t('If disabled all background_callback keys will be turned into callback & httprl_queue_background_callback will return NULL and not queue up the request. Note that background callbacks will automatically be disabled if the site is in maintenance mode.'),
+  );
+  // Currently only available on D7.
+  // http://drupal.org/node/1664784
+  if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+    $form['drupal_http_request_function'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Use httprl to handle drupal_http_request.'),
+      '#default_value' => variable_get('drupal_http_request_function', FALSE) === 'httprl_override_core' ? TRUE : FALSE,
+      '#description' => t('Use httprl to handle all calls to drupal_http_request. Requires 7.22+'),
+    );
+  }
+  $form['timeouts'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Default timeouts'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#description' => t('Set the default timeouts. These will be overridden if a different timeout is set in the options array.'),
+  );
+  $form['timeouts']['httprl_dns_timeout'] = array(
+    '#type' => 'textfield',
+    '#title' => t('DNS timeout (<code>dns_timeout</code>)'),
+    '#default_value' => variable_get('httprl_dns_timeout', HTTPRL_DNS_TIMEOUT),
+    '#description' => t('Maximum number of seconds a DNS lookup request may take. Value can be a float. The default is %value seconds.', array('%value' => HTTPRL_DNS_TIMEOUT)),
+    '#field_suffix' => t('seconds'),
+    '#size' => 5,
+  );
+  $form['timeouts']['httprl_connect_timeout'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Connection timeout (<code>connect_timeout</code>)'),
+    '#default_value' => variable_get('httprl_connect_timeout', HTTPRL_CONNECT_TIMEOUT),
+    '#description' => t('Maximum number of seconds establishing the TCP connection may take. Value can be a float. The default is %value seconds.', array('%value' => HTTPRL_CONNECT_TIMEOUT)),
+    '#field_suffix' => t('seconds'),
+    '#size' => 5,
+  );
+  $form['timeouts']['httprl_ttfb_timeout'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Time to first byte (<code>ttfb_timeout</code>)'),
+    '#default_value' => variable_get('httprl_ttfb_timeout', HTTPRL_TTFB_TIMEOUT),
+    '#description' => t('Maximum number of seconds a connection may take to download the first byte. Value can be a float. The default is %value seconds.', array('%value' => HTTPRL_TTFB_TIMEOUT)),
+    '#field_suffix' => t('seconds'),
+    '#size' => 5,
+  );
+  $form['timeouts']['httprl_timeout'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Timeout (<code>timeout</code>)'),
+    '#default_value' => variable_get('httprl_timeout', HTTPRL_TIMEOUT),
+    '#description' => t('Maximum number of seconds the request may take. Value can be a float. The default is %value seconds.', array('%value' => HTTPRL_TIMEOUT)),
+    '#field_suffix' => t('seconds'),
+    '#size' => 5,
+  );
+  $form['timeouts']['httprl_global_timeout'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Global timeout (<code>global_timeout</code>)'),
+    '#default_value' => variable_get('httprl_global_timeout', HTTPRL_GLOBAL_TIMEOUT),
+    '#description' => t('Maximum number of seconds httprl_send_request() may take. Value can be a float. The default is %value seconds.', array('%value' => HTTPRL_GLOBAL_TIMEOUT)),
+    '#field_suffix' => t('seconds'),
+    '#size' => 5,
+  );
+
+  return system_settings_form($form);
+}
+
+/**
+ * Validate form values.
+ */
+function httprl_admin_settings_form_validate($form, &$form_state) {
+  // Skip validation if we are resting to defaults.
+  if (isset($form_state['clicked_button']['#post']['op']) && $form_state['clicked_button']['#post']['op'] == 'Reset to defaults') {
+    return;
+  }
+
+  // Get form values.
+  $values = &$form_state['values'];
+
+  // If the IP field is not blank, check that it is a valid address.
+  if (   !empty($values['httprl_server_addr'])
+      && $values['httprl_server_addr'] != -1
+      && ip2long($values['httprl_server_addr']) === FALSE
+        ) {
+    form_set_error('httprl_server_addr', t('Must be a valid IP address.'));
+  }
+
+  // Make sure the timeouts are positive numbers.
+  $positive_values = array(
+    'httprl_dns_timeout',
+    'httprl_connect_timeout',
+    'httprl_ttfb_timeout',
+    'httprl_timeout',
+    'httprl_global_timeout',
+  );
+  foreach ($positive_values as $name) {
+    if (empty($values[$name])) {
+      form_set_error($name, t('Must not be empty or zero.'));
+      continue;
+    }
+    if (!is_numeric($values[$name])) {
+      form_set_error($name, t('Must be numeric.'));
+      continue;
+    }
+    if ($values[$name] <= 0) {
+      form_set_error($name, t('Must be a positive number.'));
+      continue;
+    }
+  }
+
+  // Change checkbox value to string.
+  if (!empty($values['drupal_http_request_function'])) {
+    $values['drupal_http_request_function'] = 'httprl_override_core';
+  }
+
+}

--- a/docroot/sites/all/modules/contrib/httprl/httprl.async.inc
+++ b/docroot/sites/all/modules/contrib/httprl/httprl.async.inc
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @file
+ * Functions used to run a function in the background.
+ */
+
+/**
+ * Menu Callback; run given function.
+ */
+function httprl_async_page() {
+  // Exit if
+  //  The master_key is not set.
+  //  The temp_key is not set.
+  //  The temp_key does not start with httprl_.
+  //  The master_key does not match the md5 of drupal_get_private_key().
+  if (   empty($_POST['master_key'])
+      || empty($_POST['temp_key'])
+      || strpos($_POST['temp_key'], 'httprl_') !== 0
+        ) {
+    httprl_fast403();
+  }
+
+  // Get the private key.
+  $private_key = httprl_drupal_get_private_key();
+
+  // Exit if the master_key does not match the md5 of $private_key.
+  if (   empty($private_key)
+      || $_POST['master_key'] != hash('sha512', $private_key)
+        ) {
+    httprl_fast403();
+  }
+
+  // Exit if the temp_key does not match a lock that has been taken.
+  // Wait up to 2.5 seconds for the lock to propagate out.
+  $tries = 0;
+  while (lock_may_be_available($_POST['temp_key'])) {
+    $tries++;
+    if ($tries > 5) {
+      httprl_fast403();
+    }
+    // Sleep for 500 miliseconds.
+    usleep(500000);
+  }
+
+  // If request was a non blocking one, cut the connection right here.
+  if (empty($_POST['mode']) && !empty($_POST['context']['session'])) {
+    httprl_background_processing('httprl async function callback running', FALSE);
+  }
+
+  // Release the lock.
+  httprl_lock_release($_POST['temp_key']);
+
+  // Set time limit.
+  if (isset($_POST['php_timeout']) && is_numeric($_POST['php_timeout'])) {
+    // Copy of drupal_set_time_limit().
+    if (function_exists('set_time_limit')) {
+      @set_time_limit($_POST['php_timeout']);
+    }
+  }
+
+  // Set context.
+  if (!empty($_POST['context']) && is_array($_POST['context'])) {
+    if (!empty($_POST['context']['uid'])) {
+      httprl_set_user($_POST['context']['uid']);
+    }
+    if (!empty($_POST['context']['q'])) {
+      httprl_set_q($_POST['context']['q']);
+    }
+  }
+
+  // Extract Data.
+  // Follow rfc4648 for base64url
+  // @see http://tools.ietf.org/html/rfc4648#page-7
+  $args = unserialize(base64_decode(strtr($_POST['args'], array('-' => '+', '_' => '/'))));
+
+  // Run the function.
+  if (!empty($_POST['function'])) {
+    $data = httprl_run_function($_POST['function'], $args);
+  }
+  // Run an array of functions.
+  else {
+    $args = current($args);
+    $data = httprl_run_array($args);
+  }
+
+  // Return data to caller.
+  if (!empty($_POST['mode']) && isset($data)) {
+    header('Content-Type: application/x-www-form-urlencoded');
+    // Follow rfc4648 for base64url
+    // @see http://tools.ietf.org/html/rfc4648#page-7
+    echo http_build_query(array(0 => strtr(base64_encode(serialize($data)), array('+' => '-', '/' => '_'))), '', '&');
+  }
+
+  // Exit Script.
+  httprl_call_exit();
+}

--- a/docroot/sites/all/modules/contrib/httprl/httprl.info
+++ b/docroot/sites/all/modules/contrib/httprl/httprl.info
@@ -1,0 +1,11 @@
+name = HTTP Parallel Request Library
+description = Send http requests out in parallel in a blocking or non-blocking manner.
+package = Performance and scalability
+core = 7.x
+
+; Information added by Drupal.org packaging script on 2014-01-01
+version = "7.x-1.14"
+core = "7.x"
+project = "httprl"
+datestamp = "1388542110"
+

--- a/docroot/sites/all/modules/contrib/httprl/httprl.install
+++ b/docroot/sites/all/modules/contrib/httprl/httprl.install
@@ -1,0 +1,294 @@
+<?php
+
+/**
+ * @file
+ * Handle HTTP Parallel Request Library installation and upgrade tasks.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function httprl_uninstall() {
+  variable_del('httprl_server_addr');
+  variable_del('httprl_background_callback');
+  variable_del('httprl_dns_timeout');
+  variable_del('httprl_connect_timeout');
+  variable_del('httprl_ttfb_timeout');
+  variable_del('httprl_timeout');
+  variable_del('httprl_global_timeout');
+  variable_del('httprl_url_inbound_alter');
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function httprl_requirements($phase) {
+  $requirements = array();
+  // Ensure translations don't break at install time.
+  $t = get_t();
+
+  if ($phase == 'runtime' || $phase == 'install') {
+    $function_list = array(
+      'stream_socket_client',
+      'stream_select',
+      'stream_set_blocking',
+      'stream_get_meta_data',
+      'stream_socket_get_name',
+    );
+    // Check each function to make sure it exists.
+    foreach ($function_list as $function_name) {
+      if (!function_exists($function_name)) {
+        $requirements['httprl_function_' . $function_name] = array(
+          'title' => $t('HTTPRL'),
+          'value' => $phase == 'install' ? FALSE : $function_name,
+          'severity' => REQUIREMENT_ERROR,
+          'description' => $t('<a href="!url">%name()</a> is disabled on this server. Please contact your hosting provider and see if they can re-enable this function for you.', array(
+            '!url' => 'http://php.net/' . str_replace('_', '-', $function_name),
+            '%name' => $function_name,
+          )),
+        );
+      }
+    }
+  }
+  if ($phase == 'runtime') {
+    // Check that the menu router item is working. If it is not working, the
+    // rest of the tests below will be pointless.
+    $item = menu_get_item('httprl_async_function_callback');
+    if (empty($item['page_callback']) || strpos($item['page_callback'], 'httprl') === FALSE) {
+      $requirements['httprl_callback'] = array(
+        'title'       => $t('HTTPRL - Menu Callback'),
+        'severity'    => REQUIREMENT_WARNING,
+        'value'       => $t('Flush your caches'),
+        'description' => $t('You need to flush your menu cache. The background callback for httprl is not there.'),
+      );
+      return $requirements;
+    }
+
+    if ((defined('VERSION') && substr(VERSION, 0, 1) >= 7 && variable_get('maintenance_mode', 0)) || variable_get('site_offline', 0)) {
+      if (empty($requirements)) {
+        $requirements['httprl'] = array(
+          'title'     => $t('HTTPRL'),
+          'severity'  => REQUIREMENT_INFO,
+          'value'     => $phase == 'install' ? TRUE : $t('All the required functions are enabled, but non blocking requests can not be tested while the site is in maintenance mode.'),
+        );
+      }
+      return $requirements;
+    }
+
+    global $_httprl;
+    // Test the non-blocking url.
+    if (!httprl_install_http_test(2, FALSE)) {
+      // Test the blocking url.
+      if (!httprl_install_http_test(2, TRUE)) {
+        // Test that drupal_http_request() works.
+        if (!httprl_install_http_test(1)) {
+          $requirements['httprl_callback'] = array(
+            'title'       => $t('HTTPRL - Core'),
+            'severity'    => REQUIREMENT_ERROR,
+            'value'       => $t('drupal_http_request()'),
+            'description' => $t('Your system or network configuration does not allow Drupal to access web pages. This could be due to your webserver configuration or PHP settings. Debug info: !debug <br />For more info go here: <a href="!link">"HTTP request status Fails" error</a>', array(
+                '!link' => 'http://drupal.org/node/588186',
+                '!debug' => httprl_pr($_httprl['install']['debug'], TRUE),
+              )
+            ),
+          );
+          return $requirements;
+        }
+        $requirements['httprl_blocking'] = array(
+          'title'       => $t('HTTPRL - Blocking'),
+          'severity'    => REQUIREMENT_ERROR,
+          'value'       => $t('Problem with stream_select()'),
+          'description' => $t('This server can not issue self http requests with stream_select(). Debug info: !debug <br />', array(
+              '!debug' => httprl_pr($_httprl['install']['debug'], TRUE),
+            )
+          ),
+        );
+        return $requirements;
+      }
+      $requirements['httprl_nonblocking'] = array(
+        'title'       => $t('HTTPRL - Non Blocking'),
+        'severity'    => REQUIREMENT_WARNING,
+        'value'       => $t('This server does not handle hanging connections.'),
+        'description' => $t('Using non blocking mode on this server may not work correctly. Debug info: !debug <br />', array(
+            '!debug' => httprl_pr($_httprl['install']['debug'], TRUE),
+          )
+        ),
+      );
+    }
+
+    // If request worked when using the hostname and not the ip then switch to
+    // hostname.
+    $ip = variable_get('httprl_server_addr', FALSE);
+    if (!empty($ip)) {
+      if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+        $x = @unserialize(db_query("SELECT value FROM {variable} WHERE name = :name", array(':name' => 'httprl_server_addr'))->fetchField());
+      }
+      else {
+        $x = @unserialize(db_result(db_query("SELECT value FROM {variable} WHERE name = 'httprl_server_addr'")));
+      }
+      if ($ip != $x && $ip == -1) {
+        variable_set('httprl_server_addr', -1);
+      }
+    }
+  }
+
+  if (empty($requirements)) {
+    $requirements['httprl'] = array(
+      'title'     => $t('HTTPRL'),
+      'severity'  => REQUIREMENT_OK,
+      'value'     => $phase == 'install' ? TRUE : $t('All the required functions are enabled and non blocking requests are working.'),
+    );
+  }
+
+  return $requirements;
+}
+
+/**
+ * Issue a HTTP request to admin/httprl-test, verifying that the server got it.
+ *
+ * @param int $mode
+ *   1: use drupal_http_request()
+ *   2: use httprl_request()
+ * @param bool $blocking
+ *   (Optional) HTTPRL blocking mode.
+ */
+function httprl_install_http_test($mode, $blocking = FALSE) {
+  global $conf, $_httprl;
+  // 512 bits = 64 bytes.
+  if (function_exists('drupal_random_bytes')) {
+    $id = 'httprl_' . hash('sha512', drupal_random_bytes(64));
+  }
+  elseif (function_exists('openssl_random_pseudo_bytes')) {
+    $id = 'httprl_' . hash('sha512', openssl_random_pseudo_bytes(64));
+  }
+  else {
+    $id = 'httprl_' . hash('sha512', mt_rand() . microtime(TRUE) . serialize($_SERVER));
+  }
+
+  // Set the headers to point to this hostname.
+  $headers = array(
+    'Host' => $_SERVER['HTTP_HOST'],
+    'Connection' => 'closed',
+  );
+
+  $args = array(
+    array(
+      'function' => 'httprl_lock_release',
+      // Setup options array.
+      'options' => array(
+        'blocking' => $blocking,
+        'timeout' => 7,
+        'max_redirects' => 0,
+        'headers' => $headers,
+      ),
+    ),
+    $id,
+  );
+
+  // Get a lock & start the timer.
+  lock_acquire($id, $args[0]['options']['timeout']);
+  timer_start($id);
+
+  if ($mode == 2) {
+    // Queue up the request.
+    if ($blocking) {
+      $args[0]['return'] = '';
+      $args[0]['printed'] = '';
+    }
+    $old_var = variable_get('httprl_background_callback', HTTPRL_BACKGROUND_CALLBACK);
+    $GLOBALS['conf']['httprl_background_callback'] = HTTPRL_BACKGROUND_CALLBACK;
+    $url = httprl_queue_background_callback($args);
+    if (empty($url)) {
+      return FALSE;
+    }
+    else {
+      $url = array_keys($url);
+      $url = array_pop($url);
+      // Execute request.
+      $output = httprl_send_request();
+    }
+    $GLOBALS['conf']['httprl_background_callback'] = $old_var;
+  }
+  else {
+    // Get options.
+    $callback_options = array_shift($args);
+
+    // Build URL to point to httprl_async_function_callback on this server.
+    $url = httprl_build_url_self('httprl_async_function_callback?count=0', TRUE);
+
+    // Create lock name for this run.
+    $available = FALSE;
+    $lock_counter = 0;
+    while (!$available && $lock_counter < 20) {
+      if (function_exists('openssl_random_pseudo_bytes')) {
+        $name = 'httprl_' . hash('sha512', openssl_random_pseudo_bytes(512));
+      }
+      else {
+        $name = 'httprl_' . hash('sha512', mt_rand() . microtime(TRUE));
+      }
+      $available = lock_may_be_available($name);
+      $lock_counter++;
+    }
+    $callback_options['options']['lock_name'] = $name;
+    lock_acquire($name, $callback_options['options']['timeout']);
+
+    // Create data array and options for request.
+    $options = array(
+      'data' => array(
+        'master_key' => hash('sha512', httprl_drupal_get_private_key()),
+        'temp_key' => $name,
+        'mode' => TRUE,
+        'php_timeout' => $callback_options['options']['timeout'],
+        'function' => $callback_options['function'],
+        // Follow rfc4648 for base64url
+        // @see http://tools.ietf.org/html/rfc4648#page-7
+        'args' => strtr(base64_encode(serialize($args)), array('+' => '-', '/' => '_')),
+      ),
+      'method' => 'POST',
+      'headers' => $headers,
+      'timeout' => $callback_options['options']['timeout'],
+      'max_redirects' => $callback_options['options']['max_redirects'],
+    );
+    httprl_handle_data($options);
+
+    // Execute the request using core.
+    if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+      $output = drupal_http_request($url, $options);
+    }
+    else {
+      $output = drupal_http_request($url, $options['headers'], $options['method'], $options['data'], $options['max_redirects'], $options['timeout']);
+    }
+  }
+
+  // Wait for the lock and stop the timer.
+  while (lock_wait($id)) {
+    usleep(25000);
+  }
+  $time = timer_stop($id);
+
+  // Add in debugging info.
+  $time['mode'] = $mode;
+  $time['blocking'] = $blocking;
+  $time['url'] = $url;
+  $time['request'] = $output;
+  $_httprl['install']['debug'][] = $time;
+
+  // See if the request came back in under 5 seconds, or if it timed out.
+  if (($time['time'] / 1000) > 5) {
+    $ip = variable_get('httprl_server_addr', FALSE);
+    if (empty($ip)) {
+      $conf['httprl_server_addr'] = -1;
+      $return = httprl_install_http_test($mode, $blocking);
+      if (!$return) {
+        $conf['httprl_server_addr'] == FALSE;
+      }
+      return $return;
+    }
+    else {
+      return FALSE;
+    }
+  }
+  else {
+    return TRUE;
+  }
+}

--- a/docroot/sites/all/modules/contrib/httprl/httprl.module
+++ b/docroot/sites/all/modules/contrib/httprl/httprl.module
@@ -1,0 +1,3319 @@
+<?php
+/**
+ * @file
+ * HTTP Parallel Request Library module.
+ */
+
+/**
+ * Default value
+ */
+define('HTTPRL_BACKGROUND_CALLBACK', TRUE);
+
+/**
+ * Default maximum number of seconds a single request call may take.
+ */
+define('HTTPRL_TIMEOUT', 30.0);
+
+/**
+ * Default maximum number of seconds the DNS portion of a request may take.
+ */
+define('HTTPRL_DNS_TIMEOUT', 5.0);
+
+/**
+ * Default maximum number of seconds establishing the TCP connection of a
+ * request may take.
+ */
+define('HTTPRL_CONNECT_TIMEOUT', 5.0);
+
+/**
+ * Default maximum number of seconds a connection may take to download the first
+ * byte.
+ */
+define('HTTPRL_TTFB_TIMEOUT', 20.0);
+
+/**
+ * Default maximum number of seconds a function call may take.
+ */
+define('HTTPRL_GLOBAL_TIMEOUT', 120.0);
+
+/**
+ * Error code indicating that the request made by httprl_request() exceeded
+ * the maximum allowed redirects without reaching the final target.
+ */
+define('HTTPRL_REQUEST_ALLOWED_REDIRECTS_EXHAUSTED', -2);
+
+/**
+ * Error code indicating that the call to fwrite() failed.
+ */
+define('HTTPRL_REQUEST_FWRITE_FAIL', -3);
+
+/**
+ * Error code indicating that all requests made by httprl_send_request
+ * exceeded the specified timeout.
+ */
+define('HTTPRL_FUNCTION_TIMEOUT', -4);
+
+/**
+ * Error code indicating that this request made by stream_select() couldn't
+ * open a read and/or write to any stream after a minimum of ~10 seconds.
+ */
+define('HTTPRL_STREAM_SELECT_TIMEOUT', -5);
+
+/**
+ * parse_url() was unable to parse the given url.
+ */
+define('HTTPRL_URL_PARSE_ERROR', -1001);
+
+/**
+ * Given URL is missing a schema (http, https, feed).
+ */
+define('HTTPRL_URL_MISSING_SCHEMA', -1002);
+
+/**
+ * Invalid schema. Only http, feed, and https allowed currently.
+ */
+define('HTTPRL_URL_INVALID_SCHEMA', -1003);
+
+/**
+ * An error occurred before the system connect() call. This is most likely due
+ * to a problem initializing the stream.
+ */
+define('HTTPRL_ERROR_INITIALIZING_STREAM', -1004);
+
+/**
+ * Error code indicating that software caused the connection to be aborted.
+ *
+ * @see http://msdn.microsoft.com/en-us/library/aa924071.aspx
+ */
+define('HTTPRL_REQUEST_ABORTED', -10053);
+
+/**
+ * Error code indicating that the connection was forcibly closed by the remote
+ * host.
+ *
+ * @see http://msdn.microsoft.com/en-us/library/aa924071.aspx
+ */
+define('HTTPRL_CONNECTION_RESET', -10054);
+
+/**
+ * Error code indicating that the request exceeded the specified timeout.
+ *
+ * @see http://msdn.microsoft.com/en-us/library/aa924071.aspx
+ */
+define('HTTPRL_REQUEST_TIMEOUT', -10060);
+
+/**
+ * Error code indicating that the endpoint server has refused or dropped the
+ * connection.
+ *
+ * @see http://msdn.microsoft.com/en-us/library/aa924071.aspx
+ */
+define('HTTPRL_CONNECTION_REFUSED', -10061);
+
+/**
+ * Error code indicating that the host is unknown or can not be found.
+ *
+ * @see http://msdn.microsoft.com/en-us/library/aa924071.aspx
+ */
+define('HTTPRL_HOST_NOT_FOUND', -11001);
+
+/**
+ * HTTP encapsulation boundary string.
+ */
+define('HTTPRL_MULTIPART_BOUNDARY', '---------------------------' . str_replace('.', '', microtime(TRUE)));
+
+/**
+ * Max length of a string inside of httprl_pr(). Default is 256KB.
+ */
+define('HTTPRL_PR_MAX_STRING_LENGTH', 262144);
+
+/**
+ * Run httprl_url_inbound_alter().
+ */
+define('HTTPRL_URL_INBOUND_ALTER', TRUE);
+
+/**
+ * Implements hook_url_inbound_alter().
+ */
+function httprl_url_inbound_alter(&$path, $original_path, $path_language) {
+  // Do nothing if this has been disabled.
+  if (!variable_get('httprl_url_inbound_alter', HTTPRL_URL_INBOUND_ALTER)) {
+    return;
+  }
+
+  // If requested path was for an async callback but now it is something else
+  // switch is back to the requested path.
+  $request_path = request_path();
+  if ($path != $request_path && strpos($request_path, 'httprl_async_function_callback') !== FALSE) {
+    $path = $request_path;
+  }
+}
+
+/**
+ * Implements hook_menu().
+ */
+function httprl_menu() {
+  $items = array();
+
+  // Admin page.
+  if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+    $config_url = 'admin/config/development/httprl';
+  }
+  else {
+    $config_url = 'admin/settings/httprl';
+  }
+  $items[$config_url] = array(
+    'title' => 'HTTPRL',
+    'description' => 'Configure HTTPRL settings.',
+    'access arguments' => array('administer site configuration'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('httprl_admin_settings_form'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'httprl.admin.inc',
+  );
+
+  // Async Function Callback.
+  $items['httprl_async_function_callback'] = array(
+    'title' => 'HTTPRL',
+    'page callback' => 'httprl_async_page',
+    'access callback' => TRUE,
+    'description' => 'URL for async function workers.',
+    'type' => MENU_CALLBACK,
+    'file' => 'httprl.async.inc',
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_cron().
+ *
+ * This hook should be ran about once an hour to once every 5 minutes.
+ */
+function httprl_cron() {
+  // Let expiration times vary by 5 minutes.
+  $fuzz_factor = 300;
+
+  // Remove expired locks from the semaphore database table.
+  if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+    db_delete('semaphore')
+      ->condition('value', 'httprl')
+      ->condition('expire', REQUEST_TIME - $fuzz_factor, '<')
+      ->execute();
+  }
+  else {
+    db_query("DELETE FROM {semaphore} WHERE value = 'httprl' AND expire < %f", time() - $fuzz_factor);
+  }
+}
+
+/**
+ * Queue and send off http request.
+ *
+ * @see drupal_http_request()
+ *
+ * This is a flexible and powerful HTTP client implementation. Correctly
+ * handles GET, POST, PUT or any other HTTP requests.
+ *
+ * @param string $url
+ *   A string containing a fully qualified URI.
+ * @param array $options
+ *   (optional) An array of options.
+ *
+ * @return object
+ *   The request object.
+ */
+function httprl_override_core($url, $options = array()) {
+  // Queue up the request.
+  httprl_request($url, $options);
+  // Execute request.
+  $request = httprl_send_request();
+  // Send back results.
+  return is_array($request) && is_string($url) && array_key_exists($url, $request) ? $request[$url] : array_pop($request);
+}
+
+/**
+ * Helper function to build an URL for asynchronous requests to self.
+ *
+ * @param string $level
+ *   How deep to go when setting the base path.
+ */
+function _httprl_build_drupal_root($level = 0) {
+  static $webroot;
+  $root_path = '/';
+  if ($level > 0) {
+    // Work backwards from this file till we find drupal's index.php.
+    if (!isset($webroot)) {
+      $webroot = str_replace('\\', '/', dirname(__FILE__));
+      while (!empty($webroot)) {
+        if (file_exists($webroot . '/index.php') && strpos(file_get_contents($webroot . '/index.php'), 'menu_execute_active_handler();') !== FALSE) {
+          break;
+        }
+        $new_webroot = str_replace('\\', '/', dirname($webroot));
+        if ($new_webroot == $webroot) {
+          $webroot = str_replace('\\', '/', getcwd());
+          break;
+        }
+        $webroot = $new_webroot;
+      }
+    }
+
+    $root_path = '';
+    $webroot_array = explode('/', $webroot);
+    while ($level > 0 && count($webroot_array) != 0) {
+      $level--;
+      $root_path = array_pop($webroot_array) . '/' . $root_path;
+    }
+    $root_path = '/' . $root_path;
+  }
+  else {
+    if (!empty($GLOBALS['base_path'])) {
+      $root_path = $GLOBALS['base_path'];
+    }
+  }
+
+
+  // Server auth.
+  $auth = '';
+  if (isset($_SERVER['AUTH_TYPE']) && $_SERVER['AUTH_TYPE'] == 'Basic') {
+    $auth = $_SERVER['PHP_AUTH_USER'] . ':' . $_SERVER['PHP_AUTH_PW'] . '@';
+  }
+
+  // Get Host.
+  $ip = httprl_variable_get('httprl_server_addr', FALSE);
+  if ($ip == -1) {
+    $ip = $_SERVER['HTTP_HOST'];
+    // If the host is bad don't use it.
+    if (isset($_SERVER['argc']) || isset($_SERVER['argv'])) {
+      if (gethostbyname($_SERVER['HTTP_HOST']) == $_SERVER['HTTP_HOST']) {
+        $ip = '';
+      }
+    }
+  }
+  if (empty($ip)) {
+    $ip = empty($_SERVER['SERVER_ADDR']) ? '127.0.0.1' : $_SERVER['SERVER_ADDR'];
+    // Check for IPv6. If IPv6 convert to IPv4 if possible.
+    if (strpos($ip, ':') !== FALSE) {
+      if ($_SERVER['SERVER_ADDR'] == '::1') {
+        $ip = "127.0.0.1";
+      }
+      elseif (preg_match('/^::\d+.\d+.\d+.\d+$/', $ip)) {
+        $ip = substr($ip, 2);
+      }
+      elseif (!empty($_SERVER['HTTP_HOST'])) {
+        // Last option is to use the IP from the host name.
+        $ip = gethostbyname($_SERVER['HTTP_HOST']);
+        if (gethostbyname($_SERVER['HTTP_HOST']) == $_SERVER['HTTP_HOST']) {
+          $ip = '';
+        }
+      }
+    }
+  }
+  if (empty($ip)) {
+    $ip = '127.0.0.1';
+  }
+
+  // Port.
+  $port = '';
+  //   if (   isset($_SERVER['SERVER_PORT'])
+  //       && is_numeric($_SERVER['SERVER_PORT'])
+  //       && ($_SERVER['SERVER_PORT'] != 80 || $_SERVER['SERVER_PORT'] != 443)
+  //         ) {
+  //     $port = ':' . $_SERVER['SERVER_PORT'];
+  //   }
+
+  // URL schema http or https.
+  $schema = httprl_get_server_schema() . '://';
+
+  // Special handling if clean urls are disabled.
+  if (!variable_get('clean_url', 0)) {
+    $path_parts = @parse_url('http://example.com/' . $path);
+    if (!empty($path_parts)) {
+      $path_parts_query = array();
+      if (isset($path_parts['query'])) {
+        parse_str($path_parts['query'], $path_parts_query);
+      }
+      $path_parts_query['q'] = ltrim($path_parts['path'], '/');
+      $path = '?' . http_build_query($path_parts_query, '', '&');
+    }
+  }
+
+  return $schema . $auth . $ip . $port . $root_path;
+}
+
+/**
+ * Helper function to build an URL for asynchronous requests to self.
+ *
+ * @param string $path
+ *   Path to a URI excluding everything to the left and including the base path.
+ * @param bool $detect_schema
+ *   If TRUE it will see if this request is https; if so, it will set the full
+ *   url to be https as well.
+ */
+function httprl_build_url_self($path = '', $detect_schema = FALSE) {
+  static $drupal_root;
+  if (!isset($drupal_root)) {
+    $drupal_root = _httprl_build_drupal_root();
+
+    // If ran from the command line, the drupal root might be in a subdir. Test to
+    // make sure we have the right directory.
+    if (isset($_SERVER['argc']) || isset($_SERVER['argv'])) {
+      $level = 0;
+      $found = FALSE;
+      while (!$found) {
+        // Trick due to not knowing the subdir.
+        // http://stackoverflow.com/questions/8361355/get-apache-document-root-from-command-line-execution-no-browser/8415235#8415235
+        $headers = get_headers($drupal_root . 'httprl_async_function_callback');
+        if (!empty($headers)) {
+          foreach ($headers as $header) {
+            if (stripos($header, 'X-HTTPRL') !== FALSE) {
+              $found = TRUE;
+            }
+          }
+        }
+        if (!$found) {
+          $level++;
+          $new_drupal_root = _httprl_build_drupal_root($level);
+          if ($new_drupal_root == $drupal_root) {
+            // Use no subdirectories if nothing worked.
+            $drupal_root = _httprl_build_drupal_root();
+            break;
+          }
+          $drupal_root = $new_drupal_root;
+        }
+      }
+    }
+  }
+
+  return $drupal_root . $path;
+}
+
+/**
+ * Run parse_url and handle any errors.
+ *
+ * @param string $url
+ *   String containing the URL to be parsed by parse_url().
+ * @param object &$result
+ *   Result object; used only for error handling in this function.
+ *
+ * @return array
+ *   Array from parse_url().
+ */
+function httprl_parse_url($url, &$result) {
+  // Parse the URL and make sure we can handle the schema.
+  $uri = @parse_url($url);
+
+  // If the t function is not available use httprl_pr.
+  $t = function_exists('t') ? 't' : 'httprl_pr';
+
+  if (empty($uri)) {
+    // Set error code for failed request.
+    $result->error = $t('Unable to parse URL.');
+    $result->code = HTTPRL_URL_PARSE_ERROR;
+  }
+  elseif (!isset($uri['scheme'])) {
+    // Set error code for failed request.
+    $result->error = $t('Missing schema.');
+    $result->code = HTTPRL_URL_MISSING_SCHEMA;
+  }
+
+  return $uri;
+}
+
+/**
+ * Set the default options in the $options array.
+ *
+ * @param array &$options
+ *   Array containing options.
+ */
+function httprl_set_default_options(&$options) {
+  global $base_root;
+
+  // Merge the default options.
+  $options += array(
+    'headers' => array(),
+    'method' => 'GET',
+    'data' => NULL,
+    'max_redirects' => 3,
+    'timeout' => httprl_variable_get('httprl_timeout', HTTPRL_TIMEOUT),
+    'dns_timeout' => httprl_variable_get('httprl_dns_timeout', HTTPRL_DNS_TIMEOUT),
+    'connect_timeout' => httprl_variable_get('httprl_connect_timeout', HTTPRL_CONNECT_TIMEOUT),
+    'ttfb_timeout' => httprl_variable_get('httprl_ttfb_timeout', HTTPRL_TTFB_TIMEOUT),
+    'context' => NULL,
+    'secure_socket_transport' => 'ssl',
+    'blocking' => TRUE,
+    'version' => '1.0',
+    'referrer' => FALSE,
+    'domain_connections' => 2,
+    'global_connections' => 128,
+    'global_timeout' => httprl_variable_get('httprl_global_timeout', HTTPRL_GLOBAL_TIMEOUT),
+    'chunk_size_read' => 32768,
+    'chunk_size_write' => 1024,
+    'async_connect' => TRUE,
+    'ping_db' => 20,
+  );
+
+  // Adjust Time To First Byte Timeout if timeout is large and ttfb is default.
+  if ($options['timeout'] > httprl_variable_get('httprl_timeout', HTTPRL_TIMEOUT) && $options['ttfb_timeout'] == httprl_variable_get('httprl_ttfb_timeout', HTTPRL_TTFB_TIMEOUT)) {
+    $options['ttfb_timeout'] = $options['timeout'] - max(1, httprl_variable_get('httprl_timeout', HTTPRL_TIMEOUT) - httprl_variable_get('httprl_ttfb_timeout', HTTPRL_TTFB_TIMEOUT));
+  }
+  // Adjust Global Timeout if timeout is large and global_timeout is default.
+  if ($options['timeout'] > httprl_variable_get('httprl_timeout', HTTPRL_TIMEOUT) && $options['global_timeout'] == httprl_variable_get('httprl_global_timeout', HTTPRL_GLOBAL_TIMEOUT)) {
+    $options['global_timeout'] = $options['timeout'] + max(1, httprl_variable_get('httprl_global_timeout', HTTPRL_GLOBAL_TIMEOUT) - httprl_variable_get('httprl_timeout', HTTPRL_TIMEOUT));
+  }
+
+  // Merge the default headers.
+  // Set user agent to drupal.
+  // Set connection to closed to prevent keep-alive from causing a timeout.
+  $options['headers'] += array(
+    'User-Agent' => 'Drupal (+http://drupal.org/)',
+    'Connection' => 'close',
+  );
+
+  // Set referrer to current page.
+  if (!isset($options['headers']['Referer']) && !empty($options['referrer'])) {
+    if (function_exists('request_uri')) {
+      $options['headers']['Referer'] = $base_root . request_uri();
+    }
+  }
+
+  // stream_socket_client() requires timeout to be a float.
+  $options['timeout'] = (float) $options['timeout'];
+}
+
+/**
+ * If server uses a proxy, change the request to utilize said proxy.
+ *
+ * @param array &$uri
+ *   Array from parse_url().
+ * @param array &$options
+ *   Array containing options.
+ * @param string $url
+ *   String containing the URL.
+ *
+ * @return string
+ *   String containing the proxy servers host name if one is to be used.
+ */
+function httprl_setup_proxy(&$uri, &$options, $url) {
+  // Proxy setup.
+  $proxy_server = httprl_variable_get('proxy_server', '');
+  // Use a proxy if one is defined and the host is not on the excluded list.
+  if ($proxy_server && _httprl_use_proxy($uri['host'])) {
+    // Set the scheme so we open a socket to the proxy server.
+    $uri['scheme'] = 'proxy';
+    // Set the path to be the full URL.
+    $uri['path'] = $url;
+    // Since the full URL is passed as the path, we won't use the parsed query.
+    unset($uri['query']);
+
+    // Add in username and password to Proxy-Authorization header if needed.
+    if ($proxy_username = httprl_variable_get('proxy_username', '')) {
+      $proxy_password = httprl_variable_get('proxy_password', '');
+      $options['headers']['Proxy-Authorization'] = 'Basic ' . base64_encode($proxy_username . ':' . $proxy_password);
+    }
+    // Some proxies reject requests with any User-Agent headers, while others
+    // require a specific one.
+    $proxy_user_agent = httprl_variable_get('proxy_user_agent', '');
+    // The default value matches neither condition.
+    if (is_null($proxy_user_agent)) {
+      unset($options['headers']['User-Agent']);
+    }
+    elseif ($proxy_user_agent) {
+      $options['headers']['User-Agent'] = $proxy_user_agent;
+    }
+  }
+  return $proxy_server;
+}
+
+/**
+ * Create the TCP/SSL socket connection string.
+ *
+ * @param array $uri
+ *   Array from parse_url().
+ * @param array &$options
+ *   Array containing options.
+ * @param string $proxy_server
+ *   String containing the proxy servers host name if one is to be used.
+ * @param object &$result
+ *   Result object; used only for error handling in this function.
+ *
+ * @return string
+ *   String containing the TCP/SSL socket connection URI.
+ */
+function httprl_set_socket($uri, &$options, $proxy_server, &$result) {
+  $socket = '';
+  switch ($uri['scheme']) {
+    case 'proxy':
+      // Make the socket connection to a proxy server.
+      $socket = 'tcp://' . $proxy_server . ':' . httprl_variable_get('proxy_port', 8080);
+      // The Host header still needs to match the real request.
+      $options['headers']['Host'] = $uri['host'];
+      $options['headers']['Host'] .= isset($uri['port']) && $uri['port'] != 80 ? ':' . $uri['port'] : '';
+      break;
+
+    case 'http':
+    case 'feed':
+      $port = isset($uri['port']) ? $uri['port'] : 80;
+      $socket = 'tcp://' . $uri['host'] . ':' . $port;
+      // RFC 2616: "non-standard ports MUST, default ports MAY be included".
+      // We don't add the standard port to prevent from breaking rewrite rules
+      // checking the host that do not take into account the port number.
+      if (empty($options['headers']['Host'])) {
+        $options['headers']['Host'] = $uri['host'];
+      }
+      if ($port != 80) {
+        $options['headers']['Host'] .= ':' . $port;
+      }
+      break;
+
+    case 'https':
+      // Note: Only works when PHP is compiled with OpenSSL support.
+      $port = isset($uri['port']) ? $uri['port'] : 443;
+      $socket = $options['secure_socket_transport'] . '://' . $uri['host'] . ':' . $port;
+      if (empty($options['headers']['Host'])) {
+        $options['headers']['Host'] = $uri['host'];
+      }
+      if ($port != 443) {
+        $options['headers']['Host'] .= ':' . $port;
+      }
+      break;
+
+    default:
+      // If the t function is not available use httprl_pr.
+      $t = function_exists('t') ? 't' : 'httprl_pr';
+
+      $result->error = $t('Invalid schema @scheme.', array('@scheme' => $uri['scheme']));
+      $result->code = HTTPRL_URL_INVALID_SCHEMA;
+
+  }
+
+  return $socket;
+}
+
+/**
+ * Select which connect flags to use in stream_socket_client().
+ *
+ * @param array &$options
+ *   Array containing options.
+ * @param array $uri
+ *   Array from parse_url().
+ *
+ * @return int
+ *   STREAM_CLIENT_CONNECT or STREAM_CLIENT_ASYNC_CONNECT|STREAM_CLIENT_CONNECT.
+ */
+function httprl_set_connection_flag(&$options, $uri) {
+  $flags = STREAM_CLIENT_CONNECT;
+
+  // Set connection flag.
+  if ($options['async_connect']) {
+    // Workaround for PHP bug with STREAM_CLIENT_ASYNC_CONNECT and SSL
+    // https://bugs.php.net/bug.php?id=48182 - Fixed in PHP 5.2.11 and 5.3.1
+    if ($uri['scheme'] == 'https' && (version_compare(PHP_VERSION, '5.2.11', '<') || version_compare(PHP_VERSION, '5.3.0', '='))) {
+      $options['async_connect'] = FALSE;
+    }
+    else {
+      $flags = STREAM_CLIENT_ASYNC_CONNECT | STREAM_CLIENT_CONNECT;
+    }
+  }
+  return $flags;
+}
+
+/**
+ * If data is being sent out in this request, handle it correctly.
+ *
+ * If $options['data'] is not a string, convert it to a string using
+ * http_build_query(). Set the Content-Length header correctly. Set the
+ * Content-Type to application/x-www-form-urlencoded if not already set and
+ * using method is POST.
+ *
+ * @todo
+ *   Proper mime support.
+ *
+ * @param array &$options
+ *   Array containing options.
+ */
+function httprl_handle_data(&$options) {
+  // Encode data if not already done.
+  if (isset($options['data']) && !is_string($options['data'])) {
+    // Record raw data before it gets processed.
+    $options['data-input'] = $options['data'];
+
+    if (!empty($options['headers']['Content-Type']) && strpos($options['headers']['Content-Type'], 'multipart/related') === 0 && !empty($options['data'])) {
+      // Trim semicolon from Content-Type header if needed.
+      $options['headers']['Content-Type'] = trim($options['headers']['Content-Type']);
+      if (substr_compare($options['headers']['Content-Type'], ';', -1, 1) === 0) {
+        $options['headers']['Content-Type'] = substr($options['headers']['Content-Type'], -1);
+      }
+      // Add in boundary.
+      $options['headers']['Content-Type'] .= '; boundary=' . HTTPRL_MULTIPART_BOUNDARY;
+
+      $data_stream = '';
+      foreach ($options['data'] as $part) {
+        $data_stream .= '--' . HTTPRL_MULTIPART_BOUNDARY . "\r\n";
+        foreach ($part['headers'] as $key => $value) {
+          $data_stream .= $key . ': ' . $value . "\r\n";
+        }
+        $data_stream .= "\r\n";
+        if (isset($part['file'])) {
+          $data_stream .= file_get_contents($part['file']) . "\r\n";
+        }
+        elseif (isset($part['string'])) {
+          $data_stream .= $part['string'] . "\r\n";
+        }
+      }
+
+      // Signal end of request (note the trailing "--").
+      $data_stream .= '--' . HTTPRL_MULTIPART_BOUNDARY . "--\r\n";
+      $options['data'] = $data_stream;
+    }
+    // No files passed in, url-encode the data.
+    elseif (empty($options['data']['files']) || !is_array($options['data']['files'])) {
+      $options['data'] = http_build_query($options['data'], '', '&');
+
+      // Set the Content-Type to application/x-www-form-urlencoded if the data
+      // is not empty, the Content-Type is not set, and the method is POST or
+      // PUT.
+      if (!empty($options['data']) && !isset($options['headers']['Content-Type']) && ($options['method'] == 'POST' || $options['method'] == 'PUT')) {
+        $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
+      }
+    }
+    else {
+      $data_stream = '';
+      // Add files to the request.
+      foreach ($options['data']['files'] as $field_name => $info) {
+        $multi_field = '[]';
+        // Convert $info into an array if it's a string.
+        // This makes for one code path (the foreach loop).
+        if (is_string($info)) {
+          $multi_field = '';
+          $temp = $info;
+          unset($info);
+          $info[] = $temp;
+        }
+        foreach ($info as $fullpath) {
+          // Strip '@' from the start of the path (cURL requirement).
+          if (substr($fullpath, 0, 1) == "@") {
+            $fullpath = substr($fullpath, 1);
+          }
+          $filename = basename($fullpath);
+          // TODO: mime detection.
+          $mimetype = 'application/octet-stream';
+
+          // Build the data-stream for this file.
+          $data_stream .= '--' . HTTPRL_MULTIPART_BOUNDARY . "\r\n";
+          $data_stream .= 'Content-Disposition: form-data; name="files[' . $field_name . ']' . $multi_field . '"; filename="' . $filename . "\"\r\n";
+          $data_stream .= 'Content-Transfer-Encoding: binary' . "\r\n";
+          $data_stream .= 'Content-Type: ' . $mimetype . "\r\n\r\n";
+          $data_stream .= file_get_contents($fullpath) . "\r\n";
+        }
+      }
+      // Remove files from the data array as they have already been added.
+      $data_array = $options['data'];
+      unset($data_array['files']);
+      // Add fields to the request too: $_POST['foo'] = 'bar'.
+      httprl_multipart_encoder($data_stream, $data_array);
+
+      // Signal end of request (note the trailing "--").
+      $data_stream .= '--' . HTTPRL_MULTIPART_BOUNDARY . "--\r\n";
+      $options['data'] = $data_stream;
+
+      // Set the Content-Type to multipart/form-data if the data is not empty,
+      // the Content-Type is not set, and the method is POST or PUT.
+      if (!empty($options['data']) && !isset($options['headers']['Content-Type']) && ($options['method'] == 'POST' || $options['method'] == 'PUT')) {
+        $options['headers']['Content-Type'] = 'multipart/form-data; boundary=' . HTTPRL_MULTIPART_BOUNDARY;
+      }
+    }
+  }
+
+  // Only add Content-Length if we actually have any content or if it is a POST
+  // or PUT request. Some non-standard servers get confused by Content-Length in
+  // at least HEAD/GET requests, and Squid always requires Content-Length in
+  // POST/PUT requests.
+  if (strlen($options['data']) > 0 || $options['method'] == 'POST' || $options['method'] == 'PUT') {
+    $options['headers']['Content-Length'] = httprl_strlen($options['data']);
+  }
+}
+
+/**
+ * Multipart encode a data array.
+ *
+ * PHP has http_build_query() which will url-encode data. There is no built in
+ * function to multipart encode data thus we have this function below.
+ *
+ * @param string &$data_stream
+ *   Appended with all multi-part headers.
+ * @param array $data_array
+ *   Array of data in key => value pairs.
+ * @param array $prepend
+ *   (optional) key => values pairs to prepend to $data_array.
+ */
+function httprl_multipart_encoder(&$data_stream, $data_array, $prepend = array()) {
+  foreach ($data_array as $key => $value) {
+    $key_array = $prepend;
+    $key_array[] = $key;
+    if (is_array($value)) {
+      httprl_multipart_encoder($data_stream, $value, $key_array);
+    }
+    elseif (is_scalar($value)) {
+      $key_string = array_shift($key_array);
+      if (!empty($key_array)) {
+        $key_string .= '[' . implode('][', $key_array) . ']';
+      }
+      $data_stream .= '--' . HTTPRL_MULTIPART_BOUNDARY . "\r\n";
+      $data_stream .= 'Content-Disposition: form-data; name="' . $key_string . "\"\r\n\r\n";
+      $data_stream .= $value . "\r\n";
+    }
+  }
+}
+
+/**
+ * Set the Authorization header if a user is set in the URI.
+ *
+ * @param array $uri
+ *   Array from parse_url().
+ * @param array &$options
+ *   Array containing options.
+ */
+function httprl_basic_auth($uri, &$options) {
+  // If the server URL has a user then attempt to use basic authentication.
+  if (isset($uri['user'])) {
+    $options['headers']['Authorization'] = 'Basic ' . base64_encode($uri['user'] . ':' . (isset($uri['pass']) ? $uri['pass'] : ''));
+  }
+}
+
+/**
+ * Build the request string.
+ *
+ * This string is what gets sent to the server once a connection has been made.
+ *
+ * @param array $uri
+ *   Array from parse_url().
+ * @param array $options
+ *   Array containing options.
+ *
+ * @return string
+ *   String containing the data that will be written to the server.
+ */
+function httprl_build_request_string($uri, $options) {
+  // Construct the path to act on.
+  $path = isset($uri['path']) ? $uri['path'] : '/';
+  if (isset($uri['query'])) {
+    $path .= '?' . $uri['query'];
+  }
+
+  // Assemble the request together. HTTP version requires to be a float.
+  $request = $options['method'] . ' ' . $path . ' HTTP/' . sprintf("%.1F", $options['version']) . "\r\n";
+  foreach ($options['headers'] as $name => $value) {
+    $request .= $name . ': ' . trim($value) . "\r\n";
+  }
+
+  return $request . "\r\n" . $options['data'];
+}
+
+
+/**
+ * Read the error number & string and give a nice looking error in the output.
+ *
+ * This is a flexible and powerful HTTP client implementation. Correctly
+ * handles GET, POST, PUT or any other HTTP requests.
+ *
+ * @param int $errno
+ *   Error number from stream_socket_client().
+ * @param string $errstr
+ *   Error string from stream_socket_client().
+ * @param object $result
+ *   An object for httprl_send_request.
+ */
+function httprl_stream_connection_error_formatter($errno, $errstr, &$result) {
+  // If the t function is not available use httprl_pr.
+  $t = function_exists('t') ? 't' : 'httprl_pr';
+  if (function_exists('t')) {
+    // Make sure drupal_convert_to_utf8() is available.
+    if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+      require_once DRUPAL_ROOT . '/includes/unicode.inc';
+    }
+    else {
+      require_once './includes/unicode.inc';
+    }
+
+    // Convert error message to utf-8. Using ISO-8859-1 (Latin-1) as source
+    // encoding could be wrong; it is a simple workaround :)
+    $errstr = trim(drupal_convert_to_utf8($errstr, 'ISO-8859-1'));
+  }
+
+  if (!$errno) {
+    // If $errno is 0, it is an indication that the error occurred
+    // before the connect() call.
+    if (empty($errstr)) {
+      // If the error string is empty as well, this is most likely due to a
+      // problem initializing the stream.
+      $result->code = HTTPRL_ERROR_INITIALIZING_STREAM;
+      $result->error = $t('Error initializing socket @socket.', array('@socket' => $result->socket));
+    }
+    elseif (stripos($errstr, 'network_getaddresses: getaddrinfo failed:') !== FALSE) {
+      // Host not found. No such host is known. The name is not an official host
+      // name or alias.
+      $result->code = HTTPRL_HOST_NOT_FOUND;
+      $result->error = $errstr;
+    }
+  }
+  elseif ($errno == 110) {
+    // 110 means Connection timed out. This should be HTTPRL_REQUEST_TIMEOUT.
+    $result->code = HTTPRL_REQUEST_TIMEOUT;
+    $result->error = !empty($errstr) ? $errstr : $t('Connection timed out. TCP.');
+  }
+  else {
+    // When a network error occurs, we use a negative number so it does not
+    // clash with the HTTP status codes.
+    $result->code = (int) - $errno;
+    $result->error = !empty($errstr) ? $errstr : $t('Error opening socket @socket.', array('@socket' => $result->socket));
+  }
+}
+
+/**
+ * Use stream_socket_client() to create a connection to the server.
+ *
+ * @param object $result
+ *   A object to hold the result values.
+ */
+function httprl_establish_stream_connection(&$result) {
+  // Record start time.
+  $start_time = microtime(TRUE);
+  $result->fp = FALSE;
+
+  // Try to make a connection, 3 max tries in loop.
+  $count = 0;
+  while (!$result->fp && $count < 3) {
+    // Try the connection again not using async if in https mode.
+    if ($count > 0) {
+      if ($result->flags === STREAM_CLIENT_ASYNC_CONNECT | STREAM_CLIENT_CONNECT && $result->uri['scheme'] == 'https') {
+        $result->flags = STREAM_CLIENT_CONNECT;
+        $result->options['async_connect'] = FALSE;
+      }
+      else {
+        // Break out of while loop if we can't connect.
+        break;
+      }
+    }
+
+    // Set the DNS timeout.
+    $timeout = $result->options['dns_timeout'];
+    // If not using async_connect then add connect_timeout to timeout.
+    if (!$result->options['async_connect']) {
+      $timeout += $result->options['connect_timeout'];
+    }
+
+    // Open the connection.
+    if (empty($result->options['context'])) {
+      $result->fp = @stream_socket_client($result->socket, $errno, $errstr, $timeout, $result->flags);
+    }
+    else {
+      // Create a stream with context. Context allows for the verification of
+      // a SSL certificate.
+      $result->fp = @stream_socket_client($result->socket, $errno, $errstr, $timeout, $result->flags, $result->options['context']);
+    }
+    $count++;
+  }
+
+  // Make sure the stream opened properly. This check doesn't work if
+  // async_connect is used, so only check it if async_connect is FALSE. Making
+  // sure that stream_socket_get_name returns a "TRUE" value.
+  if (   $result->fp
+      && !$result->options['async_connect']
+      && !stream_socket_get_name($result->fp, TRUE)
+        ) {
+    $errno = HTTPRL_CONNECTION_REFUSED;
+    $errstr = 'Connection refused. No connection could be made because the target machine actively refused it.';
+    $result->fp = FALSE;
+  }
+
+  // Report any errors or set the stream to non blocking mode.
+  if (!$result->fp) {
+    httprl_stream_connection_error_formatter($errno, $errstr, $result);
+  }
+  else {
+    stream_set_blocking($result->fp, 0);
+  }
+
+  // Record end time.
+  $end_time = microtime(TRUE);
+  $extra = 0;
+  if (isset($result->options['internal_states']['running_time'])) {
+    $extra = $result->options['internal_states']['running_time'];
+    unset($result->options['internal_states']['running_time']);
+  }
+  $result->running_time = $end_time - $start_time + $extra;
+}
+
+/**
+ * Queue up a HTTP request in httprl_send_request.
+ *
+ * @see drupal_http_request()
+ *
+ * This is a flexible and powerful HTTP client implementation. Correctly
+ * handles GET, POST, PUT or any other HTTP requests.
+ *
+ * @param string|array $urls
+ *   A string or an array containing a fully qualified URI(s).
+ * @param array $options
+ *   (optional) An array that can have one or more of the following elements:
+ *   - headers: An array containing request headers to send as name/value pairs.
+ *     Some of the more useful headers:
+ *     - For POST: 'Content-Type' => 'application/x-www-form-urlencoded',
+ *     - Limit number of bytes server sends back: 'Range' => 'bytes=0-1024',
+ *     - Compression: 'Accept-Encoding' => 'gzip, deflate',
+ *     - Let server know where request came from: 'Referer' => 'example.com',
+ *     - Content-Types that are acceptable: 'Accept' => 'text/plain',
+ *     - Send Cookies: 'Cookie' => 'key1=value1; key2=value2;',
+ *     - Skip the cache: 'Cache-Control' => 'no-cache',
+ *     - Skip the cache: 'Pragma' => 'no-cache',
+ *     List of headers: http://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+ *   - method: A string containing the request method. Defaults to 'GET'.
+ *   - data: A string containing the request body, formatted as
+ *     'param=value&param=value&...'. Defaults to NULL.
+ *   - max_redirects: An integer representing how many times a redirect
+ *     may be followed. Defaults to 3.
+ *   - timeout: A float representing the maximum number of seconds a connection
+ *     may take. The default is 30 seconds. If a timeout occurs, the error code
+ *     is set to the HTTPRL_REQUEST_ABORTED constant.
+ *   - dns_timeout: A float representing the maximum number of seconds a DNS
+ *     lookup request may take. The default is 5 seconds. If a timeout occurs,
+ *     the error code is set to the HTTPRL_HOST_NOT_FOUND constant.
+ *   - connect_timeout: A float representing the maximum number of seconds
+ *     establishing the TCP connection may take. The default is 5 seconds. If a
+ *     timeout occurs, the error code is set to the HTTPRL_REQUEST_TIMEOUT
+ *     constant.
+ *   - ttfb_timeout: A float representing the maximum number of seconds a
+ *     connection may take to download the first byte. The default is 20
+ *     seconds. If a timeout occurs, the error code is set to the
+ *     HTTPRL_REQUEST_ABORTED constant.
+ *   - context: A context resource created with stream_context_create().
+ *   - secure_socket_transport: The transport to use when making secure
+ *     requests over HTTPS; see http://php.net/manual/en/transports.inet.php
+ *     for more information. The value should be 'ssl', 'sslv2', 'sslv3' or
+ *     'tls'. Defaults to 'ssl', which will work for HTTPS requests to most
+ *     remote servers.
+ *   - blocking: set to FALSE to make this not care about the returned data.
+ *   - version: HTTP Version 1.0 or 1.1. Default is 1.0 for a good reason.
+ *   - referrer: TRUE - send current page; FALSE - do not send current
+ *     page. Default is FALSE.
+ *   - domain_connections: Maximum number of simultaneous connections to a given
+ *     domain name. Default is 8.
+ *   - global_connections: Maximum number of simultaneous connections that can
+ *     be open on the server. Default is 128.
+ *   - global_timeout: A float representing the maximum number of seconds the
+ *     function call may take. If a timeout occurs,the error code is set to the
+ *     HTTPRL_FUNCTION_TIMEOUT constant. Default is 120 seconds.
+ *   - chunk_size_write: max size of what will be written in fwrite().
+ *   - chunk_size_read: max size of what will be read from fread().
+ *   - async_connect: default is TRUE. FALSE may give more info on errors but is
+ *     generally slower.
+ *   - callback: Array where the first value is an array of options; the result
+ *     is passed to the callback function as the first argument, the other
+ *     options passed in this array are passed in after the result. The options
+ *     array needs to contain the function name and the target variable for the
+ *     result of the function.
+ *   - background_callback: Array where the first value is an array of options;
+ *     the result is passed to the callback function as the first argument, the
+ *     other options passed in this array are passed in after the result. The
+ *     options array needs to contain the function name. If the return or
+ *     printed keys are not defined this function will run in non blocking mode
+ *     and the parent will not be able to get the result; if the return or
+ *     printed keys defined then this function will run in blocking mode and the
+ *     returned and printed data as well as any variables passed by reference
+ *     will be available to the parent.
+ *   - alter_all_streams_function: Function name. This function runs at the end
+ *     of httprl_post_processing() so that one can alter the $responses and
+ *     $output variables inside of httprl_send_request. Defined function
+ *     should have the following parameters:
+ *       ($id, &$responses).
+ *   - stall_fread: TRUE or FALSE. If true once all fwrites have been done
+ *     httprl_send_request() will return. You will need to call
+ *     httprl_send_request() a second time to read the responses back.
+ *   - ping_db: After X amount of time, ping the DB with a simple query in order
+ *     to keep the connection alive. Default is every 20 seconds. Set to 0 to
+ *     disable.
+ *
+ * @return array
+ *   Array where key is the URL and the value is the return value from
+ *   httprl_send_request.
+ */
+function httprl_request($urls, $options = array()) {
+  // See if a full bootstrap has been done.
+  $full_bootstrap = httprl_drupal_full_bootstrap();
+
+  // Transform string to an array.
+  if (!is_array($urls)) {
+    $temp = &$urls;
+    unset($urls);
+    $urls = array(&$temp);
+    unset($temp);
+  }
+
+  if ($full_bootstrap) {
+    // Allow other modules to alter things before we get started.
+    // Run hook_pre_httprl_request_alter().
+    $data = array($urls, $options);
+    drupal_alter('pre_httprl_request', $data);
+    list($urls, $options) = $data;
+  }
+
+  $connections = array();
+  $return = array();
+  // Set things up; but do not perform any IO.
+  foreach ($urls as &$url) {
+    $result = new stdClass();
+    $result->url = &$url;
+    $result->status = 'Connecting.';
+    $result->code = 0;
+    $result->chunk_size = 1024;
+    $result->data = '';
+
+    // Copy Options.
+    $these_options = $options;
+
+    // Setup the default options.
+    httprl_set_default_options($these_options);
+
+    // Parse the given URL and skip if an error occurred.
+    $uri = httprl_parse_url($url, $result);
+    if (isset($result->error)) {
+      // Put all variables into an array for easy alterations.
+      $connections[] = array(NULL, NULL, $uri, $url, $these_options, $result, NULL);
+      $return[$url] = FALSE;
+      // Stop processing this request as we have encountered an error.
+      continue;
+    }
+
+    // Set the proxy server if one is required.
+    $proxy_server = httprl_setup_proxy($uri, $these_options, $url);
+    // Create the socket string and skip if an error occurred.
+    $socket = httprl_set_socket($uri, $these_options, $proxy_server, $result, $return, $url);
+    if (isset($result->error)) {
+      // Put all variables into an array for easy alterations.
+      $connections[] = array($socket, NULL, $uri, $url, $these_options, $result, NULL);
+      $return[$url] = FALSE;
+      // Stop processing this request as we have encountered an error.
+      continue;
+    }
+
+    // Use a sync or async connection.
+    $flags = httprl_set_connection_flag($these_options, $uri);
+    // Set basic authorization header if needed.
+    httprl_basic_auth($uri, $these_options);
+    // If any data is given, do the right things to this request so it works.
+    httprl_handle_data($these_options);
+    // Build the request string.
+    $request = httprl_build_request_string($uri, $these_options);
+
+    // Put all variables into an array for easy alterations.
+    $connections[] = array($socket, $flags, $uri, $url, $these_options, $result, $request);
+    $return[$url] = TRUE;
+  }
+
+  if ($full_bootstrap) {
+    // Allow other programs to alter the connections before they are made.
+    // run hook_httprl_request_alter().
+    drupal_alter('httprl_request', $connections);
+  }
+
+  $results = array();
+  foreach ($connections as $connection) {
+    list($socket, $flags, $uri, $url, $options, $result, $request) = $connection;
+    $result->request = $request;
+    $result->options = $options;
+    $result->socket = $socket;
+    $result->flags = $flags;
+    $result->uri = $uri;
+    $result->running_time = 0;
+    $results[] = $result;
+  }
+
+  httprl_send_request($results);
+  return $return;
+}
+
+/**
+ * Perform many HTTP requests.
+ *
+ * @see drupal_http_request()
+ *
+ * This is a flexible and powerful HTTP client implementation. Correctly
+ * handles GET, POST, PUT or any other HTTP requests.
+ *
+ * @param $results
+ *   (optional) Array of results.
+ *
+ * @return bool
+ *   TRUE if function worked as planed.
+ */
+function httprl_send_request($results = NULL) {
+  static $responses = array();
+  static $counter = 0;
+  static $output = array();
+  static $static_stall_freads = FALSE;
+
+  if (!is_null($results)) {
+    // Put the connection information into the responses array.
+    foreach ($results as $result) {
+      $responses[$counter] = $result;
+      $counter++;
+    }
+    return TRUE;
+  }
+
+  // Exit if there is nothing to do.
+  if (empty($responses)) {
+    return FALSE;
+  }
+
+  // If the t function is not available use httprl_pr.
+  $t = function_exists('t') ? 't' : 'httprl_pr';
+
+  // Remove errors from responses array and set the global timeout.
+  $global_timeout = 1;
+  $global_connection_limit = 1;
+  $stall_freads = FALSE;
+  foreach ($responses as $id => &$result) {
+    if (!empty($result->error)) {
+      $result->status = 'Connection not made.';
+      // Do post processing on the stream.
+      httprl_post_processing($id, $responses, $output);
+      continue;
+    }
+
+    // Get connection limits.
+    $global_connection_limit = max($global_connection_limit, $result->options['global_connections']);
+    if (!isset($domain_connection_limit[$result->options['headers']['Host']])) {
+      $domain_connection_limit[$result->options['headers']['Host']] = max(1, $result->options['domain_connections']);
+    }
+    else {
+      $domain_connection_limit[$result->options['headers']['Host']] = max($domain_connection_limit[$result->options['headers']['Host']], $result->options['domain_connections']);
+    }
+
+    // Set global timeout.
+    $global_timeout = max($global_timeout, $result->options['global_timeout']);
+
+    // Issue fwrite, return. Run fread later on in the script.
+    if (!empty($result->options['stall_fread']) && !$static_stall_freads) {
+      $static_stall_freads = TRUE;
+      $stall_freads = TRUE;
+    }
+  }
+
+  // Record start time.
+  $start_time_this_run = $start_time_global = microtime(TRUE);
+  // Record the number of db pings done.
+  $ping_db_counts = array();
+  $full_bootstrap = httprl_drupal_full_bootstrap();
+
+  // Run the loop as long as we have a stream to read/write to.
+  $stream_select_timeout = 1;
+  $stream_write_count = 0;
+
+  while (!empty($responses)) {
+
+    // Initialize connection limits.
+    $this_run = array();
+    $global_connection_count = 0;
+    $domain_connection_count = array();
+    $restart_timers = FALSE;
+
+    // Get time.
+    $now = microtime(TRUE);
+
+    // Calculate times.
+    $elapsed_time = $now - $start_time_this_run;
+    $start_time_this_run = $now;
+    $global_time = $global_timeout - ($start_time_this_run - $start_time_global);
+
+    // See if the DB needs to be pinged.
+    $rounded_time = floor($elapsed_time);
+    if (   $full_bootstrap
+        && !empty($result->options['ping_db'])
+        && $rounded_time >= $result->options['ping_db']
+        && $rounded_time % $result->options['ping_db'] == 0
+        && empty($ping_db_counts[$rounded_time])
+          ) {
+      $empty_array = array();
+      system_get_files_database($empty_array, 'ping_db');
+      $ping_db_counts[$rounded_time] = 1;
+    }
+
+    // Inspect each stream, checking for timeouts and connection limits.
+    foreach ($responses as $id => &$result) {
+      // See if function timed out.
+      if ($global_time <= 0) {
+        // Function timed out & the request is not done.
+        if ($result->status == 'Connecting.') {
+          $result->error = $t('Function timed out. TCP.');
+          // If stream is not done writing, then remove one from the write count.
+          if (isset($result->fp)) {
+            $stream_write_count--;
+          }
+        }
+        elseif ($result->status == 'Writing to server.') {
+          $result->error = $t('Function timed out. Write.');
+          // If stream is not done writing, then remove one from the write count.
+          if (isset($result->fp)) {
+            $stream_write_count--;
+          }
+        }
+        else {
+          $result->error = $t('Function timed out. Read');
+        }
+        $result->code = HTTPRL_FUNCTION_TIMEOUT;
+        $result->status = 'Done.';
+
+        // Do post processing on the stream and close it.
+        httprl_post_processing($id, $responses, $output, $global_time);
+        continue;
+      }
+      // Do not calculate local timeout if a file pointer doesn't exist.
+      if (isset($result->fp)) {
+        // Add the elapsed time to this stream.
+        $result->running_time += $elapsed_time;
+        // Calculate how much time is left of the original timeout value.
+        $timeout = $result->options['timeout'] - $result->running_time;
+
+        // Connection was dropped or connection timed out.
+        if ($timeout <= 0) {
+          $result->error = $t('Connection timed out.');
+          // Stream timed out & the request is not done.
+          if ($result->status == 'Writing to server.') {
+            $result->error .= ' ' . $t('Write.');
+            // If stream is not done writing, then remove one from the write count.
+            $stream_write_count--;
+          }
+          else {
+            $result->error .= ' ' . $t('Read.');
+          }
+          $result->code = HTTPRL_REQUEST_TIMEOUT;
+          $result->status = 'Done.';
+
+          // Do post processing on the stream.
+          httprl_post_processing($id, $responses, $output, $timeout);
+          continue;
+        }
+
+        // Connection was dropped or connection timed out.
+        if ($result->status == 'Connecting.' && $result->running_time > $result->options['connect_timeout']) {
+          $socket_name = stream_socket_get_name($result->fp, TRUE);
+          if (empty($socket_name) || $result->running_time > ($result->options['connect_timeout'] * 1.5)) {
+            $result->error = $t('Connection timed out.');
+            // Stream timed out & the request is not done.
+            if ($result->status == 'Connecting.') {
+              $result->error .= ' ' . $t('TCP Connect Timeout.');
+              // If stream is not done writing, then remove one from the write count.
+              $stream_write_count--;
+            }
+            $result->code = HTTPRL_REQUEST_TIMEOUT;
+            $result->status = 'Done.';
+
+            // Do post processing on the stream.
+            httprl_post_processing($id, $responses, $output, $timeout);
+            continue;
+          }
+        }
+
+        if (!isset($responses[$id]->time_to_first_byte) && $result->running_time > $result->options['ttfb_timeout']) {
+          $result->error = $t('Connection timed out. Time to First Byte Timeout.');
+          $result->code = HTTPRL_REQUEST_ABORTED;
+          $result->status = 'Done.';
+
+          // Do post processing on the stream.
+          httprl_post_processing($id, $responses, $output, $timeout);
+          continue;
+        }
+      }
+
+      // Connection was handled elsewhere.
+      if (!isset($result->fp) && $result->status != 'Connecting.') {
+        // Do post processing on the stream.
+        httprl_post_processing($id, $responses, $output);
+        continue;
+      }
+
+      // Set the connection limits for this run.
+      // Get the host name.
+      $host = $result->options['headers']['Host'];
+      // Set the domain connection limit if none has been defined yet.
+      if (!isset($domain_connection_limit[$host])) {
+        $domain_connection_limit[$host] = max(1, $result->options['domain_connections']);
+      }
+      // Count up the number of connections.
+      $global_connection_count++;
+      if (empty($domain_connection_count[$host])) {
+        $domain_connection_count[$host] = 1;
+      }
+      else {
+        $domain_connection_count[$host]++;
+      }
+      // If the conditions are correct, let the stream be ran in this loop.
+      if ($global_connection_limit >= $global_connection_count && $domain_connection_limit[$host] >= $domain_connection_count[$host]) {
+        // Establish a new connection.
+        if (!isset($result->fp) && $result->status == 'Connecting.') {
+          // Establish a connection to the server.
+          httprl_establish_stream_connection($result);
+
+          // Reset timer.
+          $restart_timers = TRUE;
+
+          // Get lock if needed.
+          if (!empty($result->options['lock_name'])) {
+            httprl_acquire_lock($result);
+          }
+
+          // If connection can not be established bail out here.
+          if (!$result->fp) {
+            // Do post processing on the stream.
+            httprl_post_processing($id, $responses, $output);
+            $domain_connection_count[$host]--;
+            $global_connection_count--;
+            continue;
+          }
+          $stream_write_count++;
+
+        }
+        if (!empty($result->fp)) {
+          $this_run[$id] = $result->fp;
+        }
+      }
+    }
+
+    // All streams removed; exit loop.
+    if (empty($responses)) {
+      break;
+    }
+    // Restart timers.
+    if ($restart_timers) {
+      $start_time_this_run = microtime(TRUE);
+    }
+    // No streams selected; restart loop from the top.
+    if (empty($this_run)) {
+      continue;
+    }
+
+    // Set the read and write vars to the streams var.
+    $read = $write = $this_run;
+    $except = array();
+    // Do some voodoo and open all streams at once. Wait 25ms for streams to
+    // respond.
+    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+      // If on windows, use error suppression http://drupal.org/node/1869026
+      $n = @stream_select($read, $write, $except, $stream_select_timeout, 25000);
+    }
+    else {
+      $n = stream_select($read, $write, $except, $stream_select_timeout, 25000);
+    }
+    $stream_select_timeout = 0;
+
+    // An error occurred with the streams. Remove bad ones.
+    if ($n === FALSE) {
+      $merged = array_unique(array_merge($read, $write, $except));
+      foreach ($merged as $m) {
+        $id = array_search($m, $this_run);
+        @fclose($m);
+        if ($id !== FALSE && isset($responses[$id])) {
+          watchdog('httprl', 'The following url had a stream_select error and had to be terminated: %info', array('%info' => $responses[$id]->url), WATCHDOG_ERROR);
+          unset($responses[$id]);
+        }
+      }
+    }
+
+    // We have some streams to read/write to.
+    $rw_done = FALSE;
+    if (!empty($n)) {
+      if (!empty($read) && is_array($read)) {
+        // Readable sockets either have data for us, or are failed connection
+        // attempts.
+        foreach ($read as $r) {
+          $id = array_search($r, $this_run);
+          // Make sure ID is in the streams.
+          if ($id === FALSE) {
+            @fclose($r);
+            continue;
+          }
+          // Do not read from the non blocking sockets.
+          if (empty($responses[$id]->options['blocking'])) {
+            // Do post processing on the stream and close it.
+            httprl_post_processing($id, $responses, $output);
+            continue;
+          }
+
+          // Read socket.
+          $chunk = fread($r, $responses[$id]->chunk_size);
+          if (strlen($chunk) > 0) {
+            $rw_done = TRUE;
+            if (!isset($responses[$id]->time_to_first_byte)) {
+              // Calculate Time to First Byte.
+              $responses[$id]->time_to_first_byte = $result->running_time + microtime(TRUE) - $start_time_this_run;
+            }
+          }
+          $responses[$id]->data .= $chunk;
+
+          // Process the headers if we have some data.
+          if (!empty($responses[$id]->data) && empty($responses[$id]->headers) &&
+              (    strpos($responses[$id]->data, "\r\n\r\n")
+                || strpos($responses[$id]->data, "\n\n")
+                || strpos($responses[$id]->data, "\r\r")
+                  )
+                    ) {
+            // See if the headers are in the data stream.
+            httprl_parse_data($responses[$id]);
+            if (!empty($responses[$id]->headers)) {
+              // Stream was a redirect, kill & close this connection; redirect is
+              // being followed now.
+              if (!empty($responses[$id]->options['internal_states']['kill'])) {
+                fclose($r);
+                unset($responses[$id]);
+                continue;
+              }
+
+              // Now that we have the headers, increase the chunk size.
+              $responses[$id]->chunk_size = $responses[$id]->options['chunk_size_read'];
+
+              // If a range header is set, 200 was returned, method is GET,
+              // calculate how many bytes need to be downloaded.
+              if (   !empty($responses[$id]->options['headers']['Range'])
+                  && $responses[$id]->code == 200
+                  && $responses[$id]->options['method'] == 'GET'
+                    ) {
+                $responses[$id]->ranges = httprl_get_ranges($responses[$id]->options['headers']['Range']);
+                $responses[$id]->options['max_data_size'] = httprl_get_last_byte_from_range($responses[$id]->ranges);
+              }
+            }
+          }
+
+          // Close the connection if Transfer-Encoding & Content-Encoding are not
+          // used, a Range request was made and the currently downloaded data size
+          // is larger than the Range request.
+          if (   !empty($responses[$id]->options['max_data_size'])
+              && is_numeric($responses[$id]->options['max_data_size'])
+              && (!isset($result->headers['transfer-encoding']) || $result->headers['transfer-encoding'] != 'chunked')
+              && (!isset($result->headers['content-encoding']) || ($result->headers['content-encoding'] != 'gzip' && $result->headers['content-encoding'] != 'deflate'))
+              && $responses[$id]->options['max_data_size'] < httprl_strlen($responses[$id]->data)
+                ) {
+            $responses[$id]->status = 'Done.';
+
+            // Do post processing on the stream.
+            httprl_post_processing($id, $responses, $output);
+            continue;
+          }
+
+          // Get stream data.
+          $info = stream_get_meta_data($r);
+          $alive = !$info['eof'] && !feof($r) && !$info['timed_out'] && strlen($chunk);
+          if (!$alive) {
+            if ($responses[$id]->status == 'Connecting.') {
+              $responses[$id]->error = $t('Connection refused by destination. TCP.');
+              $responses[$id]->code = HTTPRL_CONNECTION_REFUSED;
+            }
+            if ($responses[$id]->status == 'Writing to server.') {
+              $responses[$id]->error = $t('Connection refused by destination. Write.');
+              $responses[$id]->code = HTTPRL_CONNECTION_REFUSED;
+            }
+            $responses[$id]->status = 'Done.';
+
+            // Do post processing on the stream.
+            httprl_post_processing($id, $responses, $output);
+            continue;
+          }
+          else {
+            $responses[$id]->status = 'Reading data';
+          }
+        }
+      }
+
+      // Write to each stream if it is available.
+      if ($stream_write_count > 0 && !empty($write) && is_array($write)) {
+        foreach ($write as $w) {
+          $id = array_search($w, $this_run);
+          // Make sure ID is in the streams & status is for writing.
+          if ($id === FALSE || empty($responses[$id]->status) || ($responses[$id]->status != 'Connecting.' && $responses[$id]->status != 'Writing to server.')) {
+            continue;
+          }
+
+          // Keep track of how many bytes are sent.
+          if (!isset($responses[$id]->bytes_sent)) {
+            $responses[$id]->bytes_sent = 0;
+          }
+
+          // Have twice the number of bytes available for fwrite.
+          $data_to_send = substr($responses[$id]->request, $responses[$id]->bytes_sent, 2 * $responses[$id]->options['chunk_size_write']);
+          // Calculate the number of bytes we need to write to the stream.
+          $len = httprl_strlen($data_to_send);
+          if ($len > 0) {
+            // Write to the stream.
+            $bytes = fwrite($w, $data_to_send, min($responses[$id]->options['chunk_size_write'], $len));
+          }
+          else {
+            // Nothing to write.
+            $bytes = $len;
+          }
+
+          // See if we are done with writing.
+          if ($bytes === FALSE) {
+            // fwrite failed.
+            $responses[$id]->error = $t('fwrite() failed.');
+            $responses[$id]->code = HTTPRL_REQUEST_FWRITE_FAIL;
+            $responses[$id]->status = 'Done.';
+            $stream_write_count--;
+
+            // Do post processing on the stream.
+            httprl_post_processing($id, $responses, $output);
+            continue;
+          }
+          elseif ($bytes >= $len) {
+            // fwrite is done.
+            $stream_write_count--;
+
+            // If this is a non blocking request then close the connection and
+            // destroy the stream.
+            if (empty($responses[$id]->options['blocking'])) {
+              $responses[$id]->status = 'Non-Blocking request sent out. Not waiting for the response.';
+              // Do post processing on the stream.
+              httprl_post_processing($id, $responses, $output);
+              continue;
+            }
+            else {
+              // All data has been written to the socket. We are read only from
+              // here on out.
+              $responses[$id]->status = "Request sent, waiting for response.";
+            }
+
+            // Record how many bytes were sent.
+            $responses[$id]->bytes_sent += $bytes;
+            $rw_done = TRUE;
+          }
+          else {
+            // Change status to 'Writing to server.'
+            if ($responses[$id]->status = 'Connecting.') {
+              $responses[$id]->status = 'Writing to server.';
+            }
+            // There is more data to write to this socket. Cut what was sent
+            // across the stream and resend whats left next time in the loop.
+            $responses[$id]->bytes_sent += $bytes;
+            $rw_done = TRUE;
+          }
+        }
+      }
+      elseif ($stall_freads) {
+        return;
+      }
+    }
+    if (!$rw_done) {
+      // Wait 5ms for data buffers.
+      usleep(5000);
+    }
+  }
+
+  // Copy output.
+  $return = $output;
+
+  // Free memory/reset static variables.
+  $responses = array();
+  $counter = 0;
+  $output = array();
+  $static_stall_freads = FALSE;
+
+  return $return;
+}
+
+/**
+ * Extract the header and meta data from the http data stream.
+ *
+ * @see drupal_http_request()
+ *
+ * @todo Send cookies in the redirect request if domain/path match.
+ *
+ * @param object $result
+ *   An object from httprl_send_request.
+ */
+function httprl_parse_data(&$result) {
+  // If in non blocking mode, skip.
+  if (empty($result->options['blocking'])) {
+    return;
+  }
+
+  // If the headers are already parsed, skip.
+  if (!empty($result->headers)) {
+    return;
+  }
+
+  // If the t function is not available use httprl_pr.
+  $t = function_exists('t') ? 't' : 'httprl_pr';
+
+  // Parse response headers from the response body.
+  // Be tolerant of malformed HTTP responses that separate header and body with
+  // \n\n or \r\r instead of \r\n\r\n.
+  $response = $result->data;
+  list($response, $result->data) = preg_split("/\r\n\r\n|\n\n|\r\r/", $response, 2);
+  $response = preg_split("/\r\n|\n|\r/", $response);
+
+  // Parse the response status line.
+  $protocol_code_array = explode(' ', trim(array_shift($response)), 3);
+  $result->protocol = $protocol_code_array[0];
+  $code = (int) $protocol_code_array[1];
+  // If the response does not include a description, don't try to process it.
+  $result->status_message = isset($protocol_code_array[2]) ? $protocol_code_array[2] : '';
+  unset($protocol_code_array);
+
+  $result->headers = array();
+
+  // Parse the response headers.
+  $cookie_primary_counter = 0;
+  while ($line = trim(array_shift($response))) {
+    list($name, $value) = explode(':', $line, 2);
+    $name = strtolower($name);
+
+    // Parse cookies before they get added to the header.
+    if ($name == 'set-cookie') {
+      // Extract the key value pairs for this cookie.
+      foreach (explode(';', $value) as $cookie_name_value) {
+        $temp = explode('=', trim($cookie_name_value));
+        $cookie_key = trim($temp[0]);
+        $cookie_value = isset($temp[1]) ? trim($temp[1]) : '';
+        unset($temp);
+        // The cookie name-value pair always comes first (RFC 2109 4.2.2).
+        if (!isset($result->cookies[$cookie_primary_counter])) {
+          $result->cookies[$cookie_primary_counter] = array(
+            'name' => $cookie_key,
+            'value' => $cookie_value,
+          );
+        }
+        // Extract the rest of the attribute-value pairs.
+        else {
+          $result->cookies[$cookie_primary_counter] += array(
+            $cookie_key => $cookie_value,
+          );
+        }
+      }
+      $cookie_primary_counter++;
+    }
+
+    // Add key value pairs to the header; including cookies.
+    if (isset($result->headers[$name]) && $name == 'set-cookie') {
+      // RFC 2109: the Set-Cookie response header comprises the token Set-
+      // Cookie:, followed by a comma-separated list of one or more cookies.
+      $result->headers[$name] .= ',' . trim($value);
+    }
+    else {
+      $result->headers[$name] = trim($value);
+    }
+  }
+
+  $responses = array(
+    100 => 'Continue',
+    101 => 'Switching Protocols',
+    200 => 'OK',
+    201 => 'Created',
+    202 => 'Accepted',
+    203 => 'Non-Authoritative Information',
+    204 => 'No Content',
+    205 => 'Reset Content',
+    206 => 'Partial Content',
+    300 => 'Multiple Choices',
+    301 => 'Moved Permanently',
+    302 => 'Found',
+    303 => 'See Other',
+    304 => 'Not Modified',
+    305 => 'Use Proxy',
+    307 => 'Temporary Redirect',
+    400 => 'Bad Request',
+    401 => 'Unauthorized',
+    402 => 'Payment Required',
+    403 => 'Forbidden',
+    404 => 'Not Found',
+    405 => 'Method Not Allowed',
+    406 => 'Not Acceptable',
+    407 => 'Proxy Authentication Required',
+    408 => 'Request Time-out',
+    409 => 'Conflict',
+    410 => 'Gone',
+    411 => 'Length Required',
+    412 => 'Precondition Failed',
+    413 => 'Request Entity Too Large',
+    414 => 'Request-URI Too Large',
+    415 => 'Unsupported Media Type',
+    416 => 'Requested range not satisfiable',
+    417 => 'Expectation Failed',
+    500 => 'Internal Server Error',
+    501 => 'Not Implemented',
+    502 => 'Bad Gateway',
+    503 => 'Service Unavailable',
+    504 => 'Gateway Time-out',
+    505 => 'HTTP Version not supported',
+  );
+  // RFC 2616 states that all unknown HTTP codes must be treated the same as the
+  // base code in their class.
+  if (!isset($responses[$code])) {
+    $code = floor($code / 100) * 100;
+  }
+  $result->code = $code;
+
+  switch ($code) {
+    case 200: // OK
+    case 201: // Created
+    case 202: // Accepted
+    case 206: // Partial Content
+    case 304: // Not modified
+      break;
+
+    case 301: // Moved permanently
+    case 302: // Moved temporarily
+    case 307: // Moved temporarily
+      $location = @parse_url($result->headers['location']);
+
+      // If location isn't fully qualified URL (as per W3 RFC2616), build one.
+      if (empty($location['scheme']) || empty($location['host'])) {
+        // Get the important parts from the original request.
+        $original_location = @parse_url($result->url);
+        // Assume request is to self if none of this was setup correctly.
+        $location['scheme'] = !empty($location['scheme']) ? $location['scheme'] : $original_location['scheme'];
+        $location['host'] = !empty($location['host']) ? $location['host'] : !empty($original_location['host']) ? $original_location['host'] : $_SERVER['HTTP_HOST'];
+        $location['port'] = !empty($location['port']) ? $location['port'] : !empty($original_location['port']) ? $original_location['port'] : '';
+        $location = httprl_glue_url($location);
+      }
+      else {
+        $location = $result->headers['location'];
+      }
+
+      // Set internal redirect states.
+      $result->options['internal_states']['redirect_code_array'][] = $code;
+      $result->options['internal_states']['redirect_url_array'][] = $location;
+      if (!isset($result->options['internal_states']['original_url'])) {
+        $result->options['internal_states']['original_url'] = $result->url;
+      }
+
+      // Error out if we hit the max redirect.
+      if ($result->options['max_redirects'] <= 0) {
+        $result->code = HTTPRL_REQUEST_ALLOWED_REDIRECTS_EXHAUSTED;
+        $result->error = $t('Maximum allowed redirects exhausted.');
+      }
+      else {
+        // Redirect to the new location.
+        // TODO: Send cookies in the redirect request if domain/path match.
+        $result->options['max_redirects']--;
+        if (isset($result->options['headers']['Referer'])) {
+          $result->options['headers']['Referer'] = $result->url;
+        }
+        // Remove the host from the header.
+        unset($result->options['headers']['Host']);
+
+        // Pass along running time.
+        $result->options['internal_states']['running_time'] = $result->running_time;
+
+        // Send new request.
+        httprl_request($location, $result->options);
+        // Kill this request.
+        $result->options['internal_states']['kill'] = TRUE;
+      }
+
+      break;
+
+    default:
+      $result->error = $result->status_message;
+  }
+}
+
+/**
+ * Parse a range header into start and end byte ranges.
+ *
+ * @param string $input
+ *   String in the form of bytes=0-1024 or bytes=0-1024,2048-4096
+ *
+ * @return array
+ *   Keyed arrays containing start and end values for the byte ranges.
+ *   Empty array if the string can not be parsed.
+ */
+function httprl_get_ranges($input) {
+  $ranges = array();
+  // Make sure the input string matches the correct format.
+  $string = preg_match('/^bytes=((\d*-\d*,? ?)+)$/', $input, $matches) ? $matches[1] : FALSE;
+  if (!empty($string)) {
+    // Handle multiple ranges.
+    foreach (explode(',', $string) as $range) {
+      // Get the start and end byte values for this range.
+      $values = explode('-', $range);
+      if (count($values) != 2) {
+        return FALSE;
+      }
+      $ranges[] = array('start' => $values[0], 'end' => $values[1]);
+    }
+  }
+  return $ranges;
+}
+
+/**
+ * Given an array of ranges, get the last byte we need to download.
+ *
+ * @param array $ranges
+ *   Multi dimensional array
+ *
+ * @return int|null
+ *   NULL: Get all values; int: last byte to download.
+ */
+function httprl_get_last_byte_from_range($ranges) {
+  $max = 0;
+  if (empty($ranges)) {
+    return NULL;
+  }
+  foreach ($ranges as $range) {
+    if (!is_numeric($range['start']) || !is_numeric($range['end'])) {
+      return NULL;
+    }
+    $max = max($range['end'] + 1, $max);
+  }
+  return $max;
+}
+
+/**
+ * Run post processing on the request if we are done reading.
+ *
+ * Decode transfer-encoding and content-encoding.
+ * Reconstruct the internal redirect arrays.
+ *
+ * @result object
+ *   An object from httprl_send_request.
+ */
+function httprl_post_processing($id, &$responses, &$output, $time_left = NULL) {
+  // Create the result reference.
+  $result = &$responses[$id];
+
+  // Close file.
+  if (isset($result->fp)) {
+    @fclose($result->fp);
+  }
+
+  // Set timeout.
+  if (is_null($time_left)) {
+    $time_left = $result->options['timeout'] - $result->running_time;
+  }
+  $result->options['timeout'] = $time_left;
+
+  // Assemble redirects.
+  httprl_reconstruct_redirects($result);
+
+  // Decode chunked transfer-encoding and gzip/deflate content-encoding.
+  httprl_decode_data($result);
+
+  // If this is a background callback request, extract the data and return.
+  if (isset($result->options['internal_states']) && array_key_exists('background_function_return', $result->options['internal_states']) && isset($result->headers['content-type']) && strpos($result->headers['content-type'], 'application/x-www-form-urlencoded') !== FALSE) {
+    httprl_extract_background_callback_data($result);
+    unset($responses[$id]);
+    return;
+  }
+
+  // See if a full bootstrap has been done.
+  $full_bootstrap = httprl_drupal_full_bootstrap();
+
+  // Allow a user defined function to alter all $responses.
+  if ($full_bootstrap && !empty($result->options['alter_all_streams_function']) && function_exists($result->options['alter_all_streams_function'])) {
+    $result->options['alter_all_streams_function']($id, $responses);
+  }
+  unset($responses[$id]);
+
+  // Allow other modules to alter the result.
+  if ($full_bootstrap) {
+    // Call hook_httprl_post_processing_alter().
+    drupal_alter('httprl_post_processing', $result);
+  }
+
+  // Run callback so other modules can do stuff in the event loop.
+  if (   $full_bootstrap
+      && !empty($result->options['callback'])
+      && is_array($result->options['callback'])
+      && !empty($result->options['callback'][0])
+      && is_array($result->options['callback'][0])
+      && !empty($result->options['callback'][0]['function'])
+        ) {
+    httprl_run_callback($result);
+  }
+
+  // Run background_callback.
+  if (   !empty($result->options['background_callback'])
+      && is_array($result->options['background_callback'])
+      && !empty($result->options['background_callback'][0])
+      && is_array($result->options['background_callback'][0])
+      && !empty($result->options['background_callback'][0]['function'])
+        ) {
+    $call_is_queued = httprl_queue_background_callback($result->options['background_callback'], $result);
+    if (is_null($call_is_queued)) {
+      watchdog('httprl', 'Background callback attempted but it is disabled. Going to use a normal callback');
+      unset($result->options['callback']);
+      $result->options['callback'] = $result->options['background_callback'];
+      unset($result->options['background_callback']);
+      httprl_run_callback($result);
+    }
+  }
+
+  // Copy the result to the output array.
+  if (isset($result->url)) {
+    $output[$result->url] = $result;
+  }
+
+}
+
+/**
+ * Extract background callback data.
+ *
+ * Set the return and printed values & any pass by reference values from a
+ * background callback operation.
+ *
+ * @param object $result
+ *   An object from httprl_send_request.
+ */
+function httprl_extract_background_callback_data(&$result) {
+  // Extract data from string.
+  $data = array();
+  parse_str($result->data, $data);
+  // Follow rfc4648 for base64url
+  // @see http://tools.ietf.org/html/rfc4648#page-7
+  $data = unserialize(base64_decode(strtr(current($data), array('-' => '+', '_' => '/'))));
+
+  // Set return and printed values.
+  if (isset($data['return'])) {
+    $result->options['internal_states']['background_function_return'] = $data['return'];
+  }
+  if (isset($data['printed'])) {
+    $result->options['internal_states']['background_function_printed'] = $data['printed'];
+  }
+
+  // Set any pass by reference values.
+  if (isset($data['args'])) {
+    httprl_recursive_array_reference_extract($result->options['internal_states']['background_function_args'], $data['args']);
+  }
+}
+
+/**
+ * Replace data in place so pass by reference sill works.
+ *
+ * @param array $array
+ *   An array containing the references if any.
+ * @param array $data
+ *   An array that has the new values to copy into $array.
+ * @param int $depth
+ *   Only go 10 levels deep. Prevent infinite loops.
+ */
+function httprl_recursive_array_reference_extract(&$array, $data, $depth = 0) {
+  $depth++;
+  foreach ($array as $key => &$value) {
+    if (isset($data[$key])) {
+      if (is_array($data[$key]) && is_array($value) && $depth < 10) {
+        $value = httprl_recursive_array_reference_extract($value, $data[$key], $depth);
+      }
+      else {
+        $value = $data[$key];
+      }
+    }
+    else {
+      $value = NULL;
+    }
+  }
+  // Copy new keys into the data structure.
+  foreach ($data as $key => $value) {
+    if (isset($array[$key])) {
+      continue;
+    }
+    $array[$key] = $value;
+  }
+}
+
+/**
+ * Run callback.
+ *
+ * Will run the given callback returning values and what might have been
+ * printed by that function, as well as respecting any pass by reference values.
+ *
+ * @param object $result
+ *   An object from httprl_send_request.
+ */
+function httprl_run_callback(&$result) {
+  // Get options.
+  $callback_options = $result->options['callback'][0];
+  // Merge in values by reference.
+  $result->options['callback'][0] = &$result;
+
+  // Capture anything printed out.
+  if (array_key_exists('printed', $callback_options)) {
+    ob_start();
+  }
+  // Call function.
+  $callback_options['return'] = call_user_func_array($callback_options['function'], $result->options['callback']);
+  if (array_key_exists('printed', $callback_options)) {
+    $callback_options['printed'] = ob_get_contents();
+    ob_end_clean();
+  }
+
+  // Add options back into the callback array.
+  if (isset($result->options['callback'])) {
+    array_unshift($result->options['callback'], $callback_options);
+  }
+}
+
+/**
+ * Run callback in the background.
+ *
+ * Will run the given callback returning values and what might have been
+ * printed by that function, as well as respecting any pass by reference values.
+ *
+ * @param array $args
+ *   An array of arguments, first key value pair is used to control the
+ *   callback function. The rest of the key value pairs will be arguments for
+ *   the callback function.
+ * @param object $result
+ *   (optional) An object from httprl_send_request. If this is set, this will
+ *   be the first argument of the function.
+ */
+function httprl_queue_background_callback(&$args, &$result = NULL) {
+  // Use a counter to prevent key collisions in httprl_send_request.
+  static $counter;
+  if (!isset($counter)) {
+    $counter = 0;
+  }
+  $counter++;
+
+  if (!httprl_is_background_callback_capable()) {
+    return NULL;
+  }
+
+  // Get URL to call function in background.
+  if (empty($callback_options['url'])) {
+    $url = httprl_build_url_self('httprl_async_function_callback?count=' . $counter);
+  }
+  else {
+    $url = $callback_options['url'];
+  }
+
+  // Get options.
+  $callback_options = $args[0];
+
+  if (is_null($result)) {
+    array_shift($args);
+  }
+  else {
+    // Merge in this request by reference.
+    $args[0] = &$result;
+  }
+
+  // Set blocking mode.
+  if (isset($callback_options['return']) || isset($callback_options['printed'])) {
+    $mode = TRUE;
+  }
+  else {
+    $mode = FALSE;
+  }
+  // Make sure some array keys exist.
+  if (!isset($callback_options['return'])) {
+    $callback_options['return'] = '';
+  }
+  if (!isset($callback_options['function'])) {
+    $callback_options['function'] = '';
+  }
+
+  // Get the maximum amount of time this could take.
+  $times = array(
+    httprl_variable_get('httprl_timeout', HTTPRL_TIMEOUT),
+    httprl_variable_get('httprl_global_timeout', HTTPRL_GLOBAL_TIMEOUT),
+  );
+  if (isset($callback_options['options']['timeout'])) {
+    $times[] = $callback_options['options']['timeout'];
+  }
+  if (isset($callback_options['options']['global_timeout'])) {
+    $times[] = $callback_options['options']['global_timeout'];
+  }
+
+  // Create lock name for this run.
+  $available = FALSE;
+  $lock_counter = 0;
+  while (!$available && $lock_counter < 20) {
+    // 512 bits = 64 bytes.
+    if (function_exists('drupal_random_bytes')) {
+      $name = 'httprl_' . hash('sha512', drupal_random_bytes(64));
+    }
+    elseif (function_exists('openssl_random_pseudo_bytes')) {
+      $name = 'httprl_' . hash('sha512', openssl_random_pseudo_bytes(64));
+    }
+    else {
+      $name = 'httprl_' . hash('sha512', mt_rand() . microtime(TRUE) . serialize($_SERVER));
+    }
+    $available = lock_may_be_available($name);
+    $lock_counter++;
+  }
+  $callback_options['options']['lock_name'] = $name;
+
+  // Create data array and options for request.
+  $options = array(
+    'data' => array(
+      'master_key' => hash('sha512', httprl_drupal_get_private_key()),
+      'temp_key' => $name,
+      'mode' => $mode,
+      'php_timeout' => max($times),
+      'function' => $callback_options['function'],
+      'context' => isset($callback_options['context']) ? $callback_options['context'] : array(),
+      // Follow rfc4648 for base64url
+      // @see http://tools.ietf.org/html/rfc4648#page-7
+      'args' => strtr(base64_encode(serialize($args)), array('+' => '-', '/' => '_')),
+    ),
+    'internal_states' => array(
+      'background_function_return' => &$callback_options['return'],
+      'background_function_args' => &$args,
+    ),
+    'blocking' => $mode,
+    'method' => 'POST',
+  );
+  if (isset($callback_options['printed'])) {
+    $options['internal_states']['background_function_printed'] = &$callback_options['printed'];
+  }
+  if (isset($callback_options['options']) && is_array($callback_options['options'])) {
+    $options += $callback_options['options'];
+  }
+
+  // Set Host header.
+  if (empty($options['headers']['Host']) && !empty($_SERVER['HTTP_HOST'])) {
+    $options['headers']['Host'] = $_SERVER['HTTP_HOST'];
+  }
+
+  // Set Session header if requested to.
+  if (!empty($callback_options['context']['session']) && !empty($_COOKIE[session_name()])) {
+    if (!isset($options['headers']['Cookie'])) {
+      $options['headers']['Cookie'] = '';
+    }
+    $options['headers']['Cookie'] = session_name() . '=' . $_COOKIE[session_name()] . ';';
+  }
+
+  // Send Request.
+  return httprl_request($url, $options);
+}
+
+
+/**
+ * Get a lock so background calls work.
+ *
+ * @param object $result
+ *   An object from httprl_send_request.
+ */
+function httprl_acquire_lock(&$result) {
+  if (empty($result->options['lock_name'])) {
+    return FALSE;
+  }
+
+  // Get the maximum amount of time this could take.
+  $times = array(
+    httprl_variable_get('httprl_timeout', HTTPRL_TIMEOUT),
+    httprl_variable_get('httprl_global_timeout', HTTPRL_GLOBAL_TIMEOUT),
+  );
+  if (isset($result->options['timeout'])) {
+    $times[] = $result->options['timeout'];
+  }
+  if (isset($result->options['global_timeout'])) {
+    $times[] = $result->options['global_timeout'];
+  }
+
+  // Acquire lock for this run.
+  $locked = FALSE;
+  $lock_counter = 0;
+  $name = $result->options['lock_name'];
+  while (!$locked && $lock_counter < 3) {
+    // Set lock to maximum amount of time.
+    $locked = lock_acquire($name, max($times));
+    $lock_counter++;
+  }
+  if (!$locked) {
+    return FALSE;
+  }
+
+  // Make sure lock exists after this process is dead.
+  // Remove from the global locks variable.
+  global $locks;
+  unset($locks[$name]);
+
+  // Remove the lock_id reference in the database.
+  if (httprl_variable_get('lock_inc', './includes/lock.inc') === './includes/lock.inc') {
+    if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+      db_update('semaphore')
+        ->fields(array('value' => 'httprl'))
+        ->condition('name', $name)
+        ->condition('value', _lock_id())
+        ->execute();
+    }
+    else {
+      db_query("UPDATE {semaphore} SET value = '%s' WHERE name = '%s' AND value = '%s'", 'httprl', $name, _lock_id());
+    }
+  }
+  return TRUE;
+}
+
+/**
+ * Will decode chunked transfer-encoding and gzip/deflate content-encoding.
+ *
+ * @param object $result
+ *   An object from httprl_send_request.
+ */
+function httprl_decode_data(&$result) {
+  if (isset($result->headers['transfer-encoding']) && $result->headers['transfer-encoding'] == 'chunked') {
+    $stream_position = 0;
+    $output = '';
+    $data = $result->data;
+    while ($stream_position < httprl_strlen($data)) {
+      // Get the number of bytes to read for this chunk.
+      $rawnum = substr($data, $stream_position, strpos(substr($data, $stream_position), "\r\n") + 2);
+      $num = hexdec(trim($rawnum));
+      // Get the position to read from.
+      $stream_position += httprl_strlen($rawnum);
+      // Extract the chunk.
+      $chunk = substr($data, $stream_position, $num);
+      // Decompress if compressed.
+      if (isset($result->headers['content-encoding'])) {
+        if ($result->headers['content-encoding'] == 'gzip') {
+          $chunk = gzinflate(substr($chunk, 10));
+        }
+        elseif ($result->headers['content-encoding'] == 'deflate') {
+          $chunk = gzinflate($chunk);
+        }
+      }
+      // Glue the chunks together.
+      $output .= $chunk;
+      $stream_position += httprl_strlen($chunk);
+    }
+    $result->data = $output;
+  }
+  // Decompress if compressed.
+  elseif (isset($result->headers['content-encoding'])) {
+    if ($result->headers['content-encoding'] == 'gzip') {
+      $result->data = gzinflate(substr($result->data, 10));
+    }
+    elseif ($result->headers['content-encoding'] == 'deflate') {
+      $result->data = gzinflate($result->data);
+    }
+  }
+
+  // Cut up response for one sided Range requests.
+  if (array_key_exists('max_data_size', $result->options)) {
+    $result->code = 206;
+
+    // Make the data conform to the range request.
+    $new_data = array();
+    foreach ($result->ranges as $range) {
+      // Get only the last X number of bytes.
+      if (!is_numeric($range['start'])) {
+        $new_data[] = substr($result->data, -$range['end']);
+      }
+      // Get all but the first X number of bytes.
+      elseif (!is_numeric($range['end'])) {
+        $new_data[] = substr($result->data, $range['start']);
+      }
+      else {
+        $new_data[] = substr($result->data, $range['start'], ($range['end'] + 1) - $range['start']);
+      }
+    }
+    $result->data = implode('', $new_data);
+
+    // Fix content-length for fake 206s.
+    if (isset($result->headers['content-length'])) {
+      $result->headers['content-length'] = httprl_strlen($result->data);
+    }
+  }
+
+  // Reassemble multipart/byteranges response.
+  if (isset($result->headers['content-type']) && strpos($result->headers['content-type'], 'multipart/byteranges; boundary=') !== FALSE) {
+    // Get boundary string.
+    $boundary = "\r\n--" . substr($result->headers['content-type'], 31);
+    $datas = explode($boundary, $result->data);
+    $result->data = '';
+    foreach ($datas as $data) {
+      $split = preg_split("/\r\n\r\n|\n\n|\r\r/", $data, 2);
+      if (count($split) < 2) {
+        continue;
+      }
+
+      // Separate the data from the headers.
+      list($response, $data) = $split;
+      $response = array_filter(preg_split("/\r\n|\n|\r/", $response));
+
+      // Parse the response headers.
+      while ($line = trim(array_shift($response))) {
+        list($name, $value) = explode(':', $line, 2);
+        $name = strtolower($name);
+
+        // Add key value pairs to the header.
+        if ($name != 'content-range') {
+          $result->headers[$name] = trim($value);
+        }
+      }
+      $result->data .= $data;
+    }
+    // Fix content-length for multipart/byteranges.
+    if (isset($result->headers['content-length'])) {
+      $result->headers['content-length'] = httprl_strlen($result->data);
+    }
+  }
+}
+
+/**
+ * Reconstruct the internal redirect arrays.
+ *
+ * @param object $result
+ *   An object from httprl_send_request.
+ */
+function httprl_reconstruct_redirects(&$result) {
+  // Return if original_url is not set.
+  if (empty($result->options['internal_states']['original_url'])) {
+    return;
+  }
+  // Set the original url.
+  $result->url = $result->options['internal_states']['original_url'];
+
+  // Set the redirect code.
+  $result->redirect_code_array = $result->options['internal_states']['redirect_code_array'];
+  $result->redirect_code = array_pop($result->options['internal_states']['redirect_code_array']);
+
+  // Set the redirect url.
+  $result->redirect_url_array = $result->options['internal_states']['redirect_url_array'];
+  $result->redirect_url = array_pop($result->options['internal_states']['redirect_url_array']);
+
+  // Cleanup.
+  unset($result->options['internal_states']['original_url'], $result->options['internal_states']['redirect_code_array'], $result->options['internal_states']['redirect_url_array']);
+  if (empty($result->options['internal_states'])) {
+    unset($result->options['internal_states']);
+  }
+}
+
+/**
+ * Output text, close connection, continue processing in the background.
+ *
+ * @param string $output
+ *   Text to output to open connection.
+ * @param bool $wait
+ *   Wait 1 second?
+ * @param string $content_type
+ *   Content type header.
+ * @param int $length
+ *   Content length.
+ *
+ * @return bool
+ *   Returns TRUE if operation worked, FALSE if it failed.
+ */
+function httprl_background_processing($output, $wait = TRUE, $content_type = "text/html; charset=utf-8", $length = 0) {
+  // Can't do background processing if headers are already sent.
+  if (headers_sent()) {
+    return FALSE;
+  }
+
+  // Prime php for background operations.
+  // Remove any output buffers.
+  @ob_end_clean();
+  $loop = 0;
+  while (ob_get_level() && $loop < 25) {
+    @ob_end_clean();
+    $loop++;
+  }
+
+  // Ignore user aborts.
+  ignore_user_abort(TRUE);
+
+  // Output headers & data.
+  ob_start();
+  header("HTTP/1.0 200 OK");
+  header("Content-type: " . $content_type);
+  header("Expires: Sun, 19 Nov 1978 05:00:00 GMT");
+  header("Cache-Control: no-cache");
+  header("Cache-Control: must-revalidate");
+  header("Connection: close");
+  header('Etag: "' . microtime(TRUE) . '"');
+  print ($output);
+  $size = ob_get_length();
+  header("Content-Length: " . $size);
+  @ob_end_flush();
+  @ob_flush();
+  @flush();
+
+  if (function_exists('fastcgi_finish_request')) {
+    fastcgi_finish_request();
+  }
+
+  // Wait for 1 second.
+  if ($wait) {
+    sleep(1);
+  }
+
+  // Text returned and connection closed.
+  // Do background processing. Time taken after should not effect page load times.
+  return TRUE;
+}
+
+/**
+ * Get the length of a string in bytes.
+ *
+ * @param string $string
+ *   get string length
+ */
+function httprl_strlen($string) {
+  static $mb_strlen;
+  if (!isset($mb_strlen)) {
+    $mb_strlen = function_exists('mb_strlen');
+  }
+  if ($mb_strlen) {
+    return mb_strlen($string, '8bit');
+  }
+  else {
+    return strlen($string);
+  }
+}
+
+/**
+ * Alt to http_build_url().
+ *
+ * @see http://php.net/parse-url#85963
+ *
+ * @param array $parsed
+ *   array from parse_url()
+ *
+ * @return string
+ *   URI is returned.
+ */
+function httprl_glue_url($parsed) {
+  if (!is_array($parsed)) {
+    return FALSE;
+  }
+
+  $uri = isset($parsed['scheme']) ? $parsed['scheme'] . ':' . ((strtolower($parsed['scheme']) == 'mailto') ? '' : '//') : '';
+  $uri .= isset($parsed['user']) ? $parsed['user'] . (isset($parsed['pass']) ? ':' . $parsed['pass'] : '') . '@' : '';
+  $uri .= isset($parsed['host']) ? $parsed['host'] : '';
+  $uri .= !empty($parsed['port']) ? ':' . $parsed['port'] : '';
+
+  if (isset($parsed['path'])) {
+    $uri .= (substr($parsed['path'], 0, 1) == '/') ? $parsed['path'] : ((!empty($uri) ? '/' : '') . $parsed['path']);
+  }
+
+  $uri .= isset($parsed['query']) ? '?' . $parsed['query'] : '';
+  $uri .= isset($parsed['fragment']) ? '#' . $parsed['fragment'] : '';
+
+  return $uri;
+}
+
+/**
+ * Return the server schema (http or https).
+ *
+ * @return string
+ *   http OR https.
+ */
+function httprl_get_server_schema() {
+  return (   (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on')
+          || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+          || (isset($_SERVER['HTTP_HTTPS']) && $_SERVER['HTTP_HTTPS'] == 'on')
+            ) ? 'https' : 'http';
+}
+
+/**
+ * Send out a fast 403 and exit.
+ */
+function httprl_fast403($msg = '') {
+  global $base_path;
+
+  // Set headers.
+  if (!headers_sent()) {
+    header($_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden');
+    header('X-HTTPRL: Forbidden.');
+  }
+
+  // Print simple 403 page.
+  print '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">' . "\n";
+  print '<html>';
+  print '<head><title>403 Forbidden</title></head>';
+  print '<body><h1>Forbidden</h1>';
+  print '<p>You are not authorized to access this page.</p>';
+  print '<p><a href="' . $base_path . '">Home</a></p>';
+  print '<!-- httprl_fast403 ' . $msg . ' -->';
+  print '</body></html>';
+
+  // Exit Script.
+  httprl_call_exit();
+}
+
+/**
+ * Release a lock previously acquired by lock_acquire().
+ *
+ * This will release the named lock.
+ *
+ * @param string $name
+ *   The name of the lock.
+ */
+function httprl_lock_release($name) {
+  $lock_inc = httprl_variable_get('lock_inc', './includes/lock.inc');
+  // Core.
+  if ($lock_inc === './includes/lock.inc') {
+    global $locks;
+
+    unset($locks[$name]);
+    if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+      db_delete('semaphore')
+        ->condition('name', $name)
+        ->execute();
+    }
+    else {
+      db_query("DELETE FROM {semaphore} WHERE name = '%s'", $name);
+    }
+  }
+  // Memcache storage module.
+  elseif (strpos($lock_inc, '/memcache_storage/includes/lock.inc') !== FALSE) {
+    global $locks;
+
+    // We unset unconditionally since caller assumes lock is released anyway.
+    unset($locks[$name]);
+
+    // Remove current lock from memcached pool.
+    if (MemcacheStorageAPI::get($name, 'semaphore')) {
+      MemcacheStorageAPI::delete($name, 'semaphore');
+    }
+  }
+  else {
+    lock_release($name);
+  }
+}
+
+
+/**
+ * If $data is bool or strlen = 0 use var_export. Recursively go deeper.
+ *
+ * @param mixed $data
+ *   Data In.
+ * @param int $level
+ *   (optional) At what level of the array/object are we at.
+ *
+ * @return mixed
+ *   $data
+ */
+function httprl_print_empty(&$data, $level = 0) {
+  $level++;
+  if ($level < 5) {
+    if (is_object($data)) {
+      $new_object = new stdClass();
+      $new_object->__original_class_name__ = get_class($data);
+      foreach ($data as $key => $values) {
+        $new_object->{$key} = httprl_print_empty($values, $level);
+      }
+      $data = $new_object;
+    }
+    elseif (is_array($data)) {
+      foreach ($data as &$values) {
+        $values = httprl_print_empty($values, $level);
+      }
+    }
+    elseif (is_bool($data) || strlen((string) $data) == 0) {
+      $data = strtoupper(var_export($data, TRUE));
+    }
+    elseif (is_string($data) && strlen($data) > HTTPRL_PR_MAX_STRING_LENGTH) {
+      // Do not try to print a string longer than 256KB.
+      // Some browsers have issues with very long documents.
+      $data = substr($data, 0, HTTPRL_PR_MAX_STRING_LENGTH);
+    }
+  }
+  return $data;
+}
+
+/**
+ * Pretty print data.
+ *
+ * @param string $input
+ *   Data In.
+ *
+ * @return string
+ *   Human readable HTML version of the data.
+ */
+function httprl_pr($input) {
+  $old_setting = ini_set('mbstring.substitute_character', '"none"');
+
+  // Get extra arguments passed in.
+  $input = func_get_args();
+
+  // If bool or strlen = 0 use var_export on that variable.
+  $data = httprl_print_empty($input);
+
+  // Merge into base array if only one argument passed in.
+  if (count($data) == 1) {
+    $data = array_pop($data);
+  }
+
+  // Print_r the input.
+  $output = print_r($data, TRUE);
+
+  // Remove non UTF-8 Characters.
+  if (function_exists('mb_convert_encoding')) {
+    $translated = mb_convert_encoding($output, 'UTF-8', 'auto');
+  }
+  else {
+    $translated = @iconv('utf-8', 'utf-8//TRANSLIT//IGNORE', $output);
+  }
+
+  // Convert html entities.
+  $options = ENT_QUOTES;
+  if (defined('ENT_SUBSTITUTE')) {
+    $options = ENT_QUOTES | ENT_SUBSTITUTE;
+  }
+  elseif (defined('ENT_IGNORE')) {
+    $options = ENT_QUOTES | ENT_IGNORE;
+  }
+  $translated = htmlentities($translated, $options, 'UTF-8');
+
+  // Make sure the UTF-8 translation didn't kill the output.
+  $original_size = strlen($output);
+  $translated_size = strlen($translated);
+  $ratio = 0;
+  if ($original_size != 0) {
+    $ratio = ($original_size - $translated_size) / $original_size;
+  }
+
+  // Decide to use the original output or the translated one.
+  if (!empty($translated_size) && !empty($ratio) && $ratio < 0.5) {
+    $html_output = TRUE;
+    $output = $translated;
+  }
+  else {
+    $output = '<pre>' . str_replace(array('<', '>'), array('&lt;', '&gt;'), $output) . '</pre>';
+  }
+
+  // Remove extra new lines.
+  $output = array_filter(explode("\n", $output), 'strlen');
+
+  // Whitespace compression.
+  foreach ($output as $key => $value) {
+    if (str_replace('    ', '', $value) == "(") {
+      $output[$key - 1] .= ' (';
+      unset($output[$key]);
+    }
+  }
+
+  // Replace whitespace with html markup.
+  $output = implode("\n", $output);
+  if (!empty($html_output)) {
+    $output = str_replace('    ', '&nbsp;&nbsp;&nbsp;&nbsp;', nl2br($output)) . '<br />';
+  }
+
+  ini_set('mbstring.substitute_character', $old_setting);
+  return $output;
+}
+
+/**
+ * Helper function for determining hosts excluded from needing a proxy.
+ *
+ * @return bool
+ *   TRUE if a proxy should be used for this host.
+ */
+function _httprl_use_proxy($host) {
+  $proxy_exceptions = httprl_variable_get('proxy_exceptions', array('localhost', '127.0.0.1'));
+  return !in_array(strtolower($host), $proxy_exceptions, TRUE);
+}
+
+/**
+ * Returns a persistent variable.
+ *
+ * This version will read directly from the database if value is not in global
+ * $conf variable.
+ *
+ * Case-sensitivity of the variable_* functions depends on the database
+ * collation used. To avoid problems, always use lower case for persistent
+ * variable names.
+ *
+ * @param string $name
+ *   The name of the variable to return.
+ * @param mixed $default
+ *   The default value to use if this variable has never been set.
+ * @return mixed
+ *   The value of the variable.
+ *
+ * @see variable_del()
+ * @see variable_set()
+ */
+function httprl_variable_get($name, $default = NULL) {
+  // Try global configuration variable first.
+  global $conf;
+  if (isset($conf[$name])) {
+    return $conf[$name];
+  }
+
+  // Try database next if not at a full bootstrap level.
+  if (function_exists('db_query') && !httprl_drupal_full_bootstrap()) {
+    if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+      $variables = array_map('unserialize', db_query('SELECT name, value FROM {variable} WHERE name = :name', array(':name' => $name))->fetchAllKeyed());
+
+      // Use the default if need be.
+      return isset($variables[$name]) ? $variables[$name] : $default;
+    }
+    else {
+      $result = db_query("SELECT value FROM {variable} WHERE name = '%s'", $name);
+      if (!empty($result)) {
+        $result = db_result($result);
+        if (!empty($result)) {
+          $value = @unserialize($result);
+        }
+      }
+
+      // Use the default if need be.
+      return isset($value) ? $value : $default;
+    }
+  }
+  else {
+    // Return default if database is not available or if at a full bootstrap.
+    return $default;
+  }
+}
+
+/**
+ * Run multiple functions or methods independently or chained.
+ *
+ * Example for running a Drupal 6 Database query.
+ * @code
+ * // Run 2 queries and get it's result.
+ * $max = db_result(db_query('SELECT MAX(wid) FROM {watchdog}'));
+ * $min = db_result(db_query('SELECT MIN(wid) FROM {watchdog}'));
+ * echo $max . ' ' . $min;
+ *
+ * // Doing the same thing as above but with a set of arrays.
+ * $max = '';
+ * $min = '';
+ * $args = array(
+ *   array(
+ *     'type' => 'function',
+ *     'call' => 'db_query',
+ *     'args' => array('SELECT MAX(wid) FROM {watchdog}'),
+ *   ),
+ *   array(
+ *     'type' => 'function',
+ *     'call' => 'db_result',
+ *     'args' => array('last' => NULL),
+ *     'return' => &$max,
+ *   ),
+ *   array(
+ *     'type' => 'function',
+ *     'call' => 'db_query',
+ *     'args' => array('SELECT MIN(wid) FROM {watchdog}'),
+ *   ),
+ *   array(
+ *     'type' => 'function',
+ *     'call' => 'db_result',
+ *     'args' => array('last' => NULL),
+ *     'return' => &$min,
+ *   ),
+ * );
+ * httprl_run_array($args);
+ * echo $max . ' ' . $min;
+ * @endcode
+ *
+ * Example for running a Drupal 7 Database query.
+ * @code
+ * // Run a query and get it's result.
+ * $min = db_select('watchdog', 'w')
+ *  ->fields('w', array('wid'))
+ *  ->orderBy('wid', 'DESC')
+ *  ->range(999, 1)
+ *  ->execute()
+ *  ->fetchField();
+ * echo $min;
+ *
+ * // Doing the same thing as above but with a set of arrays.
+ * $min = '';
+ * $args = array(
+ *   array(
+ *     'type' => 'function',
+ *     'call' => 'db_select',
+ *     'args' => array('watchdog', 'w',),
+ *    ),
+ *   array(
+ *     'type' => 'method',
+ *     'call' => 'fields',
+ *     'args' => array('w', array('wid')),
+ *   ),
+ *   array(
+ *     'type' => 'method',
+ *     'call' => 'orderBy',
+ *     'args' => array('wid', 'DESC'),
+ *   ),
+ *   array(
+ *     'type' => 'method',
+ *     'call' => 'range',
+ *     'args' => array(999, 1),
+ *   ),
+ *   array(
+ *     'type' => 'method',
+ *     'call' => 'execute',
+ *     'args' => array(),
+ *   ),
+ *   array(
+ *     'type' => 'method',
+ *     'call' => 'fetchField',
+ *     'args' => array(),
+ *     'return' => &$min,
+ *   ),
+ * );
+ * httprl_run_array($args);
+ * echo $min;
+ * @endcode
+ *
+ * @param array $array
+ *   2 dimensional array
+ *   array(
+ *     array(
+ *       'type' => function or method
+ *       'call' => function name or name of object method
+ *       'args' => array(
+ *          List of arguments to pass in. If you set the key to last, the return
+ *          value of the last thing ran will be put in this place.
+ *          'last' => NULL
+ *        ),
+ *       'return' => what was returned from this call.
+ *       'printed' => what was printed from this call.
+ *       'error' => any errors that might have occurred.
+ *       'last' => set the last variable to anything.
+ *     )
+ *   )
+ */
+function httprl_run_array(&$array) {
+  $last = NULL;
+  foreach ($array as &$data) {
+    // Skip if no type is set.
+    if (!isset($data['type'])) {
+      continue;
+    }
+
+    // Set the last variable if so desired.
+    if (isset($data['last'])) {
+      $last = $data['last'];
+    }
+
+    // Replace the last key with the last thing that has been returned.
+    if (isset($data['args']) && array_key_exists('last', $data['args'])) {
+      $data['args']['last'] = $last;
+      $data['args'] = array_values($data['args']);
+    }
+
+    // Capture output if requested.
+    if (array_key_exists('printed', $data)) {
+      ob_start();
+    }
+
+    // Pass by reference trick for call_user_func_array().
+    $args = array();
+    if (isset($data['args']) && is_array($data['args'])) {
+      foreach ($data['args'] as &$arg) {
+        $args[] = &$arg;
+      }
+    }
+
+    // Start to capture errors.
+    $track_errors = ini_set('track_errors', '1');
+    $php_errormsg = '';
+
+    // Call a function or a method.
+    switch ($data['type']) {
+      case 'function':
+        if (function_exists($data['call'])) {
+          $last = call_user_func_array($data['call'], $args);
+        }
+        else {
+          $php_errormsg = 'Recoverable Fatal error: Call to undefined function ' . $data['call'] . '()';
+        }
+        break;
+
+      case 'method':
+        if (method_exists($last, $data['call'])) {
+          $last = call_user_func_array(array($last, $data['call']), $args);
+        }
+        else {
+          $php_errormsg = 'Recoverable Fatal error: Call to undefined method ' . get_class($last) . '::' . $data['call'] . '()';
+        }
+        break;
+
+    }
+
+    // Set any errors if any where thrown.
+    if (!empty($php_errormsg)) {
+      $data['error'] = $php_errormsg;
+      ini_set('track_errors', $track_errors);
+      watchdog('httprl', 'Error thrown in httprl_run_array(). <br /> @error', array('@error' => $php_errormsg),  WATCHDOG_ERROR);
+    }
+
+    // End capture.
+    if (array_key_exists('printed', $data)) {
+      $data['printed'] = ob_get_contents();
+      ob_end_clean();
+    }
+
+    // Set what was returned from each call.
+    if (array_key_exists('return', $data)) {
+      $data['return'] = $last;
+    }
+  }
+
+  return array('args' => array($array));
+}
+
+/**
+ * Run a single function.
+ *
+ * @param string $function
+ *   Name of function to run.
+ * @param array $input_args
+ *   list of arguments to pass along to the function.
+ */
+function httprl_run_function($function, &$input_args) {
+  // Pass by reference trick for call_user_func_array().
+  $args = array();
+  foreach ($input_args as &$arg) {
+    $args[] = &$arg;
+  }
+
+  // Capture anything printed out.
+  ob_start();
+
+  // Start to capture errors.
+  $track_errors = ini_set('track_errors', '1');
+  $php_errormsg = '';
+
+  // Run function.
+  $return = NULL;
+  // Do not let an exception cause issues.
+  try {
+    if (function_exists($function)) {
+      $return = call_user_func_array($function, $args);
+    }
+    else {
+      $php_errormsg = 'Recoverable Fatal error: Call to undefined function ' . $function . '()';
+    }
+  }
+  catch (Exception $e) {
+    $php_errormsg = $e;
+  }
+
+  $printed = ob_get_contents();
+  ob_end_clean();
+
+  // Create data array.
+  $data = array('return' => $return, 'args' => $args, 'printed' => $printed);
+
+  // Set any errors if any where thrown.
+  if (!empty($php_errormsg)) {
+    $data['error'] = $php_errormsg;
+    ini_set('track_errors', $track_errors);
+    watchdog('httprl', 'Error thrown in httprl_run_function(). <br /> @error', array('@error' => $php_errormsg), WATCHDOG_ERROR);
+  }
+
+  return $data;
+}
+
+/**
+ * Implements hook_boot().
+ */
+function httprl_boot() {
+  global $base_root;
+  $full_url = $base_root . request_uri();
+
+  // Return if this is not a httprl_async_function_callback request.
+  if (   strpos($full_url, '/httprl_async_function_callback') === FALSE
+      || $_SERVER['REQUEST_METHOD'] !== 'POST'
+      || empty($_POST['master_key'])
+      || empty($_POST['temp_key'])
+      || strpos($_POST['temp_key'], 'httprl_') !== 0
+      || !empty($_POST['function'])
+        ) {
+    return NULL;
+  }
+
+  // Load httprl.async.inc.
+  if (defined('DRUPAL_ROOT')) {
+    require_once DRUPAL_ROOT . '/' . dirname(drupal_get_filename('module', 'httprl')) . '/httprl.async.inc';
+  }
+  else {
+    require_once './' . dirname(drupal_get_filename('module', 'httprl')) . '/httprl.async.inc';
+  }
+  httprl_async_page();
+}
+
+/**
+ * Gets the private key variable.
+ *
+ * @return string
+ *   The private key.
+ */
+function httprl_drupal_get_private_key() {
+  $full_bootstrap = httprl_drupal_full_bootstrap();
+
+  $private_key = $full_bootstrap ? drupal_get_private_key() : httprl_variable_get('drupal_private_key', 0);
+  return $private_key;
+}
+
+/**
+ * Performs end-of-request tasks and/or call exit directly.
+ */
+function httprl_call_exit() {
+  if (defined('VERSION') && substr(VERSION, 0, 1) >= 7 && drupal_get_bootstrap_phase() == DRUPAL_BOOTSTRAP_FULL) {
+    drupal_exit();
+  }
+  else {
+    exit;
+  }
+}
+
+/**
+ * Sees if Drupal has been fully booted.
+ *
+ * @return Bool
+ *   TRUE if DRUPAL_BOOTSTRAP_FULL.
+ *   FALSE if not DRUPAL_BOOTSTRAP_FULL.
+ */
+function httprl_drupal_full_bootstrap() {
+  static $full_bootstrap;
+  if (!isset($full_bootstrap)) {
+    // See if a full bootstrap has been done given the Drupal version.
+    if (defined('VERSION') && substr(VERSION, 0, 1) >= 7) {
+      $level = drupal_bootstrap();
+      $full_bootstrap = ($level == DRUPAL_BOOTSTRAP_FULL) ? TRUE : FALSE;
+    }
+    else {
+      $full_bootstrap = isset($GLOBALS['multibyte']) ? TRUE : FALSE;
+    }
+  }
+  return $full_bootstrap;
+}
+
+
+/**
+ * Sees if httprl can run a background callback.
+ *
+ * @return Bool
+ *   TRUE or FALSE.
+ */
+function httprl_is_background_callback_capable() {
+  // Check if site is offline.
+  if ((defined('VERSION') && substr(VERSION, 0, 1) >= 7 && httprl_variable_get('maintenance_mode', 0)) || httprl_variable_get('site_offline', 0)) {
+    return FALSE;
+  }
+  // Check that the httprl_background_callback variable is enabled.
+  if (!httprl_variable_get('httprl_background_callback', HTTPRL_BACKGROUND_CALLBACK)) {
+    return FALSE;
+  }
+  // Check that the callback in menu works.
+  if (   httprl_drupal_full_bootstrap()
+      && function_exists('menu_get_item')
+      &&  !menu_get_item('httprl_async_function_callback')
+        ) {
+    return FALSE;
+  }
+
+  // All checks passed.
+  return TRUE;
+}
+
+/**
+ * Sets the global user to the given user ID.
+ *
+ * @param int $uid
+ *   Integer specifying the user ID to load.
+ */
+function httprl_set_user($uid) {
+  global $user;
+  $account = user_load($uid);
+  if (!empty($account)) {
+    $user = $account;
+    return TRUE;
+  }
+}
+
+/**
+ * Sets the global $_GET['q'] parameter.
+ *
+ * @param string $q
+ *   Internal URL.
+ */
+function httprl_set_q($q) {
+  $_GET['q'] = $q;
+}
+
+/**
+ * Queue Callback to run In a New Process.
+ *
+ * @see call_user_func_array()
+ *
+ * @param callback
+ *   The callable to be called.
+ * @param param_arr
+ *   The parameters to be passed to the callback, as an indexed array.
+ * @param $return
+ *   Set to TRUE if you want something returned.
+ * @param $httprl_options
+ *   Options to pass along to httprl_queue_background_callback.
+ * @return
+ *   Reference to the return varible OR NULL if $return is FALSE.
+ */
+function &httprl_qcinp($callback, $param_arr = array(), $return = TRUE, $httprl_options = array()) {
+  $return_var = NULL;
+
+  // Setup callback options array.
+  $callback_options[0]['function'] = $callback;
+  if ($return) {
+    $return_var = '';
+    $callback_options[0]['return'] = &$return_var;
+  }
+  if (isset($httprl_options['context'])) {
+    $callback_options[0]['context'] = $httprl_options['context'];
+    unset($httprl_options['context']);
+  }
+  $callback_options[0]['options'] = $httprl_options;
+
+  // Include function arguments.
+  $callback_options = array_merge($callback_options, $param_arr);
+
+  // Queue up the request.
+  httprl_queue_background_callback($callback_options);
+
+  return $return_var;
+}
+
+/**
+ * Given an array of data, use mutiple processes to crunch it.
+ *
+ * Similar to MapReduce.
+ *
+ * @see http://php.net/array-chunk#63394
+ *
+ * @param $callback
+ *   The function to run
+ * @param $data
+ *   The data to process.
+ * @return
+ *   Array of returned results.
+ */
+function httprl_batch_callback($callback, $data, $options = array()) {
+  // Set defaults.
+  $results = array();
+  $unified_result = NULL;
+  $number_of_items = count($data);
+  $options += array(
+    'max_batchsize' => 30,
+    'threads' => 3,
+    'timeout' => 120,
+    'multiple_helper' => FALSE,
+  );
+
+  // Shrink batchsize to evenly distribute workload if needed.
+  if ($number_of_items < $options['max_batchsize']*$options['threads']) {
+    $options['max_batchsize'] = ceil($number_of_items/$options['threads']);
+  }
+
+  // Chunk the data.
+  $data = array_chunk($data, $options['max_batchsize'], TRUE);
+
+  // Convert options to httprl_queue_background_callback options.
+  unset($options['max_batchsize']);
+  $options['domain_connections'] = $options['threads'];
+  unset($options['threads']);
+  $multiple = $options['multiple_helper'];
+  unset($options['multiple_helper']);
+
+  // Queue up the processes.
+  if ($multiple) {
+    foreach ($data as $key => $values) {
+      $results[$key] = &httprl_qcinp('httprl_run_multiple', array($callback, $values), TRUE, $options);
+    }
+  }
+  else {
+    foreach ($data as $key => $values) {
+      $results[$key] = &httprl_qcinp($callback, array($values), TRUE, $options);
+    }
+  }
+
+  // Execute in parallel.
+  httprl_send_request();
+
+  // Try to merge the results into one.
+  $unified = TRUE;
+  $is_assoc = TRUE;
+  foreach ($results as $key => $value) {
+    if (is_null($unified_result)) {
+      $unified_result = $results[$key];
+    }
+    elseif (is_string($results[$key]) && is_string($unified_result)) {
+      $unified_result .= $results[$key];
+    }
+    elseif (is_array($results[$key]) && is_array($unified_result)) {
+      if ($is_assoc && httprl_is_array_assoc($results[$key]) && httprl_is_array_assoc($unified_result)) {
+        $unified_result = httprl_lossless_assoc_array_merge($unified_result, $results[$key]);
+      }
+      else {
+        $is_assoc = FALSE;
+        $unified_result += $results[$key];
+      }
+    }
+    else {
+      $unified = FALSE;
+      break;
+    }
+  }
+
+  // Return results.
+  if ($unified) {
+    return $unified_result;
+  }
+  else {
+    return $results;
+  }
+}
+
+/**
+ * Given an array return TRUE if all keys are numeric.
+ *
+ * @see http://stackoverflow.com/questions/173400/php-arrays-a-good-way-to-check-if-an-array-is-associative-or-sequential/2444661#2444661
+ *
+ * @param $array
+ *   The data to process.
+ * @return
+ *   TRUE or FALSE.
+ */
+function httprl_is_array_assoc($array) {
+  return ctype_digit(implode('', array_keys($array)));
+}
+
+/**
+ * Merge mutiple associative arrays into one.
+ *
+ * @see http://stackoverflow.com/questions/2148694/how-to-combine-2-associative-arrays-in-php-such-that-we-do-not-overwrite-any-dup/2152054#2152054
+ *
+ * @param ...
+ *   Arrays to merge.
+ * @return
+ *   Merged array.
+ */
+function httprl_lossless_assoc_array_merge() {
+  $arrays = func_get_args();
+  $data = array();
+  foreach ($arrays as $a) {
+    foreach ($a as $k => $v) {
+      if (isset($data[$k])) {
+        $data[] = $v;
+      }
+      else {
+        $data[$k] = $v;
+      }
+    }
+  }
+  return $data;
+}
+
+/**
+ * Run array of data through callback.
+ *
+ *
+ * @param $data
+ *   The data to process.
+ * @param $callback
+ *   The function to run
+ * @return
+ *   Array of results.
+ */
+function httprl_run_multiple($callback, $data) {
+  $results = array();
+  foreach ($data as $key => $values) {
+    $results[$key] = call_user_func_array($callback, array($values));
+  }
+  return $results;
+}

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.admin.inc
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.admin.inc
@@ -1,0 +1,199 @@
+<?php
+/**
+ * @file Admin functions for the CloudFlare cache clear module
+ */
+
+
+/**
+ * Form builder: CloudFlare cache clear configuration form
+ */
+function cloudflare_cache_clear_configuration_form($form, &$form_state) {
+
+  $zone_set = _cloudflare_cache_clear_get_setting('zone');
+
+  $form['account_details'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Account details'),
+    '#collapsible' => TRUE,
+  );
+
+
+  // API key
+  $form['account_details'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'api_key'] = array(
+    '#type' => 'textfield',
+    '#title' => t('API key'),
+    '#description' => t('Your CloudFlare API key, generated on the <a href="@url">"My Account" page</a>.', array('@url' => 'https://www.cloudflare.com/a/account/my-account')),
+    '#default_value' => _cloudflare_cache_clear_get_setting('api_key'),
+  );
+
+  // Email address
+  $form['account_details'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'email'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Email address'),
+    '#description' => t('Your CloudFlare authorised email address. You can find this on the <a href="@url">"My Account" page</a>.', array('@url' => 'https://www.cloudflare.com/a/account/my-account')),
+    '#default_value' => _cloudflare_cache_clear_get_setting('email'),
+  );
+
+  // Zone
+  $form['account_details'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'zone'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Zone'),
+    '#description' => t('The CloudFlare zone for which you would like to clear the cache. Start typing the URL to view a list of available zones.'),
+    '#default_value' => _cloudflare_cache_clear_get_setting('zone'),
+    '#autocomplete_path' => _cloudflare_cache_clear_connect_status() ? 'admin/config/services/cloudflare/zones' : NULL,
+    //'#access' => _cloudflare_cache_clear_connect_status(),
+    '#access' => _cloudflare_cache_clear_account_authenticated(),
+  );
+
+  $form['domains'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Domains and protocols'),
+    '#collapsible' => TRUE,
+    '#access' => _cloudflare_cache_clear_account_authenticated() && $zone_set,
+  );
+
+
+
+  $form['domains'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'domains'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Domains to be cleared from CloudFlare'),
+    '#description' => t('Include a list of domains to be cleared from CloudFlare. Do not include the "http://" part.'),
+    '#default_value' => _cloudflare_cache_clear_get_setting('domains'),
+  );
+
+  $form['domains'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'protocols'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Protocols to be cleared from CloudFlare'),
+    '#description' => t('Which protocols should be cleared from CloudFlare?'),
+    '#options' => array(
+      'http' => t('HTTP'),
+      'https' => t('HTTPS'),
+    ),
+    '#default_value' => _cloudflare_cache_clear_get_setting('protocols', array('http')),
+  );
+
+
+  $form['entity_types'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Entity types'),
+    '#access' => _cloudflare_cache_clear_account_authenticated() && $zone_set,
+  );
+
+  $form['entity_types'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'entity_types'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Select entity types to purge from CloudFlare'),
+    '#description' => t('Choose which types of entity will trigger clearing of the CloudFlare cache.'),
+    '#options' => _cloudflare_cache_clear_entity_types(),
+    '#default_value' => _cloudflare_cache_clear_get_setting('entity_types'),
+  );
+
+  $form['advanced_settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Advanced settings'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#access' => _cloudflare_cache_clear_account_authenticated() && $zone_set,
+  );
+
+
+  $form['advanced_settings'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'endpoint'] = array(
+    '#type' => 'textfield',
+    '#title' => t('CloudFlare API endpoint'),
+    '#description' => t('Set the URL of the CloudFlare API endpoint. If in doubt, leave alone. Do not include the version'),
+    '#default_value' => _cloudflare_cache_clear_get_setting('endpoint'),
+  );
+
+
+  $form['advanced_settings'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'api_version'] = array(
+    '#type' => 'select',
+    '#title' => t('API version'),
+    '#options' => array(
+      4 => 4,
+    ),
+    '#default_value' => _cloudflare_cache_clear_get_setting('api_version'),
+  );
+
+  $form['advanced_settings'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'urls_per_request'] = array(
+    '#type' => 'textfield',
+    '#title' => t('URLs to clear per request'),
+    '#description' => t('Enter the maximum number of URLs to clear per request to the CloudFlare API.'),
+    '#default_value' => _cloudflare_cache_clear_get_setting('urls_per_request'),
+  );
+
+  $form['advanced_settings'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'exclude_paths'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Exclude paths from cache clearing'),
+    '#description' => t('Enter a list of any paths that you would like to exclude from cache clearing. Include just the path - no domain, protocol or forward slash. Each path should be on a new line.'),
+    '#default_value' => _cloudflare_cache_clear_get_setting('exclude_paths'),
+  );
+
+  $form['advanced_settings'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'exclude_admin_paths'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Exclude admin paths from cache clearing'),
+    '#description' => t('If ticked, paths that look like they are part of the administrative interface will not be cleared from the CloudFlare cache.'),
+    '#default_value' => _cloudflare_cache_clear_get_setting('exclude_admin_paths'),
+  );
+
+  $form['advanced_settings'][CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'log_level'] = array(
+    '#type' => 'select',
+    '#title' => t('Logging level'),
+    '#description' => t('Set the level of log messages to capture.'),
+    '#options' => watchdog_severity_levels(),
+    '#default_value' => _cloudflare_cache_clear_get_setting('log_level'),
+  );
+
+  $form['#validate'][] = 'cloudflare_cache_clear_configuration_form_validate_account_details';
+
+  return system_settings_form($form);
+
+}
+
+
+/**
+ * Validation function: Check acount details
+ */
+function cloudflare_cache_clear_configuration_form_validate_account_details($form, $form_state) {
+  $values = !empty($form_state['values']) ? $form_state['values'] : array();
+  $key = !empty($values[CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'api_key']) ? $values[CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'api_key'] : NULL;
+  $email = !empty($values[CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'email']) ? $values[CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'email'] : NULL;
+
+  // NULL values for API key and email are not allowed. If either is empty,
+  // return an error now
+  if (empty($key)) {
+    form_set_error(CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'api_key', t('Missing API key'));
+  }
+  if (empty($email)) {
+    form_set_error(CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'email', t('Missing email address'));
+  }
+
+  // If we have values for email and api key, we need to check that they're
+  // valid - but we only need do this if they have changed or if they are
+  // not currently valid.
+  $existing_email = _cloudflare_cache_clear_get_setting('email');
+  $existing_key = _cloudflare_cache_clear_get_setting('api_key');
+  if (_cloudflare_cache_clear_account_authenticated() && $email == $existing_email && $key == $existing_key) {
+    return;
+  }
+
+  $auth_check = _cloudflare_cache_clear_check_account_details($key, $email);
+  $field_names = array(
+    'X-Auth-Key header' => 'api_key',
+    'X-Auth-Email header' => 'email',
+  );
+  if (empty($auth_check['success'])) {
+    $error_field = 'api_key';
+    foreach ($field_names as $header => $field_name) {
+      if (strpos($auth_check['message'], $header) !== FALSE) {
+        $error_field = $field_name;
+        break;
+      }
+    }
+    _cloudflare_cache_clear_account_authenticated(FALSE);
+    form_set_error(CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . $error_field, t('CloudFlare authentication failed with the following errors: @errs.', array('@errs' => $auth_check['message'])));
+  }
+  else {
+    _cloudflare_cache_clear_account_authenticated(TRUE);
+    drupal_set_message(t('CloudFlare account details successfully authenticated.'));
+  }
+
+}

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.info
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.info
@@ -1,0 +1,7 @@
+name = CloudFlare Cache Clear
+description = "Allows clearing of the CloudFlare cache"
+core = 7.x
+dependencies[] = expire
+dependencies[] = httprl
+configure = admin/config/services/cloudflare
+package = CloudFlare

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.install
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.install
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for the CloudFlare cache clear module
+ */
+
+/**
+ * Implements hook_install().
+ */
+function cloudflare_cache_clear_install() {
+  $variables = array(
+    '@config_url' => url('admin/config/services/cloudflare'),
+  );
+  drupal_set_message(t('CloudFlare cache clear module successfully installed. You should now <a href="@config_url">modify the configuration</a> in order for the module to function properly.', $variables));
+}
+
+
+/**
+ * Implements hook_uninstall().
+ */
+function cloudflare_cache_clear_uninstall() {
+  drupal_load('module', 'cloudflare_cache_clear');
+  // Delete  variables
+  $variables = array(
+    'api_key',
+    'email',
+    'zone',
+    'domains',
+    'protocols',
+    'entity_types',
+    'endpoint',
+    'api_version',
+    'urls_per_request',
+    'exclude_paths',
+    'exclude_admin_paths',
+    'log_level',
+    'account_authenticated',
+  );
+  foreach($variables as $variable) {
+    $variable_name = CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . $variable;
+    variable_del($variable_name);
+  }
+}

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
@@ -633,12 +633,12 @@ function _cloudflare_cache_clear_check_account_details($key, $email) {
 /**
  * Helper function: Determines whether CloudFlare account details are correct
  */
-function _cloudflare_cache_clear_account_authenticated($authenticated = NULL) {
+function _cloudflare_cache_clear_account_authenticated($authenticated = FALSE) {
   $variable_name = CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'account_authenticated';
   if (func_num_args() > 0) {
     variable_set($variable_name, $authenticated);
   }
-  return variable_get($variable_name);
+  return variable_get($variable_name, FALSE);
 }
 
 
@@ -713,4 +713,18 @@ function _cloudflare_cache_clear_load_file_by_url($url) {
     return $file;
   }
   return NULL;
+}
+
+
+/**
+ * Returns the chosen protocols for clearing from the CloudFlare cache
+ */
+function cloudflare_cache_clear_get_protocols() {
+  $return = array();
+  foreach(array_values(_cloudflare_cache_clear_get_setting('protocols')) as $protocol) {
+    if (!empty($protocol)) {
+      $return[] = $protocol;
+    }
+  }
+  return $return;
 }

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
@@ -1,0 +1,716 @@
+<?php
+/**
+ * @file Module code for the CloudFlare cache clearing module
+ */
+
+
+/**
+ * Variable prefix
+ */
+define('CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX', 'cloudflare_cache_clear_');
+
+/**
+ * Default CloudFlare API version - can be overridden via Drupal admin UI
+ */
+define('CLOUDFLARE_CACHE_CLEAR_DEFAULT_API_VERSION', 4);
+
+/**
+ * Default API endpoint - can be overridden via Drupal admin UI
+ */
+define('CLOUDFLARE_CACHE_CLEAR_DEFAULT_ENDPOINT', 'https://api.cloudflare.com/client');
+
+/**
+ * Default logging level - can be overridden via Drupal admin UI
+ */
+define('CLOUDFLARE_CACHE_CLEAR_DEFAULT_LOG_LEVEL', WATCHDOG_ERROR);
+
+
+/**
+ * Implements hook_permission().
+ */
+function cloudflare_cache_clear_permission() {
+  return array(
+    'administer cloudflare cache clear' => array(
+      'title' => t('Administer CloudFlare cache clearing'),
+      'description' => t('Perform administration and configuration tasks for the CloudFlare cache clearing module.'),
+    ),
+  );
+}
+
+
+/**
+ * Implements hook_menu().
+ */
+function cloudflare_cache_clear_menu() {
+  return array(
+    // Main configuration interface
+    'admin/config/services/cloudflare' => array(
+      'title' => 'CloudFlare',
+      'description' => 'Perform administration and configuration tasks for the CloudFlare cache clearing module',
+      'access arguments' => array('administer cloudflare cache clear'),
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('cloudflare_cache_clear_configuration_form'),
+      'file' => 'cloudflare_cache_clear.admin.inc',
+    ),
+    // Autocomplete callback for zones lookup field
+    'admin/config/services/cloudflare/zones' => array(
+      'title' => 'CloudFlare zones',
+      'description' => 'Autocomplete function for CloudFlare zones',
+      'access arguments' => array('administer cloudflare cache clear'),
+      'page callback' => '_cloudflare_cache_clear_zones_autocomplete',
+      'type' => MENU_CALLBACK,
+    ),
+  );
+}
+
+
+/**
+ * Implements hook_expire_cache().
+ *
+ * This hook is invoked by the Expire module when an entity needs to be purged
+ * from the cache.
+ *
+ * Note that since CloudFlare does not support wildcard cache purging, we just
+ * ignore these.
+ */
+function cloudflare_cache_clear_expire_cache($urls, $wildcards, $object_type, $object) {
+  $entity_types = _cloudflare_cache_clear_get_setting('entity_types');
+  if (empty($entity_types[$object_type])) {
+    if (!empty($object_type) && !empty($object)) {
+      $entity_info = entity_extract_ids($object_type, $object);
+      _cloudflare_cache_clear_log('Skipping CloudFlare cache clearing for  @object_type @entity_id.', array('@object_type' => $object_type, '@entity_id' => $entity_info[0]), WATCHDOG_DEBUG);
+    }
+    return;
+  }
+  // Allow other modules to alter the URLs to be purged by cache expiration
+  drupal_alter('cloudflare_cache_clear_expire_cache', $urls, $wildcards, $object_type, $object);
+  if (!empty($urls)) {
+    cloudflare_cache_clear_purge_urls($urls, $wildcards, $object_type, $object);
+  }
+}
+
+
+/**
+ * Purge URLs from the CloudFlare cache
+ *
+ * This function can be called to purge URLs from the CloudFlare cache.
+ *
+ * @param array $urls
+ *   An array of URLs to be purged from Cloudflare. Note that these should be
+ *   Drupal paths, not full URLs - ie they should not contain the protocol,
+ *   domain or a leading forward slash.
+ *
+ * @param array $wildcards
+ *   Not used. This is here only to be consistent with the Expire module.
+ *
+ * @param string $object_type
+ *   (optional) The type of obect that is being purged.
+ *
+ * @param object $object
+ *   (optional) The object that has triggered the purge.
+ *
+ */
+function cloudflare_cache_clear_purge_urls($urls, $wildcards = NULL, $object_type = NULL, $object = NULL) {
+  // Allow modules to alter the paths to be cleared
+  drupal_alter('cloudflare_cache_clear_paths', $urls, $wildcards, $object_type, $object);
+  // Allow modules to take action when URLs are to be purged
+  module_invoke_all('cloudflare_cache_clear', $urls, $wildcards, $object_type, $object);
+}
+
+
+/**
+ * Implements hook_cloudflare_cache_clear_paths_alter().
+ */
+function cloudflare_cache_clear_cloudflare_cache_clear_paths_alter(&$paths, $wildcards, $object_type, $object) {
+  // Remove paths that users have chosen to exclude from purging
+  $exclude_paths = _cloudflare_cache_clear_split_text(_cloudflare_cache_clear_get_setting('exclude_paths'));
+  foreach ($paths as $key => $path) {
+    if (in_array($path, $exclude_paths)) {
+      unset($paths[$key]);
+    }
+    // Exclude administrative paths - if selected by administrators (default).
+    if (_cloudflare_cache_clear_get_setting('exclude_admin_paths') && path_is_admin($path)) {
+      unset($paths[$key]);
+    }
+  }
+}
+
+
+/**
+ * Implements cloudflare_cache_clear().
+ */
+function cloudflare_cache_clear_cloudflare_cache_clear($urls, $wildcards = NULL, $object_type = NULL, $object = NULL) {
+  // Call the function that actually purges the URLs
+  _cloudflare_cache_clear_purge_urls($urls, $wildcards, $object_type, $object);
+}
+
+
+/**
+ * Helper function: gets available zones
+ *
+ * @return array
+ *   An array of available CloudFlare zone objects
+ */
+function _cloudflare_cache_clear_get_zones() {
+  $options = array(
+    'headers' => _cloudflare_cache_clear_auth_headers(),
+  );
+  $url = '/zones';
+  $response = drupal_http_request(_cloudflare_cache_clear_endpoint() . $url, $options);
+  if (empty($response) || !is_object($response) || empty($response->data)) {
+    return array();
+  }
+  else {
+    $result = json_decode($response->data);
+    return !empty($result->result) ? $result->result : array();
+  }
+}
+
+
+/**
+ * Helper function: returns CloudFlare authentication headers
+ *
+ * @return array
+ *   Associative array of CloudFlare authentication headers and their stored
+ *   values.
+ */
+function _cloudflare_cache_clear_auth_headers() {
+  return array(
+    'X-Auth-Key' => _cloudflare_cache_clear_get_setting('api_key'),
+    'X-Auth-Email' => _cloudflare_cache_clear_get_setting('email'),
+  );
+}
+
+
+/**
+ * Helper function: returns the CloudFlare API endpoint
+ *
+ * @peram integer $version
+ *   (optional) The specific version of the CloudFlare API to use. If omitted,
+ *   the default version or the version stored in settings will be used.
+ *
+ * @return string
+ *   The URL of the CloudFlare API endpoint. NB This does not include a trailing
+ *   slash.
+ */
+function _cloudflare_cache_clear_endpoint($version = CLOUDFLARE_CACHE_CLEAR_DEFAULT_API_VERSION) {
+  $endpoint = _cloudflare_cache_clear_get_setting('endpoint');
+  $version = func_num_args() > 0 ? func_get_arg(0) : _cloudflare_cache_clear_get_setting('api_version');
+  return "$endpoint/v$version";
+}
+
+
+/**
+ * Helper function: determines whether we can make a successful connection
+ *
+ * @deprecated This should no longer be used and can probably be removed.
+ */
+function _cloudflare_cache_clear_connect_status() {
+
+  // No API key or email address? Can't connect
+  $key = _cloudflare_cache_clear_get_setting('api_key');
+  $email = _cloudflare_cache_clear_get_setting('email');
+  if (empty($key) || empty($email)) {
+    return FALSE;
+  }
+
+  // Try to get zones
+  $zones = _cloudflare_cache_clear_get_zones();
+  if (empty($zones)) {
+    return FALSE;
+  }
+
+  return TRUE;
+
+}
+
+
+/**
+ * Helper function: determines whether account details are populated
+ *
+ * @return boolean
+ *   TRUE if both the API key and email address settings are populated. FALSE
+ *   otherwise.
+ */
+function _cloudflare_cache_clear_account_details_provided() {
+  $key = _cloudflare_cache_clear_get_setting('api_key');
+  $email = _cloudflare_cache_clear_get_setting('email');
+  return !empty($key) && !empty($email);
+}
+
+
+/**
+ * Autocomplete function for CloudFlare API zones
+ *
+ * @param string $string
+ *   Value of the autocomplete field - used to match with the CloudFlare zones.
+ *
+ * @return string
+ *   JSON formatted array of zone IDs and domains.
+ *
+ * @see cloudflare_cache_clear_menu().
+ * @see cloudflare_cache_clear_configuration_form()
+ */
+function _cloudflare_cache_clear_zones_autocomplete($string) {
+  $zones = &drupal_static(__FUNCTION__);
+  if (!isset($zones)) {
+    $zones = _cloudflare_cache_clear_get_zones();
+  }
+  $matches = array();
+  foreach ($zones as $zone) {
+    if (!empty($zone->name) && strpos($zone->name, $string) !== FALSE) {
+      $matches[$zone->id] = $zone->name;
+    }
+  }
+  drupal_json_output($matches);
+}
+
+
+
+/**
+ * Purge URLs from CloudFlare
+ *
+ * This is the function that actually purges the required URLs from CloudFlare.
+ *
+ * It should not be called directly. Instead, modules should call
+ * cloudflare_cache_clear_purge_urls().
+ *
+ * @param array $urls
+ *   An array of paths to be cleared from the CloudFlare cache
+ *
+ * @param array $wildcards
+ *   Not used. Exists only to be consistent with the Expire module.
+ *
+ * @param string object_type
+ *   (optional) The type of object that has caused a cache clearing event
+ *
+ * @param object $object
+ *   (optional) The object that has caused a cache clearing event.
+ */
+function _cloudflare_cache_clear_purge_urls($urls, $wildcards = NULL, $object_type = NULL, $object = NULL) {
+
+  if (empty($urls) || !is_array($urls)) {
+    return;
+  }
+
+  // An empty array to hold the files to be cleared from CloudFlare
+  $files = array();
+
+  // Build an array of domains to be cleared from CloudFlare
+  $domains = _cloudflare_cache_clear_domains();
+  foreach ($urls as $url) {
+    if (!empty($url)) {
+      foreach ($domains as $domain) {
+        $files[] = trim($domain) . '/' . trim($url);
+      }
+    }
+  }
+
+  // Make sure the files to be purged are unique. We don't want to waste API
+  // calls.
+  $files = array_unique($files);
+
+  // Allow other modules to alter the full URLs to be purged from CloudFlare
+  drupal_alter('cloudflare_cache_clear_urls', $files);
+
+  _cloudflare_cache_clear_log('@count URLs to be cleared from CloudFlare: !urls.', array('@count' => count($files), '!urls' => theme('item_list', array('items' => $files))), WATCHDOG_DEBUG);
+
+  // Break the list of URLs down into chunks based on the number of files that
+  // can be cleared from CloudFlare in one request - currently 30.
+  $queue = array_chunk($files, _cloudflare_cache_clear_get_setting('urls_per_request'));
+  // Define a threshold above which non-blocking requests will be used
+  $blocking_threshold = 2;
+
+  foreach ($queue as $item) {
+    $data = array(
+      'files' => $item,
+    );
+    $options = array(
+      'headers' => _cloudflare_cache_clear_auth_headers(),
+      'method' => 'DELETE',
+      'data' => json_encode($data, JSON_UNESCAPED_SLASHES),
+      // @todo Allow other modules to provide callbacks?
+      'callback' => array(
+        array(
+          'function' => '_cloudflare_cache_clear_log_request_details',
+        ),
+      ),
+    );
+    $url = _cloudflare_cache_clear_endpoint() . '/zones/' . _cloudflare_cache_clear_get_setting('zone') . '/purge_cache';
+
+    // If we need only one request, use standard drupal_http_request()
+    if (count($queue) === 1) {
+      $request = drupal_http_request($url, $options);
+      _cloudflare_cache_clear_log_request_details($request);
+    }
+    // If there are more files to clear than can be done in one request, we use
+    // httprl_request() instead to issue parallel requests.
+    else {
+      $options['blocking'] = count($queue) > $blocking_threshold ? FALSE : TRUE;
+      httprl_request($url, $options);
+    }
+  }
+
+  if (count($queue) > 1) {
+    $request = httprl_send_request();
+  }
+  drupal_set_message('Request to purge URLs sent to CloudFlare.');
+}
+
+
+/**
+ * Helper function: Returns a list of domains to be cleared from CloudFlare
+ *
+ * @return array
+ *   An array of domains to be used to clear URLs from the CloudFlare cache
+ */
+function _cloudflare_cache_clear_domains($allow_modification = TRUE) {
+  // Get the domains from the module settings
+  $domains = preg_split('/[\n\r]/', _cloudflare_cache_clear_get_setting('domains'));
+  // @todo Add a hook here to get additional domains
+  $return = array();
+  foreach ($domains as $key => $domain) {
+    if (empty($domain)) {
+      unset($domains[$key]);
+      continue;
+    }
+    foreach(array_values(_cloudflare_cache_clear_get_setting('protocols')) as $protocol) {
+      if (!empty($protocol)) {
+        $return[] = "$protocol://$domain";
+      }
+    }
+  }
+  // Allow other modules to alter the domains to be cleared
+  drupal_alter('cloudflare_cache_clear_domains', $return);
+  return $return;
+}
+
+
+/**
+ * Helper function: removes protocol from URL
+ */
+function _cloudflare_cache_clear_strip_url_protocol($url) {
+  return preg_replace("/^http(s)?:\/\//", '', $url);
+}
+
+
+/**
+ * Helper function: returns setting values for this module
+ *
+ * @param string $setting
+ *   The name of the setting to retrieve.
+ *
+ * @param mixed $default
+ *   A default value to use if the setting is not populated. NB. sometimes this
+ *   will override the defaults already set, but not always. See code below for
+ *   details.
+ *
+ * @return mixed
+ *   The value of the setting or a default if provided. If no corresponding
+ *   setting is found, NULL is returned.
+ */
+function _cloudflare_cache_clear_get_setting($setting, $default = NULL) {
+
+  $default_supplied = func_num_args() === 2 ? TRUE : FALSE;
+
+  $return = NULL;
+
+  if (empty($setting)) {
+    return $return;
+  }
+  $variable_name = CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . $setting;
+
+  switch ($setting) {
+    case 'domains':
+      $default = $default_supplied && !empty($default) ? $default : _cloudflare_cache_clear_strip_url_protocol($GLOBALS['base_url']);
+      $return = variable_get($variable_name, $default);
+      break;
+    case 'protocols':
+      $default = $default_supplied && !empty($default) ? $default : array('http' => 'http');
+      $return = variable_get($variable_name, $default);
+      break;
+    case 'endpoint':
+      $default = CLOUDFLARE_CACHE_CLEAR_DEFAULT_ENDPOINT;
+      $return = variable_get($variable_name, $default);
+      $return = empty($return) ? $default : $return;
+      break;
+    case 'api_version':
+      $default = $default_supplied && !empty($default) ? $default : CLOUDFLARE_CACHE_CLEAR_DEFAULT_API_VERSION;
+      $return = variable_get($variable_name, $default);
+      break;
+    case 'urls_per_request':
+      $default = $default_supplied && !empty($default) ? $default : 30;
+      $return = variable_get($variable_name, $default);
+      $return = empty($return) ? $default : $return;
+      break;
+    case 'exclude_admin_paths':
+      $default = TRUE;
+      $return = variable_get($variable_name, $default);
+      break;
+    case 'log_level':
+      $default = CLOUDFLARE_CACHE_CLEAR_DEFAULT_LOG_LEVEL;
+      $return = variable_get($variable_name, $default);
+      break;
+    case 'entity_types':
+      $default = array('node', 'file');
+      $return = variable_get($variable_name, $default);
+      break;
+    default:
+      $return = variable_get($variable_name, $default);
+      break;
+  }
+
+  return $return;
+}
+
+
+/**
+ * Implements hook_cloudflare_cache_clear_domains_alter().
+ */
+function cloudflare_cache_clear_cloudflare_cache_clear_domains_alter(&$domains) {}
+
+
+/**
+ * Helper function: converts text separated by linebreaks into an array
+ */
+function _cloudflare_cache_clear_split_text($text) {
+  return preg_split("/(\r\n?|\n)/", $text);
+}
+
+
+/**
+ * Callback function for HTTPRL requests
+ *
+ * This is used primarily for logging the results of requests.
+ *
+ * @see _cloudflare_cache_clear_purge_urls()
+ * @todo Allow other modules to provide callbacks?
+ */
+function _cloudflare_cache_clear_log_request_details($request) {
+  if (empty($request)) {
+    return;
+  }
+  // If we're on debug level and devel is available, log a message to the
+  // screen.
+  if (_cloudflare_cache_clear_get_setting('log_level') == WATCHDOG_DEBUG && module_exists('devel')) {
+    dpm($request, 'CloudFlare cache clear request');
+  }
+
+  $status_message = property_exists($request, 'status') ? $request->status : (property_exists($request, 'status_message') ? $request->status_message : '');
+  $data = !empty($request->data) ? json_decode($request->data) : NULL;
+  $result_id = !empty($data) && !empty($data->result) && !empty($data->result->id) ? $data->result->id : '';
+  $errors = !empty($data) && !empty($data->errors) ? $data->errors : array();
+  $errs_array = array();
+  foreach ($errors as $error) {
+    $errs_array[] = $error->code . ' ' . $error->message;
+  }
+  $error_message = !empty($errs_array) ? implode(', ', $errs_array) : '';
+
+  $log_level = (!empty($request->code) && $request->code >= 400) ? WATCHDOG_ERROR : WATCHDOG_INFO;
+
+  if ($log_level <= WATCHDOG_ERROR) {
+    drupal_set_message(t('An error occurred purging pages from CloudFlare. Please check the logs for more information.'), 'error');
+  }
+
+  $message = array();
+  $message[] = 'CloudFlare cache clear request returned code @code with status %status.';
+  $message[] = !empty($result_id) ? 'The result ID was: @result_id.' : '';
+  $message[] = !empty($error_message) ? 'The following errors were returned: %error_message.' : '';
+  $message = implode(' ', $message);
+
+  $variables = array(
+    '@code' => $request->code,
+    '%status' => $status_message,
+    '@result_id' => $result_id,
+    '@request' => serialize($request),
+    '%error_message' => $error_message,
+  );
+
+  _cloudflare_cache_clear_log($message, $variables, $log_level);
+}
+
+
+/**
+ * Helper function: used to log messages
+ */
+function _cloudflare_cache_clear_log($message, $variables = array(), $level = WATCHDOG_NOTICE) {
+  if ($level > _cloudflare_cache_clear_get_setting('log_level')) {
+    return;
+  }
+  $type = 'cloudflare_cache_clear';
+  watchdog($type, $message, $variables, $level);
+}
+
+
+/**
+ * Helper function: returns a list of entity types for purging
+ */
+function _cloudflare_cache_clear_entity_types() {
+  $entity_types = module_invoke_all('cloudflare_cache_clear_entity_types');
+  return $entity_types;
+}
+
+
+/**
+ * Implements hook_action_info().
+ */
+function cloudflare_cache_clear_action_info() {
+  return array(
+    'cloudflare_cache_clear_clear_cache_action' => array(
+      'type' => 'entity',
+      'label' => t('Clear entity from the CloudFlare cache'),
+      'behavior' => array('none'), // We don't want this to trigger save hooks
+      'configurable' => FALSE,
+      'vbo_configurable' => FALSE,
+      'triggers' => array('any'),
+      'aggregate' => TRUE,
+    ),
+  );
+}
+
+
+/**
+ * Action callback
+ *
+ * @see cloudflare_cache_clear_action_info().
+ */
+function cloudflare_cache_clear_clear_cache_action($entities, $context) {
+  $urls = array();
+  $entities = !is_array($entities) ? array($entities) : $entities;
+  foreach ($entities as $entity) {
+    $entity_type = !empty($context['entity_type']) ? $context['entity_type'] : NULL;
+    $entity_ids = !empty($entity) && !empty($entity_type) ? entity_extract_ids($entity_type, $entity) : array();
+    $entity_id = !empty($entity_ids[0]) ? $entity_ids[0] : NULL;
+    $entity_uri = entity_uri($entity_type, $entity);
+    $internal_path = !empty($entity_uri['path']) ? $entity_uri['path'] : NULL;
+    $alias = drupal_get_path_alias($internal_path);
+    if (!empty($internal_path)) {
+      $urls[] = $internal_path;
+      if (!empty($alias) && $alias != $internal_path) {
+        $urls[] = $alias;
+      }
+    }
+  }
+  if (!empty($urls)) {
+    cloudflare_cache_clear_purge_urls($urls);
+  }
+}
+
+
+/**
+ * Helper function: Checks CloudFlare account details
+ */
+function _cloudflare_cache_clear_check_account_details($key, $email) {
+  $headers = empty($key) || empty($email) ? _cloudflare_cache_clear_auth_headers() : array('X-Auth-Key' => $key, 'X-Auth-Email' => $email);
+  $options = array(
+    'headers' => $headers,
+  );
+  // To check authentication, we just try to retrieve user details.
+  $url = _cloudflare_cache_clear_endpoint() . '/user';
+  $response = drupal_http_request($url, $options);
+  $success = !empty($response->code) && $response->code == 200;
+  $data = !empty($response->data) ? json_decode($response->data) : '';
+  $errors = !empty($data) && !empty($data->errors) ? $data->errors : array();
+  $errs = array();
+  foreach ($errors as $error) {
+    if (!empty($error->code) && !empty($error->message)) {
+      $errs[] = $error->code . ': ' . $error->message;
+    }
+    if (!empty($error->error_chain)) {
+      foreach ($error->error_chain as $err) {
+        $errs[] = $err->code . ': ' . $err->message;
+      }
+    }
+  }
+  $return = array(
+    'success' => $success,
+    'message' => implode(', ', $errs),
+  );
+  return $return;
+}
+
+
+/**
+ * Helper function: Determines whether CloudFlare account details are correct
+ */
+function _cloudflare_cache_clear_account_authenticated($authenticated = NULL) {
+  $variable_name = CLOUDFLARE_CACHE_CLEAR_VARIABLE_PREFIX . 'account_authenticated';
+  if (func_num_args() > 0) {
+    variable_set($variable_name, $authenticated);
+  }
+  return variable_get($variable_name);
+}
+
+
+/**
+ * Implements hook_cloudflare_cache_clear_entity_types().
+ */
+function cloudflare_cache_clear_cloudflare_cache_clear_entity_types() {
+  $entity_types = array(
+    'node' => t('Nodes'),
+    'file' => t('Files'),
+    'user' => t('Users'),
+    'taxonomy_term' => t('Taxonomy terms'),
+    'menu_link' => t('Menu links'),
+  );
+  return $entity_types;
+}
+
+
+/**
+ * Helper function to get the object type based on path
+ *
+ * This is very rudimentary, but for our purposes, we don't need anything
+ * especially sophisticated, since we use this function primarily within the
+ * purge now functionality.
+ *
+ */
+function _cloudflare_cache_clear_get_object_type_from_path($path) {
+  if (empty($path)) {
+    return NULL;
+  }
+
+  $public_path = variable_get('file_public_path');
+  $private_path = 'system/files';
+
+  // Is it a file path
+  if (strpos($path, $public_path) === 0 || strpos($path, $private_path) === 0) {
+    return 'file';
+  }
+
+  // Is it an unaliased node page?
+  if (strpos($path, 'node/') === 0 && strpos($path, 'node/add') === FALSE) {
+    return 'node';
+  }
+
+  // Is it a user path?
+  if (preg_match("/^user\/[0-9]+$/", $path)) {
+    return 'user';
+  }
+
+  // Check if our path is a node alias
+  if (preg_match("/^node\/[0-9]+/", drupal_lookup_path('source', $path))) {
+    return 'node';
+  }
+
+  return 'unknown';
+}
+
+
+/**
+ * Helper function: attempts to load a file object based on URL
+ */
+function _cloudflare_cache_clear_load_file_by_url($url) {
+  $public_path = variable_get('file_public_path');
+  $uri = str_replace($public_path . '/', 'public://', $url);
+  $query = db_select('file_managed', 'f')
+    ->fields('f', array('fid'))
+    ->condition('uri', $uri);
+  $fids = $query->execute()->fetchCol('fid');
+  if (!empty($fids)) {
+    $fid = current($fids);
+    $file = file_load($fid);
+    return $file;
+  }
+  return NULL;
+}

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
@@ -301,7 +301,7 @@ function _cloudflare_cache_clear_purge_urls($urls, $wildcards = NULL, $object_ty
   foreach ($urls as $url) {
     if (!empty($url)) {
       foreach ($domains as $domain) {
-        $files[] = trim($domain) . '/' . urlencode(trim($url));
+        $files[] = trim($domain) . '/' . drupal_encode_path(trim($url));
       }
     }
   }

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/cloudflare_cache_clear.module
@@ -301,7 +301,7 @@ function _cloudflare_cache_clear_purge_urls($urls, $wildcards = NULL, $object_ty
   foreach ($urls as $url) {
     if (!empty($url)) {
       foreach ($domains as $domain) {
-        $files[] = trim($domain) . '/' . trim($url);
+        $files[] = trim($domain) . '/' . urlencode(trim($url));
       }
     }
   }

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_image.info
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_image.info
@@ -1,0 +1,5 @@
+name = CloudFlare cache clear image
+description = "Provides additional CloudFlare cache clearing functionality for images"
+core = 7.x
+package = CloudFlare
+dependencies = cloudflare_cache_clear

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_image.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_image.module
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @file Module code for the CloudFlare cache clear image module
+ */
+
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * @see fsa_cache_clear_file_entity_edit_submit()
+ */
+function cloudflare_cache_clear_image_form_file_entity_edit_alter(&$form, &$form_state, $form_id) {
+  if (!empty($form['actions']['submit']['#submit'])) {
+    // Add our submit handler to the file_entity edit form.
+    array_unshift($form['actions']['submit']['#submit'], 'cloudflare_cache_clear_image_file_entity_edit_submit');
+  }
+}
+
+
+/**
+ * Additional submit handler for the file entity edit form.
+ *
+ * We use this to determine which derived image files exist before they are
+ * deleted. We can then purge these derived files from CloudFlare.
+ */
+function cloudflare_cache_clear_image_file_entity_edit_submit($form, &$form_state) {
+  // Get the file object
+  $file = !empty($form_state['file']) ? $form_state['file'] : NULL;
+  // Get the replacement file object
+  $replace_file = !empty($form_state['values']['replace_upload']) ? TRUE : FALSE;
+  // If we have no file object or replacement file object, return now.
+  if (empty($file) || empty($replace_file)) {
+    return;
+  }
+  // An array to hold URLs for clearing.
+  $urls = array();
+  // Filename for the file to be replaced
+  $filename = file_uri_target($file->uri);
+  // Get the path for public files.
+  $public_path = variable_get('file_public_path');
+  // Add the filename to the URLs for clearing
+  $urls[] =  "$public_path/$filename";
+  // If the file is an image, we need to check whether it has any existing
+  // style derivatives, as these will need to be cleared from CloudFlare too.
+  if ($file->type == 'image') {
+    $urls = array_merge($urls, _cloudflare_cache_clear_image_style_urls($file));
+  }
+  cloudflare_cache_clear_purge_urls($urls);
+}
+
+
+/**
+ * Implements hook_cloudflare_cache_clear_manual_purge_urls_alter().
+ */
+function cloudflare_cache_clear_image_cloudflare_cache_clear_manual_purge_urls_alter(&$urls) {
+  $temp_urls = $urls;
+  foreach ($temp_urls as $url) {
+    $object_type = _cloudflare_cache_clear_get_object_type_from_path($url);
+    if ($object_type == 'file') {
+      $file = _cloudflare_cache_clear_load_file_by_url($url);
+      if (!empty($file) && !empty($file->type) && $file->type == 'image') {
+        $urls = array_merge($urls, _cloudflare_cache_clear_image_style_urls($file));
+      }
+    }
+  }
+}
+
+
+/**
+ * Helper function: returns URLs for image derivative files
+ */
+function _cloudflare_cache_clear_image_style_urls($file) {
+  $urls = array();
+  $public_path = variable_get('file_public_path');
+  if ($file->type == 'image') {
+    $filename = file_uri_target($file->uri);
+    $image_styles = image_styles();
+    foreach ($image_styles as $style_name => $style_properties) {
+      if (file_exists(image_style_path($style_name, $filename))) {
+        // Get the image style token to add to the URL for CloudFlare
+        $image_style_path_token = image_style_path_token($style_name,  "public://$filename");
+        // Add the path to be cleared from the CloudFlare cache, including the
+        // image derivative token as this is stored in CloudFlare.
+        $urls[] = $public_path . '/' . file_uri_target(image_style_path($style_name, $filename)) . "?" . IMAGE_DERIVATIVE_TOKEN . "=$image_style_path_token";
+      }
+    }
+  }
+  return $urls;
+}
+
+
+/**
+ * Implements hook_cloudflare_cache_clear_expire_cache_alter().
+ */
+function cloudflare_cache_clear_image_cloudflare_cache_clear_expire_cache_alter(&$urls, $wildcards, $object_type, $object) {
+  // If a file is an image, we don't want it to be cleared automatically when
+  // it is updated since we're handling this with a submit handler.
+  if ($object_type == 'file' && !empty($object) && !empty($object->type) && $object->type == 'image') {
+    foreach ($urls as $key => $url) {
+      unset($urls[$key]);
+    }
+  }
+}

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_image.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_image.module
@@ -29,7 +29,7 @@ function cloudflare_cache_clear_image_file_entity_edit_submit($form, &$form_stat
   // Get the replacement file object
   $replace_file = !empty($form_state['values']['replace_upload']) ? TRUE : FALSE;
   // If we have no file object or replacement file object, return now.
-  if (empty($file) || empty($replace_file)) {
+   if (empty($file) || empty($replace_file) || empty($file->type) || $file->type != 'image') {
     return;
   }
   // An array to hold URLs for clearing.
@@ -96,6 +96,13 @@ function cloudflare_cache_clear_image_cloudflare_cache_clear_expire_cache_alter(
   // If a file is an image, we don't want it to be cleared automatically when
   // it is updated since we're handling this with a submit handler.
   if ($object_type == 'file' && !empty($object) && !empty($object->type) && $object->type == 'image') {
+    foreach ($urls as $key => $url) {
+      unset($urls[$key]);
+    }
+  }
+  // If the ojbect is a file and it uses the temporary stream wrapper, don't
+  // clear the CloudFlare cache.
+  if ($object_type == 'file' && !empty($object) && !empty($object->uri) && strpos($object->uri, 'temporary://') === 0) {
     foreach ($urls as $key => $url) {
       unset($urls[$key]);
     }

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_ui.admin.inc
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_ui.admin.inc
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @file Admin functions for the CloudFlare cache clear UI module
+ */
+
+
+/**
+ * Form builder: Purge URLs form
+ */
+function cloudflare_cache_clear_ui_purge_url_form($form, &$form_state) {
+
+  // URLs to purge
+  $form['urls'] = array(
+    '#type' => 'textarea',
+    '#title' => t('URLs to purge'),
+    '#description' => t('Enter URL(s) to be purged from the CloudFlare cache. For multiple URLs, enter each on a new line'),
+    '#default_value' => !empty($form_state['values']['urls']) ? $form_state['values']['urls'] : NULL,
+  );
+
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Purge URLs'),
+  );
+
+  return $form;
+
+}
+
+
+/**
+ * Submit handler: Purge URLs form
+ */
+function cloudflare_cache_clear_ui_purge_url_form_submit($form, &$form_state) {
+  $urls = !empty($form_state['values']['urls']) ? preg_split ('/(\r\n?|\n)/', $form_state['values']['urls']) : array();
+  if (!empty($urls)) {
+    drupal_alter('cloudflare_cache_clear_manual_purge_urls', $urls);
+    cloudflare_cache_clear_purge_urls($urls);
+  }
+}

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_ui.info
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_ui.info
@@ -1,0 +1,5 @@
+name = CloudFlare Cache Clear UI
+description = "Provides a user interface for the CloudFlare cache clear module"
+core = 7.x
+dependencies[] = cloudflare_cache_clear
+package = CloudFlare

--- a/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_ui.module
+++ b/docroot/sites/all/modules/custom/cloudflare_cache_clear/modules/cloudflare_cache_clear_ui.module
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @file Module code for the CloudFlare cache clear UI module
+ */
+
+/**
+ * Implements hook_permission().
+ */
+function cloudflare_cache_clear_ui_permission() {
+  return array(
+    'cloudflare cache clear purge urls' => array(
+      'title' => t('Purge URLs from CloudFlare'),
+      'description' => t('Allows users to purge URLs from CloudFlare'),
+    ),
+  );
+}
+
+
+/**
+ * Implements hook_menu().
+ */
+function cloudflare_cache_clear_ui_menu() {
+  return array(
+    'admin/config/services/cloudflare/purge' => array(
+      'title' => 'Purge URLs',
+      'description' => 'Clear URLs from the CloudFlare cache',
+      'access arguments' => array('cloudflare cache clear purge urls'),
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('cloudflare_cache_clear_ui_purge_url_form'),
+      'file' => 'cloudflare_cache_clear_ui.admin.inc',
+      'type' => MENU_LOCAL_TASK,
+    ),
+    'admin/config/services/cloudflare/config' => array(
+      'title' => 'CloudFlare configuration',
+      'type' => MENU_DEFAULT_LOCAL_TASK,
+    ),
+  );
+}
+

--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -499,6 +499,8 @@ function _local_committee_domains() {
  *
  * We do this using this hook, rather than the path-based one as we need to add
  * domains to the resulting array.
+ *
+ * We also need to clear URLs for standard pages based on the committee domains.
  */
 function local_cloudflare_cache_clear_urls_alter(&$urls, $wildcards, $object_type, $object) {
   $temp_urls = $urls;
@@ -512,6 +514,16 @@ function local_cloudflare_cache_clear_urls_alter(&$urls, $wildcards, $object_typ
       foreach (array_keys($committee_domains) as $committee_domain) {
         foreach (cloudflare_cache_clear_get_protocols() as $protocol) {
           $urls[] = $protocol . '://' . $committee_domain . '/' . $path;
+        }
+      }
+    }
+    // For pages, if they have a path that looks like a committee path, make
+    // sure the URL based on the relevant committee domain also gets cleared
+    foreach ($committee_domains as $committee_domain => $committee_path) {
+      if (strpos($path, $committee_path) === 0) {
+        foreach (cloudflare_cache_clear_get_protocols() as $protocol) {
+          $new_path = trim($protocol . '://' . $committee_domain . '/' . preg_replace("@^" . $committee_path . "/?(.*)$@", '$1', $path));
+          $urls[] = $new_path;
         }
       }
     }

--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -469,3 +469,51 @@ function local_national_archives_site_url_alter(&$site_url, &$url) {
  function local_form_node_form_alter(&$form, &$form_state) {
  	$form['#attached']['css'][] = drupal_get_path('module', 'local') . '/css/local.css';
  }
+
+
+ /**
+ * Returns an array of committee domains and their associated paths.
+ *
+ * @return array
+ *   Array of committee domains and their associated paths.
+ */
+function _local_committee_domains() {
+  $committee_domains = array(
+    'cot.food.gov.uk' => 'committee/committee-on-toxicity',
+    'acmsf.food.gov.uk' => 'committee/acmsf',
+    'acnfp.food.gov.uk'=> 'committee/acnfp',
+    'acaf.food.gov.uk' => 'committee/acaf',
+    'gacs.food.gov.uk'=> 'committee/gacs',
+    'ssrc.food.gov.uk'=> 'committee/social-science-research-committee-ssrc',
+  );
+  return $committee_domains;
+}
+
+
+/**
+ * Implements hook_cloudflare_cache_clear_urls_alter().
+ *
+ * Since files can be used in any committee site, we need to make sure that when
+ * we clear the CloudFlare cache for a file, we also do so for every committee
+ * domain.
+ *
+ * We do this using this hook, rather than the path-based one as we need to add
+ * domains to the resulting array.
+ */
+function local_cloudflare_cache_clear_urls_alter(&$urls, $wildcards, $object_type, $object) {
+  $temp_urls = $urls;
+  // Get the local committee domains
+  $committee_domains = _local_committee_domains();
+  foreach ($temp_urls as $url) {
+    // Extract the path part from the URL
+    $path = preg_replace("@^http(?:s)://.*?/(.*)$@", '$1', $url);
+    // Determine whether it's a file type based on the path
+    if (_cloudflare_cache_clear_get_object_type_from_path($path) == 'file') {
+      foreach (array_keys($committee_domains) as $committee_domain) {
+        foreach (cloudflare_cache_clear_get_protocols() as $protocol) {
+          $urls[] = $protocol . '://' . $committee_domain . '/' . $path;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Created a new cache clearing module to allow clearing of items from the CloudFlare cache using the latest version of the CloudFlare API.

Also included is the HTTPRL module for making parallel, non-blocking HTTP requests.

Enable the module
----------------------
Once the code has been deployed, the new module will need to be enabled:

```
drush en cloudflare_cache_clear --y
drush en cloudflare_cache_clear_ui --y
drush en cloudflare_cache_clear_image --y
```
It would also be good to clear the Drupal caches:

`drush cc all `

[ Partial fix for #10421 ]