### PR TITLE
104903: Add X-Reporter header to RAFP emails

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.module
@@ -1478,6 +1478,10 @@ function fsa_report_problem_mail($key, &$message, $params) {
       $message['from'] = !empty($message_details['sender_email']) ? $message_details['sender_email'] : $message['from'];
       $message['headers']['From'] = $message['from'];
 
+      // Add a custom header to allow mail to be dropped by Postfix based on the
+      // sender email
+      $message['headers']['X-Reporter'] = $message['from'];
+
       // If we have a reply-to header for this email, use it
       if (!empty($message_details['reply_to_email'])) {
         $message['headers']['Reply-to'] = $message_details['reply_to_email'];


### PR DESCRIPTION
Added a new custom header - `X-Reporter` - to the report emails generated by the report a food problem module. This will allow emails to be dropped by Postfix based on the reporter's email address.

[ Partial fix for 104904 ]