### PR TITLE
103273: Enable Mollom module in update hook (develop)

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_feedback/fsa_feedback.install
+++ b/docroot/sites/all/modules/custom/fsa_feedback/fsa_feedback.install
@@ -33,9 +33,17 @@ function fsa_feedback_update_7003() {
 
 
 /**
- * Enables Mollom protection for the feedback form
+ * Enables the Mollom module
  */
 function fsa_feedback_update_7004() {
+  module_enable(array('mollom'));
+}
+
+
+/**
+ * Enables Mollom protection for the feedback form
+ */
+function fsa_feedback_update_7005() {
 $mollom_form = mollom_form_new('feedback_form');
   $mollom_form['mode'] = 2;
   $mollom_form['checks'] = array('spam');


### PR DESCRIPTION
We use an update hook to ensure the Mollom module is installed and enabled before creating the mollom settings for the feedback form.

[ Partial fix for 103273 ]