### PR TITLE
104248 Set Return-Path header for forwarded food problem reports

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1506,6 +1506,7 @@ function fsa_report_problem_mail($key, &$message, $params) {
     case 'report_forward':
       $message['body'][] = $params['message'];
       $message['subject'] = $params['subject'];
+      $message['headers']['Return-Path'] = $message['from'];
       break;
 
     case 'acknowledgement':


### PR DESCRIPTION
For forwarded food problem reports, we set the Return-Path header to be the same as the From address to prevent bouncebacks from Office 365.

[ Partial fix for 104248 ]