### PR TITLE
Update references to old domain from www. to old.

### DIFF
--- a/docroot/sites/all/modules/custom/local/local.module
+++ b/docroot/sites/all/modules/custom/local/local.module
@@ -57,14 +57,14 @@ function local_get_site_domain($admin = FALSE, $protocol = ''){
       'local' => '//science-council.ddev.local',
       'development' => '//foodsciencecommitteedev.prod.acquia-sites.com',
       'staging' => '//foodsciencecommitteestg.prod.acquia-sites.com',
-      'production' => '//www.food.gov.uk',
+      'production' => '//old.food.gov.uk',
     );
   }
 
   // Return the domain for the selected environment. If none is set, we return
-  // www.food.gov.uk as default.
+  // old.food.gov.uk as default.
   $protocol = !empty($protocol) ? "$protocol:" : '';
-  return !empty($environment) && !empty($environments[$environment]) ? $protocol . $environments[$environment] : "$protocol//www.food.gov.uk";
+  return !empty($environment) && !empty($environments[$environment]) ? $protocol . $environments[$environment] : "$protocol//old.food.gov.uk";
 }
 
 /**


### PR DESCRIPTION
Updating the custom 'local' module so it sees old.food.gov.uk as the site's default domain, now that www.food.gov.uk is used by a separate D8 site. Hopefully this will fix the ajax path issue, or at least point it to the same site.