### PR TITLE
105041: Allow beta banner configuration via Drupal admin UI

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
@@ -41,7 +41,7 @@ function fsa_beta_banner_block_view($delta = '') {
         'subject' => NULL,
         'content' => NULL,
       );
-      if (variable_get('fsa_beta_banner_enabled', TRUE)) {
+      if (variable_get('fsa_beta_banner_enabled', FALSE)) {
         $block['content'] = array(
           '#type' => 'link',
           '#title' => variable_get('fsa_beta_banner_text', FSA_BETA_BANNER_DEFAULT_TEXT),

--- a/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
@@ -39,6 +39,7 @@ function fsa_beta_banner_block_view($delta = '') {
           '#attributes' => array(
             'target' => '_blank',
             'title' => t('Visit the new beta.food.gov.uk site - opens in a new window'),
+            'rel' => 'noopener noreferrer',
           ),
         );
         // @todo Use '#attached' to do this instead

--- a/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
@@ -36,6 +36,10 @@ function fsa_beta_banner_block_view($delta = '') {
           '#type' => 'link',
           '#title' => variable_get('fsa_beta_banner_text', t('Try our new food.gov.uk website')),
           '#href' => variable_get('fsa_beta_banner_href', 'https://beta.food.gov.uk'),
+          '#attributes' => array(
+            'target' => '_blank',
+            'title' => t('Visit the new beta.food.gov.uk site - opens in a new window'),
+          ),
         );
         // @todo Use '#attached' to do this instead
         drupal_add_css(drupal_get_path('module', 'fsa_beta_banner') . '/css/beta-banner.css');

--- a/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
@@ -31,6 +31,57 @@ function fsa_beta_banner_block_info() {
 
 
 /**
+ * Implements hook_block_configure().
+ */
+function fsa_beta_banner_block_configure($delta = '') {
+  $form = array();
+  if ($delta == 'beta_banner') {
+    // Beta banner settings fieldset
+    $form['fsa_beta_banner_settings'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Beta banner settings'),
+    );
+    // Checkbox to enable/disable the beta banner
+    $form['fsa_beta_banner_settings']['fsa_beta_banner_enabled'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Beta banner enabled'),
+      '#description' => t('Tick this box to enable the beta banner'),
+      '#default_value' => variable_get('fsa_beta_banner_enabled'),
+    );
+    // Text field to set the link text for the beta banner
+    $form['fsa_beta_banner_settings']['fsa_beta_banner_text'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Banner text'),
+      '#description' => t('Set the text to display in the beta banner.'),
+      '#required' => TRUE,
+      '#default_value' => variable_get('fsa_beta_banner_text', FSA_BETA_BANNER_DEFAULT_TEXT),
+    );
+    // Text field to set the link URL for the beta banner
+    $form['fsa_beta_banner_settings']['fsa_beta_banner_href'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Banner link URL'),
+      '#description' => t('Set the URL that the beta banner will link to.'),
+      '#required' => TRUE,
+      '#default_value' => variable_get('fsa_beta_banner_href', FSA_BETA_BANNER_DEFAULT_HREF),
+    );
+  }
+  return $form;
+}
+
+
+/**
+ * Implements hook_block_save().
+ */
+function fsa_beta_banner_block_save($delta = '', $edit = array()) {
+  if ($delta == 'beta_banner') {
+    variable_set('fsa_beta_banner_enabled', $edit['fsa_beta_banner_enabled']);
+    variable_set('fsa_beta_banner_text', $edit['fsa_beta_banner_text']);
+    variable_set('fsa_beta_banner_href', $edit['fsa_beta_banner_href']);
+  }
+}
+
+
+/**
  * Implements hook_block_view().
  */
 function fsa_beta_banner_block_view($delta = '') {
@@ -71,4 +122,27 @@ function fsa_beta_banner_theme() {
       'path' => drupal_get_path('module', 'fsa_beta_banner') . '/theme',
     ),
   );
+}
+
+
+/**
+ * Implements hook_form_alter().
+ *
+ * We use this hook to alter the block configure form for the beta_banner
+ * block so that it doesn't provide fields that aren't used by this block.
+ */
+function fsa_beta_banner_form_block_admin_configure_alter(&$form, &$form_state, $form_id) {
+  // Get the block delta
+  $delta = !empty($form['delta']['#value']) ? $form['delta']['#value'] : NULL;
+  // Act only on the beta_banner block
+  if ($delta != 'beta_banner') {
+    return;
+  }
+  // Hide the block title - it's not used for the beta banner.
+  $form['settings']['title']['#access'] = FALSE;
+  // Hide the CSS class field - we don't want it used here
+  $form['settings']['css_class']['#access'] = FALSE;
+  // Make the regions fieldset collapsed by default
+  $form['regions']['#collapsible'] = TRUE;
+  $form['regions']['#collapsed'] = TRUE;
 }

--- a/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
@@ -39,7 +39,7 @@ function fsa_beta_banner_block_view($delta = '') {
           '#attributes' => array(
             'target' => '_blank',
             'title' => t('Visit the new beta.food.gov.uk site - opens in a new window'),
-            'rel' => 'noopener noreferrer',
+            'rel' => 'noopener',
           ),
         );
         // @todo Use '#attached' to do this instead

--- a/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
@@ -44,8 +44,8 @@ function fsa_beta_banner_block_view($delta = '') {
       if (variable_get('fsa_beta_banner_enabled', TRUE)) {
         $block['content'] = array(
           '#type' => 'link',
-          '#title' => variable_get('fsa_beta_banner_text', t('Try our new food.gov.uk website')),
-          '#href' => variable_get('fsa_beta_banner_href', 'https://beta.food.gov.uk'),
+          '#title' => variable_get('fsa_beta_banner_text', FSA_BETA_BANNER_DEFAULT_TEXT),
+          '#href' => variable_get('fsa_beta_banner_href', FSA_BETA_BANNER_DEFAULT_HREF),
           '#attributes' => array(
             'target' => '_blank',
             'title' => t('Visit the new beta.food.gov.uk site - opens in a new window'),

--- a/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/fsa_beta_banner.module
@@ -3,6 +3,16 @@
  * @file Module code for the FSA beta banner module
  */
 
+/**
+ * Default beta banner text
+ */
+define('FSA_BETA_BANNER_DEFAULT_TEXT', t('Try our new food.gov.uk website'));
+
+/**
+ * Default beta banner URL
+ */
+define('FSA_BETA_BANNER_DEFAULT_HREF', 'https://beta.food.gov.uk');
+
 
  /**
   * Implements hook_block_info().

--- a/docroot/sites/all/modules/custom/fsa_beta_banner/theme/block--fsa-beta-banner.tpl.php
+++ b/docroot/sites/all/modules/custom/fsa_beta_banner/theme/block--fsa-beta-banner.tpl.php
@@ -1,4 +1,5 @@
 <div <?php print $attributes; ?>>
+  <?php print render($title_suffix); ?>
   <div <?php print $content_attributes; ?>>
     <div class="beta-link">
       <?php print $content; ?>

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.install
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.install
@@ -594,3 +594,14 @@ function fsa_report_problem_update_7018() {
   // class as it allows us to add attachment
   mailsystem_set(array('fsa_report_problem_weekly_report' => 'MimeMailSystem'));
 }
+
+
+/**
+ * Enables the beta banner module
+ */
+function fsa_report_problem_update_7019() {
+  // This enables the beta banner module. We put this here for the sake of
+  // convenience only - it has nothing to do with the functionality of this
+  // module - it is just here to avoid a manual step on deployment.
+  module_enable(array('fsa_beta_banner'));
+}

--- a/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.install
+++ b/docroot/sites/all/modules/custom/fsa_report_problem/fsa_report_problem.install
@@ -594,14 +594,3 @@ function fsa_report_problem_update_7018() {
   // class as it allows us to add attachment
   mailsystem_set(array('fsa_report_problem_weekly_report' => 'MimeMailSystem'));
 }
-
-
-/**
- * Enables the beta banner module
- */
-function fsa_report_problem_update_7019() {
-  // This enables the beta banner module. We put this here for the sake of
-  // convenience only - it has nothing to do with the functionality of this
-  // module - it is just here to avoid a manual step on deployment.
-  module_enable(array('fsa_beta_banner'));
-}

--- a/docroot/sites/all/modules/features/global/sitewide_feature/sitewide_feature.install
+++ b/docroot/sites/all/modules/features/global/sitewide_feature/sitewide_feature.install
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @file Install, update and uninstall hools for the sitewide_feature module
+ */
+
+
+ /**
+  * Enables the beta banner module
+  */
+ function sitewide_feature_update_7001() {
+   // This enables the beta banner module. We put this here for the sake of
+   // convenience only - it has nothing to do with the functionality of this
+   // module - it is just here to avoid a manual step on deployment.
+   module_enable(array('fsa_beta_banner'));
+ }


### PR DESCRIPTION
It is now possible to enable/disable the beta banner and to change the text and link URL for the beta banner via the block configure interface in the Drupal admin UI.

The beta banner is also now disabled by default.

[ Partial fix for 105041 ]