### PR TITLE
103798: Make sure MapIt API key is supplied

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/forms/make_report_form.php
@@ -189,7 +189,7 @@ function fsa_report_problem_make_report_form_submit($form, &$form_state) {
     $postcode = !empty($form_state['values']['business_postcode']) ? _fsa_report_problem_format_postcode($form_state['values']['business_postcode']) : NULL;
     // If we have a valid postcode, let's look up the local authority
     if (!empty($postcode) && _fsa_report_problem_valid_postcode($postcode)) {
-      $local_authority = fsa_report_problem_get_local_authority_by_postcode($postcode);
+      $local_authority = fsa_report_problem_get_local_authority_by_postcode($postcode, 'report_problem_form');
       $area_id = !empty($local_authority['id']) ? $local_authority['id'] : 0;
       // If we have a local authority, set the submission value to it so that
       // we can use it on the report complete form.

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.admin.inc
@@ -1278,7 +1278,7 @@ function fsa_report_problem_report_local_authority_form_submit(&$form, &$form_st
     case 'postcode':
       $postcode = !empty($form_state['values']['postcode']) ? $form_state['values']['postcode'] : '';
       try {
-        $la = fsa_report_problem_get_local_authority_by_postcode($postcode);
+        $la = fsa_report_problem_get_local_authority_by_postcode($postcode, 'report_problem_form');
         $area_id = $la['id'];
       }
       catch (MapItApiException $e) {


### PR DESCRIPTION
In order to ensure that the correct MapIt API key is included in requests, we provide a delta wherever we call the API function.

[ Partial fix for 103798 ]