### PR TITLE
105127: Add new ACSS domains for dev and staging

### DIFF
--- a/docroot/sites/all/themes/committee_acss/committee_acss.info
+++ b/docroot/sites/all/themes/committee_acss/committee_acss.info
@@ -80,3 +80,5 @@ settings[omega_libraries][pie][status] = 1
 settings[omega_libraries][html5shiv][status] = 1
 settings[favicon_mimetype] = image/vnd.microsoft.icon
 settings[committee_domains][] = acss.food.gov.uk
+settings[committee_domains][] = acss.dev.food.gov.uk
+settings[committee_domains][] = acss.staging.food.gov.uk


### PR DESCRIPTION
Added a couple of new domains for the ACSS committee site for use with the dev and staging environments:

* acss.dev.food.gov.uk
* acss.staging.food.gov.uk

[ Partial fix for 105127 ]