### PR TITLE
Feature/solr jobs premature indexing exit

### DIFF
--- a/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
+++ b/docroot/sites/all/modules/custom/fsa_maintenance_page/fsa_maintenance_page.module
@@ -85,23 +85,23 @@ function fsa_maintenance_page_preprocess_maintenance_page(&$variables) {
   );
 
   // Add the 'viewport' meta tag.
-  if (omega_theme_get_setting('omega_viewport', TRUE)) {
+  if (theme_get_setting('omega_viewport', TRUE)) {
     $content = array('width=device-width');
 
     // Add the 'initial-scale' property if configured.
-    if ($value = omega_theme_get_setting('omega_viewport_initial_scale')) {
+    if ($value = theme_get_setting('omega_viewport_initial_scale')) {
       $content[] = "initial-scale=$value";
     }
 
     // The minimum-scale and maximum-scale properties are ignored if
     // user-scalable is set to 'no'.
-    if (omega_theme_get_setting('omega_viewport_user_scaleable', TRUE) == FALSE) {
+    if (theme_get_setting('omega_viewport_user_scaleable', TRUE) == FALSE) {
       $content[] = 'user-scalable=no';
     }
     else {
       // Set the minimum-scale and maximum-scale properties if specified.
       foreach (array('minimum', 'maximum') as $type) {
-        if ($value = omega_theme_get_setting("omega_viewport_{$type}_scale")) {
+        if ($value = theme_get_setting("omega_viewport_{$type}_scale")) {
           $content[] = "$type-scale=$value";
         }
       }

--- a/docroot/sites/all/themes/site_frontend/preprocess/node.preprocess.inc
+++ b/docroot/sites/all/themes/site_frontend/preprocess/node.preprocess.inc
@@ -119,6 +119,14 @@ function site_frontend_preprocess_node__job(&$variables, $node = NULL) {
     $variables['title_link']['#options']['attributes']['target'] = '_blank';
   }
 
+  // Redirect field triggers indexing issues, so check the view mode + whether it's CLI or not
+  // and redirect if the user doesn't have permission to bypass redirect fields. If we leave
+  // the redirect field formatter in place, it is triggered when the node is 'built' as part of the
+  // Solr indexing process causing premature exit from the indexing process.
+  if ($variables['view_mode'] == 'full' && !drupal_is_cli() && !user_access('bypass redirection')) {
+    drupal_goto($node->field_url[LANGUAGE_NONE][0]['url']);
+  }
+
 }
 
 


### PR DESCRIPTION
The field redirect contrib module is used to control redirections from Job nodes to the target URL attached to the node. That's all well and good, but when Solr is creating documents to index it triggers this behaviour by assembling the node and rendering it in a specific view mode (full). This prevents some later content from indexing because the redirect triggers a premature exit from the batch process.

This small tweak to custom code bridges that issue. Also needs the redirect field switched from 'Redirect' to, well, almost anything else in order to work. Ideally, that'd go through a feature update, but they're in a real state at the moment so it's more constructive to make the change by hand after any code changes are applied.