### PR TITLE
104870: Increase admin memory to 900M

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -335,7 +335,7 @@ fast_404_ext_check();
 
 
 if (strpos($_GET['q'], 'admin') === 0) {
-  ini_set('memory_limit', '700M');
+  ini_set('memory_limit', '900M');
   ini_set('max_execution_time', 120);
 }
 


### PR DESCRIPTION
Increased the PHP `memory_limit` setting from 700M to 900M when in the admin section of the site.

[ Partial fix for #104870 ]