### PR TITLE
101415: Use MapIt API key (develop)

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -3390,6 +3390,9 @@ function _fsa_report_problem_api_settings($delta = NULL) {
         'user_agent' => array(
           'title' => t('User agent string'),
         ),
+        'api_key' => array(
+          'title' => t('API key'),
+        ),
       );
       $settings['google_places'] = array(
         'api_key' => array(
@@ -3402,6 +3405,9 @@ function _fsa_report_problem_api_settings($delta = NULL) {
         'user_agent' => array(
           'title' => t('User agent string'),
         ),
+        'api_key' => array(
+          'title' => t('API key'),
+        ),
       );
       $settings['google_places'] = array(
         'api_key' => array(
@@ -3413,6 +3419,9 @@ function _fsa_report_problem_api_settings($delta = NULL) {
       $settings['mapit'] = array(
         'user_agent' => array(
           'title' => t('User agent string'),
+        ),
+        'api_key' => array(
+          'title' => t('API key'),
         ),
       );
       break;
@@ -3739,6 +3748,14 @@ function _fsa_report_problem_mapit_user_agent($delta = NULL) {
 
 
 /**
+ * Helper function: returns the MapIt API key
+ */
+function _fsa_report_problem_mapit_api_key($delta = NULL) {
+  return _fsa_report_problem_api_setting('mapit', 'api_key', $delta);
+}
+
+
+/**
  * Helper function: returns MapIt HTTP request options
  *
  * @param string $delta
@@ -3757,6 +3774,7 @@ function _fsa_report_problem_mapit_http_options($delta = NULL) {
   $options = array();
   $options['headers'] = array(
     'User-Agent' => _fsa_report_problem_mapit_user_agent($delta),
+    'X-Api-Key' => _fsa_report_problem_mapit_api_key($delta),
   );
   return $options;
 }


### PR DESCRIPTION
Added the ability to include the MapIt API key when making requests as part of the Report a food problem service.

Manual configuration
-------------------------
The MapIt API key needs to be added in the configuration interface in Drupal via:

Admin > Configuration > Food problem reporting > API settings

Note that it needs to be added for each service.

The API key can be found in LastPass under MapIt

[ Partial fix for #101415 ]