### PR TITLE
Upgrade to core 7.5.9 #105785

### DIFF
--- a/docroot/CHANGELOG.txt
+++ b/docroot/CHANGELOG.txt
@@ -1,4 +1,8 @@
 
+Drupal 7.59, 2018-04-25
+-----------------------
+- Fixed security issues (remote code execution). See SA-CORE-2018-004.
+
 Drupal 7.58, 2018-03-28
 -----------------------
 - Fixed security issues (multiple vulnerabilities). See SA-CORE-2018-002.

--- a/docroot/includes/bootstrap.inc
+++ b/docroot/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.58');
+define('VERSION', '7.59');
 
 /**
  * Core API compatibility.
@@ -2777,6 +2777,11 @@ function _drupal_bootstrap_variables() {
     if (isset($_GET['destination']) && url_is_external($_GET['destination'])) {
       unset($_GET['destination']);
       unset($_REQUEST['destination']);
+    }
+    // Use the DrupalRequestSanitizer to ensure that the destination's query
+    // parameters are not dangerous.
+    if (isset($_GET['destination'])) {
+      DrupalRequestSanitizer::cleanDestination();
     }
     // If there's still something in $_REQUEST['destination'] that didn't come
     // from $_GET, check it too.

--- a/docroot/includes/common.inc
+++ b/docroot/includes/common.inc
@@ -611,8 +611,9 @@ function drupal_parse_url($url) {
   }
   // The 'q' parameter contains the path of the current page if clean URLs are
   // disabled. It overrides the 'path' of the URL when present, even if clean
-  // URLs are enabled, due to how Apache rewriting rules work.
-  if (isset($options['query']['q'])) {
+  // URLs are enabled, due to how Apache rewriting rules work. The path
+  // parameter must be a string.
+  if (isset($options['query']['q']) && is_string($options['query']['q'])) {
     $options['path'] = $options['query']['q'];
     unset($options['query']['q']);
   }

--- a/docroot/includes/request-sanitizer.inc
+++ b/docroot/includes/request-sanitizer.inc
@@ -52,6 +52,38 @@ class DrupalRequestSanitizer {
   }
 
   /**
+   * Removes the destination if it is dangerous.
+   *
+   * Note this can only be called after common.inc has been included.
+   *
+   * @return bool
+   *   TRUE if the destination has been removed from $_GET, FALSE if not.
+   */
+  public static function cleanDestination() {
+    $dangerous_keys = array();
+    $log_sanitized_keys = variable_get('sanitize_input_logging', FALSE);
+
+    $parts = drupal_parse_url($_GET['destination']);
+    // If there is a query string, check its query parameters.
+    if (!empty($parts['query'])) {
+      $whitelist = variable_get('sanitize_input_whitelist', array());
+
+      self::stripDangerousValues($parts['query'], $whitelist, $dangerous_keys);
+      if (!empty($dangerous_keys)) {
+        // The destination is removed rather than sanitized to mirror the
+        // handling of external destinations.
+        unset($_GET['destination']);
+        unset($_REQUEST['destination']);
+        if ($log_sanitized_keys) {
+          trigger_error(format_string('Potentially unsafe destination removed from query string parameters (GET) because it contained the following keys: @keys', array('@keys' => implode(', ', $dangerous_keys))));
+        }
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
    * Strips dangerous keys from the provided input.
    *
    * @param mixed $input

--- a/docroot/modules/aggregator/aggregator.info
+++ b/docroot/modules/aggregator/aggregator.info
@@ -7,8 +7,7 @@ files[] = aggregator.test
 configure = admin/config/services/aggregator/settings
 stylesheets[all][] = aggregator.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/aggregator/tests/aggregator_test.info
+++ b/docroot/modules/aggregator/tests/aggregator_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/block/block.info
+++ b/docroot/modules/block/block.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = block.test
 configure = admin/structure/block
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/block/tests/block_test.info
+++ b/docroot/modules/block/tests/block_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/block/tests/themes/block_test_theme/block_test_theme.info
+++ b/docroot/modules/block/tests/themes/block_test_theme/block_test_theme.info
@@ -13,8 +13,7 @@ regions[footer] = Footer
 regions[highlighted] = Highlighted
 regions[help] = Help
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/blog/blog.info
+++ b/docroot/modules/blog/blog.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 files[] = blog.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/book/book.info
+++ b/docroot/modules/book/book.info
@@ -7,8 +7,7 @@ files[] = book.test
 configure = admin/content/book/settings
 stylesheets[all][] = book.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/color/color.info
+++ b/docroot/modules/color/color.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 files[] = color.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/comment/comment.info
+++ b/docroot/modules/comment/comment.info
@@ -9,8 +9,7 @@ files[] = comment.test
 configure = admin/content/comment
 stylesheets[all][] = comment.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/contact/contact.info
+++ b/docroot/modules/contact/contact.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = contact.test
 configure = admin/structure/contact
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/contextual/contextual.info
+++ b/docroot/modules/contextual/contextual.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 files[] = contextual.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/dashboard/dashboard.info
+++ b/docroot/modules/dashboard/dashboard.info
@@ -7,8 +7,7 @@ files[] = dashboard.test
 dependencies[] = block
 configure = admin/dashboard/customize
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/dblog/dblog.info
+++ b/docroot/modules/dblog/dblog.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 files[] = dblog.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field/field.info
+++ b/docroot/modules/field/field.info
@@ -11,8 +11,7 @@ dependencies[] = field_sql_storage
 required = TRUE
 stylesheets[all][] = theme/field.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field/modules/field_sql_storage/field_sql_storage.info
+++ b/docroot/modules/field/modules/field_sql_storage/field_sql_storage.info
@@ -7,8 +7,7 @@ dependencies[] = field
 files[] = field_sql_storage.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field/modules/list/list.info
+++ b/docroot/modules/field/modules/list/list.info
@@ -7,8 +7,7 @@ dependencies[] = field
 dependencies[] = options
 files[] = tests/list.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field/modules/list/tests/list_test.info
+++ b/docroot/modules/field/modules/list/tests/list_test.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field/modules/number/number.info
+++ b/docroot/modules/field/modules/number/number.info
@@ -6,8 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = number.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field/modules/options/options.info
+++ b/docroot/modules/field/modules/options/options.info
@@ -6,8 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = options.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field/modules/text/text.info
+++ b/docroot/modules/field/modules/text/text.info
@@ -7,8 +7,7 @@ dependencies[] = field
 files[] = text.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field/tests/field_test.info
+++ b/docroot/modules/field/tests/field_test.info
@@ -6,8 +6,7 @@ files[] = field_test.entity.inc
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/field_ui/field_ui.info
+++ b/docroot/modules/field_ui/field_ui.info
@@ -6,8 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = field_ui.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/file/file.info
+++ b/docroot/modules/file/file.info
@@ -6,8 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = tests/file.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/file/file.module
+++ b/docroot/modules/file/file.module
@@ -239,6 +239,9 @@ function file_ajax_upload() {
   $form_parents = func_get_args();
   $form_build_id = (string) array_pop($form_parents);
 
+  // Sanitize form parents before using them.
+  $form_parents = array_filter($form_parents, 'element_child');
+
   if (empty($_POST['form_build_id']) || $form_build_id != $_POST['form_build_id']) {
     // Invalid request.
     drupal_set_message(t('An unrecoverable error occurred. The uploaded file likely exceeded the maximum file size (@size) that this server supports.', array('@size' => format_size(file_upload_max_size()))), 'error');

--- a/docroot/modules/file/tests/file_module_test.info
+++ b/docroot/modules/file/tests/file_module_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/filter/filter.info
+++ b/docroot/modules/filter/filter.info
@@ -7,8 +7,7 @@ files[] = filter.test
 required = TRUE
 configure = admin/config/content/formats
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/forum/forum.info
+++ b/docroot/modules/forum/forum.info
@@ -9,8 +9,7 @@ files[] = forum.test
 configure = admin/structure/forum
 stylesheets[all][] = forum.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/help/help.info
+++ b/docroot/modules/help/help.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 files[] = help.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/image/image.info
+++ b/docroot/modules/image/image.info
@@ -7,8 +7,7 @@ dependencies[] = file
 files[] = image.test
 configure = admin/config/media/image-styles
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/image/tests/image_module_test.info
+++ b/docroot/modules/image/tests/image_module_test.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = image_module_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/locale/locale.info
+++ b/docroot/modules/locale/locale.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = locale.test
 configure = admin/config/regional/language
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/locale/tests/locale_test.info
+++ b/docroot/modules/locale/tests/locale_test.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/menu/menu.info
+++ b/docroot/modules/menu/menu.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = menu.test
 configure = admin/structure/menu
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/node/node.info
+++ b/docroot/modules/node/node.info
@@ -9,8 +9,7 @@ required = TRUE
 configure = admin/structure/types
 stylesheets[all][] = node.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/node/tests/node_access_test.info
+++ b/docroot/modules/node/tests/node_access_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/node/tests/node_test.info
+++ b/docroot/modules/node/tests/node_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/node/tests/node_test_exception.info
+++ b/docroot/modules/node/tests/node_test_exception.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/openid/openid.info
+++ b/docroot/modules/openid/openid.info
@@ -5,8 +5,7 @@ package = Core
 core = 7.x
 files[] = openid.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/openid/tests/openid_test.info
+++ b/docroot/modules/openid/tests/openid_test.info
@@ -6,8 +6,7 @@ core = 7.x
 dependencies[] = openid
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/overlay/overlay.info
+++ b/docroot/modules/overlay/overlay.info
@@ -4,8 +4,7 @@ package = Core
 version = VERSION
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/path/path.info
+++ b/docroot/modules/path/path.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = path.test
 configure = admin/config/search/path
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/php/php.info
+++ b/docroot/modules/php/php.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 files[] = php.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/poll/poll.info
+++ b/docroot/modules/poll/poll.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = poll.test
 stylesheets[all][] = poll.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/profile/profile.info
+++ b/docroot/modules/profile/profile.info
@@ -11,8 +11,7 @@ configure = admin/config/people/profile
 ; See user_system_info_alter().
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/rdf/rdf.info
+++ b/docroot/modules/rdf/rdf.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 files[] = rdf.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/rdf/tests/rdf_test.info
+++ b/docroot/modules/rdf/tests/rdf_test.info
@@ -6,8 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = blog
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/search/search.info
+++ b/docroot/modules/search/search.info
@@ -8,8 +8,7 @@ files[] = search.test
 configure = admin/config/search/settings
 stylesheets[all][] = search.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/search/tests/search_embedded_form.info
+++ b/docroot/modules/search/tests/search_embedded_form.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/search/tests/search_extra_type.info
+++ b/docroot/modules/search/tests/search_extra_type.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/search/tests/search_node_tags.info
+++ b/docroot/modules/search/tests/search_node_tags.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/shortcut/shortcut.info
+++ b/docroot/modules/shortcut/shortcut.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = shortcut.test
 configure = admin/config/user-interface/shortcut
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/simpletest.info
+++ b/docroot/modules/simpletest/simpletest.info
@@ -57,8 +57,7 @@ files[] = tests/upgrade/update.trigger.test
 files[] = tests/upgrade/update.field.test
 files[] = tests/upgrade/update.user.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/actions_loop_test.info
+++ b/docroot/modules/simpletest/tests/actions_loop_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/ajax_forms_test.info
+++ b/docroot/modules/simpletest/tests/ajax_forms_test.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/ajax_test.info
+++ b/docroot/modules/simpletest/tests/ajax_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/batch_test.info
+++ b/docroot/modules/simpletest/tests/batch_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/boot_test_1.info
+++ b/docroot/modules/simpletest/tests/boot_test_1.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/boot_test_2.info
+++ b/docroot/modules/simpletest/tests/boot_test_2.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/common_test.info
+++ b/docroot/modules/simpletest/tests/common_test.info
@@ -7,8 +7,7 @@ stylesheets[all][] = common_test.css
 stylesheets[print][] = common_test.print.css
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/common_test_cron_helper.info
+++ b/docroot/modules/simpletest/tests/common_test_cron_helper.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/database_test.info
+++ b/docroot/modules/simpletest/tests/database_test.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
+++ b/docroot/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
@@ -7,8 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/docroot/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/docroot/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/entity_cache_test.info
+++ b/docroot/modules/simpletest/tests/entity_cache_test.info
@@ -6,8 +6,7 @@ core = 7.x
 dependencies[] = entity_cache_test_dependency
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/entity_cache_test_dependency.info
+++ b/docroot/modules/simpletest/tests/entity_cache_test_dependency.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/entity_crud_hook_test.info
+++ b/docroot/modules/simpletest/tests/entity_crud_hook_test.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/entity_query_access_test.info
+++ b/docroot/modules/simpletest/tests/entity_query_access_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/error_test.info
+++ b/docroot/modules/simpletest/tests/error_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/file_test.info
+++ b/docroot/modules/simpletest/tests/file_test.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = file_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/filter_test.info
+++ b/docroot/modules/simpletest/tests/filter_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/form_test.info
+++ b/docroot/modules/simpletest/tests/form_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/image_test.info
+++ b/docroot/modules/simpletest/tests/image_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/menu_test.info
+++ b/docroot/modules/simpletest/tests/menu_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/module_test.info
+++ b/docroot/modules/simpletest/tests/module_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/path_test.info
+++ b/docroot/modules/simpletest/tests/path_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/psr_0_test/psr_0_test.info
+++ b/docroot/modules/simpletest/tests/psr_0_test/psr_0_test.info
@@ -5,8 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/psr_4_test/psr_4_test.info
+++ b/docroot/modules/simpletest/tests/psr_4_test/psr_4_test.info
@@ -5,8 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/requirements1_test.info
+++ b/docroot/modules/simpletest/tests/requirements1_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/requirements2_test.info
+++ b/docroot/modules/simpletest/tests/requirements2_test.info
@@ -7,8 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/session_test.info
+++ b/docroot/modules/simpletest/tests/session_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/system_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_dependencies_test.info
@@ -6,8 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = _missing_dependency
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
@@ -6,8 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = system_incompatible_core_version_test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/system_incompatible_core_version_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_core_version_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 5.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
@@ -7,8 +7,7 @@ hidden = TRUE
 ; system_incompatible_module_version_test declares version 1.0
 dependencies[] = system_incompatible_module_version_test (>2.0)
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/system_incompatible_module_version_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_module_version_test.info
@@ -5,8 +5,7 @@ version = 1.0
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/system_project_namespace_test.info
+++ b/docroot/modules/simpletest/tests/system_project_namespace_test.info
@@ -6,8 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = drupal:filter
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/system_test.info
+++ b/docroot/modules/simpletest/tests/system_test.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = system_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/taxonomy_test.info
+++ b/docroot/modules/simpletest/tests/taxonomy_test.info
@@ -6,8 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = taxonomy
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/theme_test.info
+++ b/docroot/modules/simpletest/tests/theme_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
+++ b/docroot/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
@@ -6,8 +6,7 @@ hidden = TRUE
 settings[basetheme_only] = base theme value
 settings[subtheme_override] = base theme value
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
+++ b/docroot/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
@@ -6,8 +6,7 @@ hidden = TRUE
 
 settings[subtheme_override] = subtheme value
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/themes/test_theme/test_theme.info
+++ b/docroot/modules/simpletest/tests/themes/test_theme/test_theme.info
@@ -17,8 +17,7 @@ stylesheets[all][] = system.base.css
 
 settings[theme_test_setting] = default value
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
+++ b/docroot/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
@@ -4,8 +4,7 @@ core = 7.x
 hidden = TRUE
 engine = nyan_cat
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/update_script_test.info
+++ b/docroot/modules/simpletest/tests/update_script_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/update_test_1.info
+++ b/docroot/modules/simpletest/tests/update_test_1.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/update_test_2.info
+++ b/docroot/modules/simpletest/tests/update_test_2.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/update_test_3.info
+++ b/docroot/modules/simpletest/tests/update_test_3.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/url_alter_test.info
+++ b/docroot/modules/simpletest/tests/url_alter_test.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/simpletest/tests/xmlrpc_test.info
+++ b/docroot/modules/simpletest/tests/xmlrpc_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/statistics/statistics.info
+++ b/docroot/modules/statistics/statistics.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = statistics.test
 configure = admin/config/system/statistics
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/syslog/syslog.info
+++ b/docroot/modules/syslog/syslog.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = syslog.test
 configure = admin/config/development/logging
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/system/system.info
+++ b/docroot/modules/system/system.info
@@ -12,8 +12,7 @@ files[] = system.test
 required = TRUE
 configure = admin/config/system
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/system/tests/cron_queue_test.info
+++ b/docroot/modules/system/tests/cron_queue_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/system/tests/system_cron_test.info
+++ b/docroot/modules/system/tests/system_cron_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/taxonomy/taxonomy.info
+++ b/docroot/modules/taxonomy/taxonomy.info
@@ -8,8 +8,7 @@ files[] = taxonomy.module
 files[] = taxonomy.test
 configure = admin/structure/taxonomy
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/toolbar/toolbar.info
+++ b/docroot/modules/toolbar/toolbar.info
@@ -4,8 +4,7 @@ core = 7.x
 package = Core
 version = VERSION
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/tracker/tracker.info
+++ b/docroot/modules/tracker/tracker.info
@@ -6,8 +6,7 @@ version = VERSION
 core = 7.x
 files[] = tracker.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/translation/tests/translation_test.info
+++ b/docroot/modules/translation/tests/translation_test.info
@@ -5,8 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/translation/translation.info
+++ b/docroot/modules/translation/translation.info
@@ -6,8 +6,7 @@ version = VERSION
 core = 7.x
 files[] = translation.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/trigger/tests/trigger_test.info
+++ b/docroot/modules/trigger/tests/trigger_test.info
@@ -4,8 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/trigger/trigger.info
+++ b/docroot/modules/trigger/trigger.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = trigger.test
 configure = admin/structure/trigger
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/update/tests/aaa_update_test.info
+++ b/docroot/modules/update/tests/aaa_update_test.info
@@ -4,8 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/update/tests/bbb_update_test.info
+++ b/docroot/modules/update/tests/bbb_update_test.info
@@ -4,8 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/update/tests/ccc_update_test.info
+++ b/docroot/modules/update/tests/ccc_update_test.info
@@ -4,8 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/update/tests/themes/update_test_admintheme/update_test_admintheme.info
+++ b/docroot/modules/update/tests/themes/update_test_admintheme/update_test_admintheme.info
@@ -3,8 +3,7 @@ description = Test theme which is used as admin theme.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
+++ b/docroot/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
@@ -3,8 +3,7 @@ description = Test theme which acts as a base theme for other test subthemes.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
+++ b/docroot/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
@@ -4,8 +4,7 @@ core = 7.x
 base theme = update_test_basetheme
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/update/tests/update_test.info
+++ b/docroot/modules/update/tests/update_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/update/update.info
+++ b/docroot/modules/update/update.info
@@ -6,8 +6,7 @@ core = 7.x
 files[] = update.test
 configure = admin/reports/updates/settings
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/user/tests/user_form_test.info
+++ b/docroot/modules/user/tests/user_form_test.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/modules/user/user.info
+++ b/docroot/modules/user/user.info
@@ -9,8 +9,7 @@ required = TRUE
 configure = admin/config/people
 stylesheets[all][] = user.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/profiles/minimal/minimal.info
+++ b/docroot/profiles/minimal/minimal.info
@@ -5,8 +5,7 @@ core = 7.x
 dependencies[] = block
 dependencies[] = dblog
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/profiles/standard/standard.info
+++ b/docroot/profiles/standard/standard.info
@@ -24,8 +24,7 @@ dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = rdf
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/docroot/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -6,8 +6,7 @@ core = 7.x
 hidden = TRUE
 files[] = drupal_system_listing_compatible_test.test
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/docroot/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -8,8 +8,7 @@ version = VERSION
 core = 6.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/profiles/testing/testing.info
+++ b/docroot/profiles/testing/testing.info
@@ -4,8 +4,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/themes/bartik/bartik.info
+++ b/docroot/themes/bartik/bartik.info
@@ -34,8 +34,7 @@ regions[footer] = Footer
 settings[shortcut_module_link] = 0
 
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/themes/garland/garland.info
+++ b/docroot/themes/garland/garland.info
@@ -7,8 +7,7 @@ stylesheets[all][] = style.css
 stylesheets[print][] = print.css
 settings[garland_width] = fluid
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/themes/seven/seven.info
+++ b/docroot/themes/seven/seven.info
@@ -13,8 +13,7 @@ regions[page_bottom] = Page bottom
 regions[sidebar_first] = First sidebar
 regions_hidden[] = sidebar_first
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"

--- a/docroot/themes/stark/stark.info
+++ b/docroot/themes/stark/stark.info
@@ -5,8 +5,7 @@ version = VERSION
 core = 7.x
 stylesheets[all][] = layout.css
 
-; Information added by Drupal.org packaging script on 2018-03-28
-version = "7.58"
+; Information added by Drupal.org packaging script on 2018-04-25
+version = "7.59"
 project = "drupal"
-datestamp = "1522264019"
-
+datestamp = "1524673284"


### PR DESCRIPTION
Drupal 7 and 8 core critical release on April 25th, 2018 PSA-2018-003