### PR TITLE
105041: Add noopener noreferrer to beta link

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
@@ -39,6 +39,7 @@ function fsa_beta_banner_block_view($delta = '') {
           '#attributes' => array(
             'target' => '_blank',
             'title' => t('Visit the new beta.food.gov.uk site - opens in a new window'),
+            'rel' => 'noopener noreferrer',
           ),
         );
         // @todo Use '#attached' to do this instead


### PR DESCRIPTION
Added `rel="noopener noreferrer"` to beta site link to prevent potential phishing attacks.

[ Partial fix for 105041 ]