### PR TITLE
103273: Add extra validation to compare feedback fields (develop)

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_feedback/fsa_feedback.install
+++ b/docroot/sites/all/modules/custom/fsa_feedback/fsa_feedback.install
@@ -57,3 +57,10 @@ $mollom_form = mollom_form_new('feedback_form');
   }
 }
 
+
+/**
+ * Sets the feedback form to compare fields by default
+ */
+function fsa_feedback_update_7006() {
+  variable_set('fsa_feedback_form_validation_compare_fields', TRUE);
+}

--- a/docroot/sites/all/modules/custom/fsa_feedback/fsa_feedback.module
+++ b/docroot/sites/all/modules/custom/fsa_feedback/fsa_feedback.module
@@ -1400,6 +1400,18 @@ function feedback_form_validate($form, &$form_state) {
     }
   }
 
+  // Check to see whether the 'What you were doing' and 'What went wrong' fields
+  // are different. Spam submissions typically just repeat themselves.
+  // Note that this validation can be disabled by setting the value of the
+  // variable 'fsa_feedback_form_validation_compare_fields' to FALSE.
+  if (variable_get('fsa_feedback_form_validation_compare_fields')) {
+    $doing = !empty($form_state['values']['doing']) ? trim(strtolower($form_state['values']['doing'])) : NULL;
+    $wrong = !empty($form_state['values']['wrong']) ? trim(strtolower($form_state['values']['wrong'])) : NULL;
+    if (!empty($doing) && !empty($wrong) && $doing == $wrong) {
+      form_set_error('doing', t('Sorry, it looks like you\'ve entered the same information in both fields. Please check your submission.'));
+    }
+  }
+
 }
 
 /**


### PR DESCRIPTION
Added a new validation for the feedback form that checks to see if both fields contain the same information. If so, we warn the user as it is likely spam.

[ Partial fix for 103273 ]